### PR TITLE
Compatibility with Python 3

### DIFF
--- a/python/step0_repl.py
+++ b/python/step0_repl.py
@@ -11,7 +11,7 @@ def EVAL(ast, env):
     try:
         return eval(ast)
     except SyntaxError:
-        exec compile(ast, '', 'single') in globals()
+        exec(compile(ast, '', 'single'), globals())
         return None
 
 # print

--- a/runtest.py
+++ b/runtest.py
@@ -7,6 +7,8 @@ import pty, signal, atexit
 from subprocess import Popen, STDOUT, PIPE
 from select import select
 
+IS_PY_3 = sys.version_info[0] == 3
+
 # TODO: do we need to support '\n' too
 sep = "\r\n"
 #sep = "\n"
@@ -65,6 +67,7 @@ class Runner():
             if self.stdout in outs:
                 new_data = self.stdout.read(1)
                 #print "new_data: '%s'" % new_data
+                new_data = new_data.decode("utf-8") if IS_PY_3 else new_data
                 if self.mono:
                     self.buf += new_data.replace("\n", "\r\n")
                 else:
@@ -81,10 +84,13 @@ class Runner():
         return None
 
     def writeline(self, str):
-        self.stdin.write(str + "\n")
+        def _to_bytes(s):
+            return bytes(s, "utf-8") if IS_PY_3 else s
+
+        self.stdin.write(_to_bytes(str + "\n"))
         if self.mono:
             # Simulate echo
-            self.buf += str + "\r\n"
+            self.buf += _to_bytes(str + "\r\n")
 
     def cleanup(self):
         #print "cleaning up"
@@ -113,10 +119,10 @@ def read_test(data):
         elif line[0:3] == ";;;":       # ignore comment
             continue
         elif line[0:2] == ";;":        # output comment
-            print line[3:]
+            print(line[3:])
             continue
         elif line[0:2] == ";":         # unexpected comment
-            print "Test data error at line %d:\n%s" % (test_idx, line)
+            print("Test data error at line %d:\n%s" % (test_idx, line))
             return None, None, None, test_idx
         form = line   # the line is a form to send
 
@@ -144,10 +150,10 @@ def assert_prompt(timeout):
     header = r.read_to_prompt(['user> ', 'mal-user> '], timeout=timeout)
     if not header == None:
         if header:
-            print "Started with:\n%s" % header
+            print("Started with:\n%s" % header)
     else:
-        print "Did not get 'user> ' or 'mal-user> ' prompt"
-        print "    Got      : %s" % repr(r.buf)
+        print("Did not get 'user> ' or 'mal-user> ' prompt")
+        print("    Got      : %s" % repr(r.buf))
         sys.exit(1)
 
 
@@ -177,17 +183,17 @@ while test_data:
                                 timeout=args.test_timeout)
         #print "%s,%s,%s" % (idx, repr(p.before), repr(p.after))
         if ret == "*" or res == expected:
-            print " -> SUCCESS"
+            print(" -> SUCCESS")
         else:
-            print " -> FAIL (line %d):" % line_num
-            print "    Expected : %s" % repr(expected)
-            print "    Got      : %s" % repr(res)
+            print(" -> FAIL (line %d):" % line_num)
+            print("    Expected : %s" % repr(expected))
+            print("    Got      : %s" % repr(res))
             fail_cnt += 1
     except:
-        print "Got Exception"
+        print("Got Exception")
         sys.exit(1)
 
 if fail_cnt > 0:
-    print "FAILURES: %d" % fail_cnt
+    print("FAILURES: %d" % fail_cnt)
     sys.exit(2)
 sys.exit(0)


### PR DESCRIPTION
Two things:
* a syntax error in 'step0_repl.py' (see below) fixed
```bash
$ python --version
Python 3.4.3
$ cd python/
$ python step0_repl.py
  File "step0_repl.py", line 14
    exec compile(ast, '', 'single') in globals()
               ^
SyntaxError: invalid syntax
```
* the test script, 'runtest.py', now made compatible with Python 3 (initially getting errors about ``print`` missing parentheses, and ``bytes``/``str`` decoding/encoding)

Now, I can run Mal tests in both Python 2 and 3. Also tested with Ruby and Clojure.

Thanks for reviewing.
