### PR TITLE
Require correct node_readline file

### DIFF
--- a/coffee/core.coffee
+++ b/coffee/core.coffee
@@ -1,4 +1,4 @@
-readline = require "../js/node_readline"
+readline = require "./node_readline"
 types = require "./types.coffee"
 reader = require "./reader.coffee"
 printer = require "./printer.coffee"
@@ -51,7 +51,7 @@ exports.ns = {
   '*': (a,b) -> a*b,
   '/': (a,b) -> a/b,
   'time-ms': () -> new Date().getTime(),
-  
+
   'list': (a...) -> a,
   'list?': types._list_Q,
   'vector': (a...) -> types._vector(a...),


### PR DESCRIPTION
The previous version was requiring the `js` directory's version of `node_readline`, which crashes if `npm install` has not been run in that directory.

This commit uses the file located in the `coffee` directory. Running `make test^coffee` passes.