### PR TITLE
lua: fix time-ms to return actual millisecond resolution timestamp

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -82,7 +82,6 @@ Javascript:
     - fix "user> " prompt with mal/clojurewest2014.mal
 
 Lua:
-    - time-ms should get actual milliseconds
 
 Make:
     - allow '_' in make variable names

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /mal
 # Lua
 RUN apt-get -y install lua5.1 lua-rex-pcre luarocks
 RUN luarocks install linenoise
+RUN luarocks install luasocket
 
 # luarocks .cache directory is relative to HOME
 ENV HOME /mal

--- a/lua/core.lua
+++ b/lua/core.lua
@@ -3,6 +3,7 @@ local types = require('types')
 local reader = require('reader')
 local printer = require('printer')
 local readline = require('readline')
+local socket = require('socket')
 
 local Nil, List, _pr_str = types.Nil, types.List, printer._pr_str
 
@@ -201,8 +202,7 @@ M.ns = {
     ['-'] =  function(a,b) return a-b end,
     ['*'] =  function(a,b) return a*b end,
     ['/'] =  function(a,b) return math.floor(a/b) end,
-    -- TODO: get actual milliseconds
-    ['time-ms'] = function() return os.time() * 1000 end,
+    ['time-ms'] = function() return math.floor(socket.gettime() * 1000) end,
 
     list = function(...) return List:new(arg) end,
     ['list?'] = function(a) return types._list_Q(a) end,


### PR DESCRIPTION
We install the luasocket rock to use its `socket.gettime()` function which returns sub-second resolution timestamps.