### PR TITLE
Make Nim implementation a bit nicer

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ make -f stepX_YYY.mk
 *The Nim implementation was created by [Dennis Felsing (def-)](https://github.com/def-)*
 
 Running the Nim implementation of mal requires Nim's current devel branch
-(0.10.3) or later, and the nre library installed.
+(0.10.3) or later.
 
 ```
 cd nim

--- a/nim/Makefile
+++ b/nim/Makefile
@@ -3,6 +3,7 @@
 SOURCES_BASE = types.nim reader.nim printer.nim
 SOURCES_LISP = env.nim core.nim stepA_mal.nim
 SOURCES = $(SOURCES_BASE) $(SOURCES_LISP)
+SOURCES_REBUILD = $(SOURCES_BASE) env.nim core.nim
 
 #####################
 
@@ -18,11 +19,11 @@ all: $(BINS) mal
 mal: $(word $(words $(BINS)),$(BINS))
 	cp $< $@
 
-$(BINS): %: %.nim
-	nim -d:release c $@
+$(BINS): %: %.nim $(SOURCES_REBUILD)
+	nim -d:release --nimcache:nimcache-$@ c $@
 
 clean:
-	rm -rf nimcache/ $(BINS)
+	rm -rf nimcache-*/ $(BINS)
 	rm -f mal
 
 .PHONY: stats stats-lisp

--- a/nim/mal.nimble
+++ b/nim/mal.nimble
@@ -1,6 +1,6 @@
 [Package]
 name          = "mal"
-version       = "1.0"
+version       = "1.1"
 author        = "Dennis Felsing"
 description   = "Mal code in Nim"
 license       = "MIT"
@@ -8,4 +8,4 @@ license       = "MIT"
 bin           = "step0_repl, step1_read_print, step2_eval, step3_env, step4_if_fn_do, step5_tco, step6_file, step7_quote, step8_macros, step9_try, stepA_mal"
 
 [Deps]
-Requires      = "nim >= 0.10.3, nre >= 0.6.0"
+Requires      = "nim >= 0.10.3"

--- a/nim/reader.nim
+++ b/nim/reader.nim
@@ -1,4 +1,4 @@
-import nre, optional_t, strutils, types
+import re, strutils, sequtils, types
 
 let
   tokenRE = re"""[\s,]*(~@|[\[\]{}()'`~^@]|"(?:\\.|[^\\"])*"|;.*|[^\s\[\]{}('"`,;)]*)"""
@@ -24,9 +24,16 @@ proc peek(r: Reader): string =
 
 proc tokenize(str: string): seq[string] =
   result = @[]
-  for match in str.findIter(tokenRE):
-    if match.captures[0][0] != ';':
-      result.add match.captures[0]
+  var pos = 0
+  while pos < str.len:
+    var matches: array[2, string]
+    var len = str.findBounds(tokenRE, matches, pos)
+    if len.first != -1 and len.last != -1:
+      pos = len.last + 1
+      if matches[0][0] != ';':
+        result.add matches[0]
+    else:
+      inc pos
 
 proc read_form(r: var Reader): MalType
 


### PR DESCRIPTION
- Use re from standard library instead of nre
- Allow make -j4
- Rebuild binaries after source changed

I guess it's better/easier not to use an external regexp library. All tests still pass.