### PR TITLE
Test case & fix for typo in Perl _clone implementation

### DIFF
--- a/perl/types.pm
+++ b/perl/types.pm
@@ -58,7 +58,7 @@ sub _clone {
             return Vector->new( [ @{$obj->{val}} ] );
         }
         when (/^HashMap/) {
-            return Vector->new( { %{$obj->{val}} } );
+            return HashMap->new( { %{$obj->{val}} } );
         }
         when (/^Function/) {
             return Function->new_from_hash( { %{$obj} } );

--- a/tests/stepA_mal.mal
+++ b/tests/stepA_mal.mal
@@ -161,14 +161,23 @@
 (meta (with-meta [1 2 3] {"a" 1}))
 ;=>{"a" 1}
 
+(vector? (with-meta [1 2 3] {"a" 1}))
+;=>true
+
 (meta (with-meta [1 2 3] "abc"))
 ;=>"abc"
 
 (meta (with-meta (list 1 2 3) {"a" 1}))
 ;=>{"a" 1}
 
+(list? (with-meta (list 1 2 3) {"a" 1}))
+;=>true
+
 (meta (with-meta {"abc" 123} {"a" 1}))
 ;=>{"a" 1}
+
+(map? (with-meta {"abc" 123} {"a" 1}))
+;=>true
 
 ;;; Not actually supported by Clojure
 ;;;(meta (with-meta (atom 7) {"a" 1}))


### PR DESCRIPTION
I stumbled over this typo while looking through the Perl implementation.

Thought I might as well add a test case to catch similar errors.