### PR TITLE
Replace `pcre` with Rust-implemented regex crate (based on RE2).

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,3 @@ authors = [ "Your name <you@example.com>" ]
 time = "0.1"
 regex = "0.1"
 libc = "0.1"
-
-[dependencies.pcre]
-git = "https://github.com/alexcrichton/rust-pcre"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(io, fs, core, std_misc, collections)]
 
 extern crate libc;
-extern crate pcre;
 extern crate regex;
 extern crate time;
 


### PR DESCRIPTION
I fixed the bug in Rust's `regex` library and things seem to be working great now. Even through `regex` is based on RE2, I didn't have to change your regex at all. :-)

I ran this to test:

```bash
make perf^rust
make MAL_IMPL=rust test^mal
```

The first passes and the second passes all tests except for 1, but it looks like the same failing test from #26.