### PR TITLE
perl: Support newer Perl versions (e.g. v5.20.0)

### DIFF
--- a/perl/printer.pm
+++ b/perl/printer.pm
@@ -22,7 +22,7 @@ sub _pr_str {
         }
         when(/^HashMap/) {
             my @elems = ();
-            foreach my $key (keys $obj->{val}) {
+            foreach my $key (keys %{$obj->{val}}) {
                 push(@elems, _pr_str(String->new($key), $_r));
                 push(@elems, _pr_str($obj->{val}->{$key}, $_r));
             }

--- a/perl/reader.pm
+++ b/perl/reader.pm
@@ -75,18 +75,18 @@ sub read_form {
     my($rdr) = @_;
     my $token = $rdr->peek();
     given ($token) {
-        when("'") { $rdr->next(); List->new([Symbol->new('quote'),
+        when("'") { $rdr->next(); my $q = 'quote';      List->new([Symbol->new($q),
                                              read_form($rdr)]) }
-        when('`') { $rdr->next(); List->new([Symbol->new('quasiquote'),
+        when('`') { $rdr->next(); my $q = 'quasiquote'; List->new([Symbol->new($q),
                                              read_form($rdr)]) }
-        when('~') { $rdr->next(); List->new([Symbol->new('unquote'),
+        when('~') { $rdr->next(); my $q = 'unquote';    List->new([Symbol->new($q),
                                              read_form($rdr)]) }
-        when('~@') { $rdr->next(); List->new([Symbol->new('splice-unquote'),
+        when('~@') { $rdr->next(); my $q = 'splice-unquote'; List->new([Symbol->new($q),
                                               read_form($rdr)]) }
-        when('^') { $rdr->next(); my $meta = read_form($rdr);
-                    List->new([Symbol->new('with-meta'),
+        when('^') { $rdr->next(); my $meta = read_form($rdr); my $q = 'with-meta';
+                    List->new([Symbol->new($q),
                                read_form($rdr), $meta]) }
-        when('@') { $rdr->next(); List->new([Symbol->new('deref'),
+        when('@') { $rdr->next(); my $q = 'deref'; List->new([Symbol->new($q),
                                               read_form($rdr)]) }
 
         when(')') { die "unexpected ')'" }


### PR DESCRIPTION
There were error messages:

keys on reference is experimental at perl/printer.pm line 25.
Compilation failed in require at perl/step1_read_print.pl line 10.
BEGIN failed--compilation aborted at perl/step1_read_print.pl line 10.

---

Error: Modification of a read-only value attempted at perl/types.pm line 111, <FIN> line 1.