### PR TITLE
Only print Elixir header info in REPL mode

### DIFF
--- a/elixir/lib/mix/tasks/step6_file.ex
+++ b/elixir/lib/mix/tasks/step6_file.ex
@@ -6,12 +6,10 @@ defmodule Mix.Tasks.Step6File do
     env = Mal.Env.new()
     Mal.Env.merge(env, Mal.Core.namespace)
     bootstrap(args, env)
-    load_file(args, env)
     loop(env)
   end
 
-  defp load_file([], _env), do: nil
-  defp load_file([file_name | _args], env) do
+  defp load_file(file_name, env) do
     read_eval_print("""
       (load-file "#{file_name}")
       """, env)
@@ -37,8 +35,12 @@ defmodule Mix.Tasks.Step6File do
     end})
 
     case args do
-      [_file_name | rest] -> Mal.Env.set(env, "*ARGV*", list(rest))
-      [] -> Mal.Env.set(env, "*ARGV*", list([]))
+      [file_name | rest] ->
+        Mal.Env.set(env, "*ARGV*", list(rest))
+        load_file(file_name, env)
+
+      [] ->
+        Mal.Env.set(env, "*ARGV*", list([]))
     end
   end
 

--- a/elixir/lib/mix/tasks/step7_quote.ex
+++ b/elixir/lib/mix/tasks/step7_quote.ex
@@ -6,12 +6,10 @@ defmodule Mix.Tasks.Step7Quote do
     env = Mal.Env.new()
     Mal.Env.merge(env, Mal.Core.namespace)
     bootstrap(args, env)
-    load_file(args, env)
     loop(env)
   end
 
-  defp load_file([], _env), do: nil
-  defp load_file([file_name | _args], env) do
+  defp load_file(file_name, env) do
     read_eval_print("""
       (load-file "#{file_name}")
       """, env)
@@ -37,8 +35,12 @@ defmodule Mix.Tasks.Step7Quote do
     end})
 
     case args do
-      [_file_name | rest] -> Mal.Env.set(env, "*ARGV*", list(rest))
-      [] -> Mal.Env.set(env, "*ARGV*", list([]))
+      [file_name | rest] ->
+        Mal.Env.set(env, "*ARGV*", list(rest))
+        load_file(file_name, env)
+
+      [] ->
+        Mal.Env.set(env, "*ARGV*", list([]))
     end
   end
 

--- a/elixir/lib/mix/tasks/step8_macros.ex
+++ b/elixir/lib/mix/tasks/step8_macros.ex
@@ -6,12 +6,10 @@ defmodule Mix.Tasks.Step8Macros do
     env = Mal.Env.new()
     Mal.Env.merge(env, Mal.Core.namespace)
     bootstrap(args, env)
-    load_file(args, env)
     loop(env)
   end
 
-  defp load_file([], _env), do: nil
-  defp load_file([file_name | _args], env) do
+  defp load_file(file_name, env) do
     read_eval_print("""
       (load-file "#{file_name}")
       """, env)
@@ -60,8 +58,12 @@ defmodule Mix.Tasks.Step8Macros do
     end})
 
     case args do
-      [_file_name | rest] -> Mal.Env.set(env, "*ARGV*", list(rest))
-      [] -> Mal.Env.set(env, "*ARGV*", list([]))
+      [file_name | rest] ->
+        Mal.Env.set(env, "*ARGV*", list(rest))
+        load_file(file_name, env)
+
+      [] ->
+        Mal.Env.set(env, "*ARGV*", list([]))
     end
   end
 

--- a/elixir/lib/mix/tasks/step9_try.ex
+++ b/elixir/lib/mix/tasks/step9_try.ex
@@ -6,12 +6,10 @@ defmodule Mix.Tasks.Step9Try do
     env = Mal.Env.new()
     Mal.Env.merge(env, Mal.Core.namespace)
     bootstrap(args, env)
-    load_file(args, env)
     loop(env)
   end
 
-  defp load_file([], _env), do: nil
-  defp load_file([file_name | _args], env) do
+  defp load_file(file_name, env) do
     read_eval_print("""
       (load-file "#{file_name}")
       """, env)
@@ -60,8 +58,12 @@ defmodule Mix.Tasks.Step9Try do
     end})
 
     case args do
-      [_file_name | rest] -> Mal.Env.set(env, "*ARGV*", list(rest))
-      [] -> Mal.Env.set(env, "*ARGV*", list([]))
+      [file_name | rest] ->
+        Mal.Env.set(env, "*ARGV*", list(rest))
+        load_file(file_name, env)
+
+      [] ->
+        Mal.Env.set(env, "*ARGV*", list([]))
     end
   end
 

--- a/elixir/lib/mix/tasks/stepA_mal.ex
+++ b/elixir/lib/mix/tasks/stepA_mal.ex
@@ -6,12 +6,10 @@ defmodule Mix.Tasks.StepAMal do
     env = Mal.Env.new()
     Mal.Env.merge(env, Mal.Core.namespace)
     bootstrap(args, env)
-    load_file(args, env)
     loop(env)
   end
 
-  defp load_file([], _env), do: nil
-  defp load_file([file_name | _args], env) do
+  defp load_file(file_name, env) do
     read_eval_print("""
       (load-file "#{file_name}")
       """, env)
@@ -58,15 +56,18 @@ defmodule Mix.Tasks.StepAMal do
               `(let* (or_FIXME ~(first xs)) (if or_FIXME or_FIXME (or ~@(rest xs))))))))
       """, env)
 
-    read_eval_print("(println (str \"Mal [\" *host-language* \"]\"))", env)
-
     Mal.Env.set(env, "eval", %Function{value: fn [ast] ->
       eval(ast, env)
     end})
 
     case args do
-      [_file_name | rest] -> Mal.Env.set(env, "*ARGV*", list(rest))
-      [] -> Mal.Env.set(env, "*ARGV*", list([]))
+      [file_name | rest] ->
+        Mal.Env.set(env, "*ARGV*", list(rest))
+        load_file(file_name, env)
+
+      [] ->
+        Mal.Env.set(env, "*ARGV*", list([]))
+        read_eval_print("(println (str \"Mal [\" *host-language* \"]\"))", env)
     end
   end
 


### PR DESCRIPTION
As for the `iex -S mix stepA_mal` vs `mix stepA_mal` issue:

> The reason I'm running it with `iex -S` is to be able to use `iex`'s readline functionality, as there's no readline wrapper available for Elixir. If you want to I'll change it to just `mix stepA_mal` which compiles if necessary and runs the REPL, albeit without history/parenthesis matching and so on.

What do you think?