### PR TITLE
Remove extra ) from step9 test snippet

### DIFF
--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -4,7 +4,7 @@
 (try* 123 (catch* e 456))
 ;=>123
 
-(try* (abc 1 2) (catch* exc (prn "exc is:" exc))))
+(try* (abc 1 2) (catch* exc (prn "exc is:" exc)))
 ; "exc is:" "'abc' not found"
 ;=>nil
 


### PR DESCRIPTION
My reader complains if there is extra input after the top-level
read_form, so this test was inadvertently failing for me.