### PR TITLE
runtest.py: Repeat failed test cases at the bottom

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -231,6 +231,7 @@ test_cnt = 0
 pass_cnt = 0
 fail_cnt = 0
 soft_fail_cnt = 0
+failures = []
 
 while t.next():
     log("TEST: %s -> [%s,%s]" % (t.form, repr(t.out), t.ret), end='')
@@ -255,18 +256,30 @@ while t.next():
             if t.soft and not args.hard:
                 log(" -> SOFT FAIL (line %d):" % t.line_num)
                 soft_fail_cnt += 1
+                fail_type = "SOFT "
             else:
                 log(" -> FAIL (line %d):" % t.line_num)
                 fail_cnt += 1
+                fail_type = ""
             log("    Expected : %s" % repr(expected[0]))
             log("    Got      : %s" % repr(res))
+            failed_test = """%sFAILED TEST (line %d): %s -> [%s,%s]:
+    Expected : %s
+    Got      : %s""" % (fail_type, t.line_num, t.form, repr(t.out), t.ret, repr(expected[0]), repr(res))
+            failures.append(failed_test)
     except:
         _, exc, _ = sys.exc_info()
         log("\nException: %s" % repr(exc))
         log("Output before exception:\n%s" % r.buf)
         sys.exit(1)
 
-results = """TEST RESULTS (for %s):
+if len(failures) > 0:
+    log("\nFAILURES:")
+    for f in failures:
+        log(f)
+
+results = """
+TEST RESULTS (for %s):
   %3d: soft failing tests
   %3d: failing tests
   %3d: passing tests


### PR DESCRIPTION
Gather and re-print failed test cases at the end of the test suite. This saves the trouble of scanning up the 157 test cases and finding the two failures.

Example output:

```
...
...
Testing vector parameter lists
TEST: ( (fn* [] 4) ) -> ['',4] -> SUCCESS
TEST: ( (fn* [f x] (f x)) (fn* [a] (+ 1 a)) 7) -> ['',8] -> SUCCESS

-------- Soft tests --------
(when most implementations will implement these tests correctly this section
will be modified to hard failures)
Nested vector/list equality
TEST: (= [(list)] (list [])) -> ['',true] -> SUCCESS
TEST: (= [1 2 (list 3 4 [5 6])] (list 1 2 [3 4 (list 5 6)])) -> ['',true] -> SUCCESS

FAILURES:
FAILED TEST (line 314): (str (list 1 2 "abc" "\"") "def") -> ['',"(1 2 \"abc\" \"\\\"\")def"]:
    Expected : '(str (list 1 2 "abc" "\\"") "def")\r\n"(1 2 \\"abc\\" \\"\\\\\\"\\")def"'
    Got      : '(str (list 1 2 "abc" "\\"") "def")\r\n"(1 2 abc \\")def"'
FAILED TEST (line 317): (str [1 2 "abc" "\""] "def") -> ['',"[1 2 \"abc\" \"\\\"\"]def"]:
    Expected : '(str [1 2 "abc" "\\""] "def")\r\n"[1 2 \\"abc\\" \\"\\\\\\"\\"]def"'
    Got      : '(str [1 2 "abc" "\\""] "def")\r\n"[1 2 abc \\"]def"'

TEST RESULTS (for ../tests/step4_if_fn_do.mal):
    0: soft failing tests
    2: failing tests
  155: passing tests
  157: total tests

make: *** [test^ruby^step4] Error 1
```