### PR TITLE
Ruby: Updated for Ruby 1.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ cd racket
 ./stepX_YYY.rb
 ```
 
-### Ruby (1.8)
+### Ruby (1.9+)
 
 ```
 cd ruby

--- a/ruby/core.rb
+++ b/ruby/core.rb
@@ -1,6 +1,6 @@
 require "readline"
-require "reader"
-require "printer"
+require_relative "reader"
+require_relative "printer"
 
 $core_ns = {
     :"=" =>       lambda {|a,b| a == b},

--- a/ruby/mal_readline.rb
+++ b/ruby/mal_readline.rb
@@ -4,7 +4,7 @@ $history_loaded = false
 $histfile = "#{ENV['HOME']}/.mal-history"
 
 def _readline(prompt)
-    if not $history_loaded
+    if !$history_loaded && File.exist?($histfile)
         $history_loaded = true
         File.readlines($histfile).each {|l| Readline::HISTORY.push(l.chomp)}
     end

--- a/ruby/printer.rb
+++ b/ruby/printer.rb
@@ -1,4 +1,4 @@
-require "types"
+require_relative "types"
 
 def _pr_str(obj, print_readably=true)
     _r = print_readably

--- a/ruby/reader.rb
+++ b/ruby/reader.rb
@@ -1,4 +1,4 @@
-require "types"
+require_relative "types"
 
 class Reader
     def initialize(tokens)

--- a/ruby/step0_repl.rb
+++ b/ruby/step0_repl.rb
@@ -1,5 +1,4 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
+require_relative "mal_readline"
 
 # read
 def READ(str)

--- a/ruby/step1_read_print.rb
+++ b/ruby/step1_read_print.rb
@@ -1,8 +1,7 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
 
 # read
 def READ(str)

--- a/ruby/step2_eval.rb
+++ b/ruby/step2_eval.rb
@@ -1,8 +1,7 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
 
 # read
 def READ(str)

--- a/ruby/step3_env.rb
+++ b/ruby/step3_env.rb
@@ -1,9 +1,8 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
-require "env"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
+require_relative "env"
 
 # read
 def READ(str)

--- a/ruby/step4_if_fn_do.rb
+++ b/ruby/step4_if_fn_do.rb
@@ -1,10 +1,9 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
-require "env"
-require "core"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
+require_relative "env"
+require_relative "core"
 
 # read
 def READ(str)

--- a/ruby/step5_tco.rb
+++ b/ruby/step5_tco.rb
@@ -1,10 +1,9 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
-require "env"
-require "core"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
+require_relative "env"
+require_relative "core"
 
 # read
 def READ(str)

--- a/ruby/step6_file.rb
+++ b/ruby/step6_file.rb
@@ -1,10 +1,9 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
-require "env"
-require "core"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
+require_relative "env"
+require_relative "core"
 
 # read
 def READ(str)

--- a/ruby/step7_quote.rb
+++ b/ruby/step7_quote.rb
@@ -1,10 +1,9 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
-require "env"
-require "core"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
+require_relative "env"
+require_relative "core"
 
 # read
 def READ(str)

--- a/ruby/step8_macros.rb
+++ b/ruby/step8_macros.rb
@@ -1,10 +1,9 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
-require "env"
-require "core"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
+require_relative "env"
+require_relative "core"
 
 # read
 def READ(str)

--- a/ruby/step9_try.rb
+++ b/ruby/step9_try.rb
@@ -1,10 +1,9 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
-require "env"
-require "core"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
+require_relative "env"
+require_relative "core"
 
 # read
 def READ(str)

--- a/ruby/stepA_interop.rb
+++ b/ruby/stepA_interop.rb
@@ -1,10 +1,9 @@
-$: << File.expand_path(File.dirname(__FILE__))
-require "mal_readline"
-require "types"
-require "reader"
-require "printer"
-require "env"
-require "core"
+require_relative "mal_readline"
+require_relative "types"
+require_relative "reader"
+require_relative "printer"
+require_relative "env"
+require_relative "core"
 
 # read
 def READ(str)

--- a/ruby/types.rb
+++ b/ruby/types.rb
@@ -1,4 +1,4 @@
-require "env"
+require_relative "env"
 
 class MalException < StandardError
   attr_reader :data


### PR DESCRIPTION
Hey! 

This patch makes mal run on modern rubies. I've tested it on 2.1 and 2.2, but it should work on anything from 1.9 on. It also fixes a crash if the history file doesn't exist.

Ruby 1.8 will no longer work. Hopefully that won't be a problem, 1.8.7 is long retired.