### PR TITLE
Step 9 test cases for apply on vectors

### DIFF
--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -56,16 +56,24 @@
 ;=>5
 (apply + 4 (list 5))
 ;=>9
+(apply + 4 [5])
+;=>9
 (apply prn (list 1 2 "3" (list)))
 ; 1 2 "3" ()
 (apply prn 1 2 (list "3" (list)))
 ; 1 2 "3" ()
+(apply prn 1 2 ["3" 4])
+; 1 2 "3" 4
 ;=>nil
 
 ;; Testing apply function with user functions
 (apply (fn* (a b) (+ a b)) (list 2 3))
 ;=>5
 (apply (fn* (a b) (+ a b)) 4 (list 5))
+;=>9
+(apply (fn* (a b) (+ a b)) [2 3])
+;=>5
+(apply (fn* (a b) (+ a b)) 4 [5])
 ;=>9
 
 ;; Testing map function


### PR DESCRIPTION
While it still needs a little work, my C++ implementation now passes all[1] of the self-hosting tests (!)

The only bug I had between passing stepA, and then passing the self-hosting tests was that my apply implementation insisted on a list, and needed to be relaxed to accept any sequence.

Here's a couple of (apply f vector) tests which catch that bug.

[1] All but one. `(read-string ";; comment")` in the step 6 test gives me a strange python IO error from runtest.py. I need to look further into that one - it works fine if I type it in manually.
