### PR TITLE
fix history function of C

### DIFF
--- a/c/readline.c
+++ b/c/readline.c
@@ -42,7 +42,7 @@ void append_to_history() {
 #ifdef USE_READLINE
     append_history(1, hf);
 #else
-    HIST_ENTRY *he = history_get(history_length-1);
+    HIST_ENTRY *he = history_get(history_base+history_length-1);
     FILE *fp = fopen(hf, "a");
     if (fp) {
         fprintf(fp, "%s\n", he->line);


### PR DESCRIPTION
When the editline was used instead of the readline, the history function of C didn't work as intended.

It was caused like below.

- segmentation fault if a history is empty.
- incorrect line was added to a history file.