### PR TITLE
Fix reading/printing of escaped characters

### DIFF
--- a/erlang/rebar.config
+++ b/erlang/rebar.config
@@ -2,7 +2,7 @@
 %% rebar configuration file (https://github.com/rebar/rebar)
 %%
 
-{require_otp_vsn, "17"}.
+{require_otp_vsn, "17|18"}.
 
 {erl_opts, [debug_info, fail_on_warning]}.
 

--- a/erlang/src/printer.erl
+++ b/erlang/src/printer.erl
@@ -54,7 +54,7 @@ escape_str(String) ->
         case C of
             $"  -> [C, $\\|AccIn];
             $\\ -> [C, $\\|AccIn];
-            $\n -> [C, $\\|AccIn];
+            $\n -> [$n, $\\|AccIn];
             _   -> [C|AccIn]
         end
     end,

--- a/erlang/src/reader.erl
+++ b/erlang/src/reader.erl
@@ -216,8 +216,9 @@ lex_string([], _String) ->
 lex_string([$\\,Escaped|Rest], String) ->
     % unescape the string while building it
     case Escaped of
-        [] -> {error, "end of string reached in escape"};
-        _  -> lex_string(Rest, [Escaped|String])
+        []  -> {error, "end of string reached in escape"};
+        $n  -> lex_string(Rest, [$\n|String]);
+        _   -> lex_string(Rest, [Escaped|String])
     end;
 lex_string([$"|Rest], String) ->
     {{string, lists:reverse(String)}, Rest};


### PR DESCRIPTION
Properly read \\n and convert to a newline, and when printing with
readability enabled, convert the newline back to \\n.

Add support for Erlang R18, which was nothing more than tweaking the
requirements in the rebar.config file.

Fixes #100

make test^erlang passes