### PR TITLE
Trying step0 in javascript, readline not working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PYTHON = python
 
 IMPLS = bash c clojure coffee cs forth go haskell java js lua make mal \
 	ocaml matlab miniMAL nim perl php ps python r racket ruby rust \
-	scala vb
+	scala vb javascript
 
 step0 = step0_repl
 step1 = step1_read_print
@@ -59,7 +59,7 @@ forth_STEP_TO_PROG =   forth/$($(1)).fs
 go_STEP_TO_PROG =      go/$($(1))
 java_STEP_TO_PROG =    java/src/main/java/mal/$($(1)).java
 haskell_STEP_TO_PROG = haskell/$($(1))
-js_STEP_TO_PROG =      js/$($(1)).js
+javascript_STEP_TO_PROG =      javascript/$($(1)).js
 lua_STEP_TO_PROG =     lua/$($(1)).lua
 make_STEP_TO_PROG =    make/$($(1)).mk
 mal_STEP_TO_PROG =     mal/$($(1)).mal
@@ -92,7 +92,7 @@ forth_RUNSTEP =   gforth ../$(2) $(3)
 go_RUNSTEP =      ../$(2) $(3)
 haskell_RUNSTEP = ../$(2) $(3)
 java_RUNSTEP =    mvn -quiet exec:java -Dexec.mainClass="mal.$($(1))" $(if $(3), -Dexec.args="$(3)",)
-js_RUNSTEP =      node ../$(2) $(3)
+javascript_RUNSTEP =      node ../$(2) $(3)
 lua_RUNSTEP =     ../$(2) $(3)
 make_RUNSTEP =    make -f ../$(2) $(3)
 mal_RUNSTEP =     $(call $(MAL_IMPL)_RUNSTEP,$(1),$(call $(MAL_IMPL)_STEP_TO_PROG,stepA),../$(2),")  #"

--- a/javascript/step0_repl.js
+++ b/javascript/step0_repl.js
@@ -1,0 +1,32 @@
+function READ(x) {
+    return x;
+}
+
+function EVAL(x) {
+    return x;
+}
+
+function PRINT(x) {
+    return x;
+}
+
+function rep(x) {
+    return PRINT(EVAL(READ(x)));
+}
+
+var readline = require("readline"),
+    rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+
+rl.setPrompt("user> ");
+rl.prompt();
+
+rl.on("line", function(line) {
+    console.log(rep(line));
+    rl.prompt();
+}).on("exit", function() {
+    rl.close();
+    process.exit(0);
+});


### PR DESCRIPTION
Hello @kanaka,

I'm trying to make a lisp in Javascript. I'm failing at step0, and would love your help to understand why my implementation doesn't work. Basically it doesn't pass the tests, they all fail after the timeout. The test output is below.

```
-> make test^javascript^step0
----------------------------------------------
Testing test^javascript^step0, step file: javascript/step0_repl.js, test file: tests/step0_repl.mal
Running: ../runtest.py  ../tests/step0_repl.mal -- node ../javascript/step0_repl.js 
Started with:

TEST: hello world -> ['','hello world'] -> FAIL (line 2):
    Expected : ['hello world\r\nhello world', 'hello world\r\nhello world\r\nhello world']
    Got      : None
TEST: abcABC123 -> ['','abcABC123'] -> FAIL (line 5):
    Expected : ['abcABC123\r\nabcABC123', 'abcABC123\r\nabcABC123\r\nabcABC123']
    Got      : None
TEST: ;:() []{}"'* -> ['',';:() []{}"\'*'] -> FAIL (line 8):
    Expected : [';:() []{}"\'*\r\n;:() []{}"\'*', ';:() []{}"\'*\r\n;:() []{}"\'*\r\n;:() []{}"\'*']
    Got      : None
TEST: hello world abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789 (;:() []{}"'* ;:() []{}"'* ;:() []{}"'*) -> ['','hello world abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789 (;:() []{}"\'* ;:() []{}"\'* ;:() []{}"\'*)'] -> FAIL (line 13):
    Expected : ['hello world abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789 (;:() []{}"\'* ;:() []{}"\'* ;:() []{}"\'*)\r\nhello world abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789 (;:() []{}"\'* ;:() []{}"\'* ;:() []{}"\'*)', 'hello world abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789 (;:() []{}"\'* ;:() []{}"\'* ;:() []{}"\'*)\r\nhello world abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789 (;:() []{}"\'* ;:() []{}"\'* ;:() []{}"\'*)\r\nhello world abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789 (;:() []{}"\'* ;:() []{}"\'* ;:() []{}"\'*)']
    Got      : None
FAILURES: 4
make: *** [test^javascript^step0] Error 2
```

After many failing I decided to "cheat" and read your implementation. This is where I noticed that basically 2 things that differed with mine :
- you wrap a binary tool with an ffi to do the "readline" stuff, adding history along the way ; I just use the core node.js module `readline`.
- you expose a printer that basically wraps `console.log` ; I just use `console.log` directly.

I think the problem I have is with "readline", but I have no clue why it's not working. I also don't understand why you didn't use the core readline module.

I wanted to read the test protocol but I'm not proficient (at all) with Python to understand and make sure my code pass the tests.

So basically, I'm requesting a code review :) That's why I made a pull request, just so you could read the code easily.