### PR TITLE
Crystal: Fixed missing method error for Crystal 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ coffee ./stepX_YYY
 
 *The Crystal implementation of mal was created by [Linda_pp](https://github.com/rhysd)*
 
-The Crystal implementation of mal has been tested with Crystal 0.7.2.
+The Crystal implementation of mal has been tested with Crystal 0.8.0.
 
 ```
 cd crystal

--- a/crystal/core.cr
+++ b/crystal/core.cr
@@ -338,7 +338,7 @@ def self.conj(args)
 end
 
 def self.time_ms(args)
-  (Time.now.to_i.to_i32) * 1000
+  Time.now.epoch_ms.to_i32
 end
 
 # Note:


### PR DESCRIPTION
Now all tests are passed in my local environment (OS X 10.9).