### PR TITLE
tests: step9: add hash-map equality tests

### DIFF
--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -261,4 +261,14 @@
 ;=>true
 
 
+;; ------- Optional Functionality --------------
+;; ------- (Not needed for self-hosting) -------
+;>>> soft=True
 
+;; Testing equality of hash-maps
+(= {:a 11 :b 22} (hash-map :b 22 :a 11))
+;=>true
+(= {:a 11 :b 22} (hash-map :a 11))
+;=>false
+(= {:a 11 :b 22} (list :a 11 :b 22))
+;=>false


### PR DESCRIPTION
No one was testing that the `=` function works correctly on hash-maps. I introduce this test in step9 together with `hash-map`, `map?` etc.