### PR TITLE
Changed nim/nimcache to nim/nimcache* in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ haskell/*.hi
 haskell/*.o
 lua/lib
 lua/linenoise.so
-nim/nimcache
+nim/nimcache*
 .lein
 .m2
 .ivy2


### PR DESCRIPTION
A seperate nimcache folder was being generated for each step with the
name of the step appended to nimcache, like nimcache-step0_repl and so
was not being ignored by git.
This change will prevent git from tracking
any folder with name starting with nimcache in the nim directory.