### PR TITLE
tests: add soft tests for nested vector/list equality in step 4

### DIFF
--- a/tests/step4_if_fn_do.mal
+++ b/tests/step4_if_fn_do.mal
@@ -422,3 +422,15 @@ nil
 ;=>4
 ( (fn* [f x] (f x)) (fn* [a] (+ 1 a)) 7)
 ;=>8
+
+;;
+;; -------- Soft tests --------
+;; (when most implementations will implement these tests correctly this section
+;; will be modified to hard failures)
+;>>> soft=True
+
+;; Nested vector/list equality
+(= [(list)] (list []))
+;=>true
+(= [1 2 (list 3 4 [5 6])] (list 1 2 [3 4 (list 5 6)]))
+;=>true


### PR DESCRIPTION
(as discussed in #116)

For example, these nested list/vector tests currently soft-fail in the guile implementation.
