### PR TITLE
C#: fix arguments handling

### DIFF
--- a/cs/step6_file.cs
+++ b/cs/step6_file.cs
@@ -141,13 +141,13 @@ namespace Mal {
             }
             repl_env.set(new MalSymbol("eval"), new MalFunc(
                         a => EVAL(a[0], repl_env)));
-            int fileIdx = 1;
+            int fileIdx = 0;
             if (args.Length > 0 && args[0] == "--raw") {
                 Mal.readline.mode = Mal.readline.Mode.Raw;
-                fileIdx = 2;
+                fileIdx = 1;
             }
             MalList _argv = new MalList();
-            for (int i=fileIdx; i < args.Length; i++) {
+            for (int i=fileIdx+1; i < args.Length; i++) {
                 _argv.conj_BANG(new MalString(args[i]));
             }
             repl_env.set(new MalSymbol("*ARGV*"), _argv);

--- a/cs/step7_quote.cs
+++ b/cs/step7_quote.cs
@@ -173,13 +173,13 @@ namespace Mal {
             }
             repl_env.set(new MalSymbol("eval"), new MalFunc(
                         a => EVAL(a[0], repl_env)));
-            int fileIdx = 1;
+            int fileIdx = 0;
             if (args.Length > 0 && args[0] == "--raw") {
                 Mal.readline.mode = Mal.readline.Mode.Raw;
-                fileIdx = 2;
+                fileIdx = 1;
             }
             MalList _argv = new MalList();
-            for (int i=fileIdx; i < args.Length; i++) {
+            for (int i=fileIdx+1; i < args.Length; i++) {
                 _argv.conj_BANG(new MalString(args[i]));
             }
             repl_env.set(new MalSymbol("*ARGV*"), _argv);

--- a/cs/step8_macros.cs
+++ b/cs/step8_macros.cs
@@ -210,13 +210,13 @@ namespace Mal {
             }
             repl_env.set(new MalSymbol("eval"), new MalFunc(
                         a => EVAL(a[0], repl_env)));
-            int fileIdx = 1;
+            int fileIdx = 0;
             if (args.Length > 0 && args[0] == "--raw") {
                 Mal.readline.mode = Mal.readline.Mode.Raw;
-                fileIdx = 2;
+                fileIdx = 1;
             }
             MalList _argv = new MalList();
-            for (int i=fileIdx; i < args.Length; i++) {
+            for (int i=fileIdx+1; i < args.Length; i++) {
                 _argv.conj_BANG(new MalString(args[i]));
             }
             repl_env.set(new MalSymbol("*ARGV*"), _argv);

--- a/cs/step9_try.cs
+++ b/cs/step9_try.cs
@@ -231,13 +231,13 @@ namespace Mal {
             }
             repl_env.set(new MalSymbol("eval"), new MalFunc(
                         a => EVAL(a[0], repl_env)));
-            int fileIdx = 1;
+            int fileIdx = 0;
             if (args.Length > 0 && args[0] == "--raw") {
                 Mal.readline.mode = Mal.readline.Mode.Raw;
-                fileIdx = 2;
+                fileIdx = 1;
             }
             MalList _argv = new MalList();
-            for (int i=fileIdx; i < args.Length; i++) {
+            for (int i=fileIdx+1; i < args.Length; i++) {
                 _argv.conj_BANG(new MalString(args[i]));
             }
             repl_env.set(new MalSymbol("*ARGV*"), _argv);

--- a/cs/stepA_mal.cs
+++ b/cs/stepA_mal.cs
@@ -237,7 +237,7 @@ namespace Mal {
                 fileIdx = 1;
             }
             MalList _argv = new MalList();
-            for (int i=fileIdx; i < args.Length; i++) {
+            for (int i=fileIdx+1; i < args.Length; i++) {
                 _argv.conj_BANG(new MalString(args[i]));
             }
             repl_env.set(new MalSymbol("*ARGV*"), _argv);


### PR DESCRIPTION
The arguments handling was incorrect like below.

- step6 to step9  
    `*ARGV*` was right but the filename of `load-file` was wrong.
- stepA  
    The filename of `load-file` was right but `*ARGV*` includes the
    filename.