### PR TITLE
Add outer tests to step3_env.mal

### DIFF
--- a/tests/step3_env.mal
+++ b/tests/step3_env.mal
@@ -32,6 +32,16 @@ x
 (let* (p (+ 2 3) q (+ 2 p)) (+ p q))
 ;=>12
 
+;; Testing outer environment
+(def! a 4)
+;=>4
+(let* (q 9) q)
+;=>9
+(let* (q 9) a)
+;=>4
+(let* (z 2) (let* (q 9) a))
+;=>4
+
 ;;
 ;; -------- Optional Functionality --------
 


### PR DESCRIPTION
I noticed that when I implemented step 3 with an environment that didn't have an "outer" reference, all the tests passed.  Here are some simple tests that check if outer is functioning.