### PR TITLE
tests: Add str and pr-str tests in step4 and step9

### DIFF
--- a/clojure/src/core.clj
+++ b/clojure/src/core.clj
@@ -1,5 +1,6 @@
 (ns core
-  (:require [readline]))
+  (:require [readline]
+            [printer]))
 
 ;; Errors/exceptions
 (defn mal_throw [obj]
@@ -14,6 +15,22 @@
 (defn mal_meta [obj]
   (:meta (meta obj)))
 
+; Strings and printing functions
+(defn pr-helper [coll sep readable?]
+  (clojure.string/join sep (map #(printer/mal-pr-str % readable?) coll)))
+
+(defn mal_pr_str [& args]
+  (pr-helper args " " true))
+
+(defn mal_str [& args]
+  (pr-helper args "" false))
+
+(defn mal_prn [& args]
+  (println (pr-helper args " " true)))
+
+(defn mal_println [& args]
+  (println (pr-helper args " " false)))
+
 ;; core_ns is core namespaces functions
 (def core_ns
   [['= =]
@@ -26,10 +43,10 @@
    ['keyword keyword]
    ['keyword? keyword?]
 
-   ['pr-str pr-str]
-   ['str str]
-   ['prn prn]
-   ['println println]
+   ['pr-str mal_pr_str]
+   ['str mal_str]
+   ['prn mal_prn]
+   ['println mal_println]
    ['readline readline/readline]
    ['read-string reader/read-string]
    ['slurp slurp]

--- a/clojure/src/printer.clj
+++ b/clojure/src/printer.clj
@@ -1,7 +1,28 @@
 (ns printer)
 
-(defmethod clojure.core/print-method clojure.lang.Atom [a writer]
-  (.write writer "(atom ")
-  (.write writer (pr-str @a))
-  (.write writer ")"))
+(declare pr-seq)
 
+(defn mal-pr-str [obj readable?]
+  (cond
+    (nil? obj)
+    "nil"
+
+    (vector? obj)
+    (pr-seq obj "[" "]" readable?)
+
+    (seq? obj)
+    (pr-seq obj "(" ")" readable?)
+
+    (map? obj)
+    (pr-seq (mapcat identity obj) "{" "}" readable?)
+
+    (= (type obj) clojure.lang.Atom)
+    (str "(atom" (mal-pr-str @obj true) ")")
+
+    :else
+    ((if readable? pr-str str) obj)))
+
+(defn pr-seq [elements start end readable?]
+  (str start
+       (clojure.string/join " " (map #(mal-pr-str % readable?) elements))
+       end))

--- a/erlang/src/printer.erl
+++ b/erlang/src/printer.erl
@@ -41,13 +41,11 @@ pr_list(Seq, Start, End, Join, Readably) ->
     Start ++ L ++ End.
 
 pr_map(Map, Readably) ->
-    PrintKV = fun({Key, Value}) ->
-        KS = pr_str(Key, Readably),
-        VS = pr_str(Value, Readably),
-        KS ++ " " ++ VS
+    AppendKV = fun({Key, Value}, AccIn) ->
+        AccIn ++ [Key, Value]
     end,
-    L = string:join(lists:map(PrintKV, maps:to_list(Map)), " "),
-    io_lib:format("{~s}", [L]).
+    Elements = lists:foldl(AppendKV, [], maps:to_list(Map)),
+    pr_list(Elements, "{", "}", " ", Readably).
 
 escape_str(String) ->
     Escape = fun(C, AccIn) ->

--- a/forth/printer.fs
+++ b/forth/printer.fs
@@ -58,7 +58,7 @@ MalMap
         list MalList/start @ { start }
         start @ pr-buf a-space start cell+ @ pr-buf
         count 2 / 1 ?do
-            s" , " str-append
+            a-space
             start i 2 * cells + @ pr-buf a-space
             start i 2 * 1+ cells + @ pr-buf
         loop

--- a/guile/printer.scm
+++ b/guile/printer.scm
@@ -25,7 +25,7 @@
       (string-join
        (hash-map->list
         (lambda (k v)
-          (format #f "~a ~a" (pr_str k #t) (pr_str v #t)))
+          (format #f "~a ~a" (p k) (p v)))
         hm)
        " ")
       port)

--- a/ocaml/printer.ml
+++ b/ocaml/printer.ml
@@ -31,7 +31,7 @@ let rec pr_str mal_obj print_readably =
       | T.Vector { T.value = xs } ->
           "[" ^ (String.concat " " (List.map (fun s -> pr_str s r) xs)) ^ "]"
       | T.Map { T.value = xs } ->
-         "{" ^ (Types.MalMap.fold (fun k v s -> s ^ (if s = "" then "" else ", ") ^ (pr_str k r)
+         "{" ^ (Types.MalMap.fold (fun k v s -> s ^ (if s = "" then "" else " ") ^ (pr_str k r)
                                                 ^ " " ^ (pr_str v r)) xs "")
          ^ "}"
       | T.Fn f -> "#<fn>"

--- a/tests/step4_if_fn_do.mal
+++ b/tests/step4_if_fn_do.mal
@@ -269,12 +269,20 @@ a
 (pr-str (list 1 2 "abc" "\"") "def")
 ;=>"(1 2 \"abc\" \"\\\"\") \"def\""
 
+(pr-str [1 2 "abc" "\""] "def")
+;=>"[1 2 \"abc\" \"\\\"\"] \"def\""
+
 (pr-str "abc\ndef\nghi")
 ;=>"\"abc\\ndef\\nghi\""
 
 (pr-str "abc\\def\\ghi")
 ;=>"\"abc\\\\def\\\\ghi\""
 
+(pr-str (list))
+;=>"()"
+
+(pr-str [])
+;=>"[]"
 
 ;; Testing str
 
@@ -302,10 +310,17 @@ a
 (str "abc\\def\\ghi")
 ;=>"abc\\def\\ghi"
 
-;;; TODO: get this working properly
-;;;(str (list 1 2 "abc" "\"") "def")
-;;;;=>"(1 2 \"abc\" \"\\\"\")def"
+(str (list 1 2 "abc" "\"") "def")
+;=>"(1 2 abc \")def"
 
+(str [1 2 "abc" "\""] "def")
+;=>"[1 2 abc \"]def"
+
+(str (list))
+;=>"()"
+
+(str [])
+;=>"[]"
 
 ;; Testing prn
 (prn)

--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -268,6 +268,29 @@
 (dissoc {:cde nil :fgh 456} :cde)
 ;=>{:fgh 456}
 
+;;
+;; Additional str and pr-str tests
+
+(str "A" {:abc "val"} "Z")
+;=>"A{:abc val}Z"
+
+(str true "." false "." nil "." :keyw "." 'symb)
+;=>"true.false.nil.:keyw.symb"
+
+(pr-str "A" {:abc "val"} "Z")
+;=>"\"A\" {:abc \"val\"} \"Z\""
+
+(pr-str true "." false "." nil "." :keyw "." 'symb)
+;=>"true \".\" false \".\" nil \".\" :keyw \".\" symb"
+
+(def! s (str {:abc "val1" :def "val2"}))
+(or (= s "{:abc val1 :def val2}") (= s "{:def val2 :abc val1}"))
+;=>true
+
+(def! p (pr-str {:abc "val1" :def "val2"}))
+(or (= p "{:abc \"val1\" :def \"val2\"}") (= p "{:def \"val2\" :abc \"val1\"}"))
+;=>true
+
 ;; ------- Optional Functionality --------------
 ;; ------- (Not needed for self-hosting) -------
 ;>>> soft=True


### PR DESCRIPTION
Specifically test serializing nil, empty collections and `str` of
collections.  The Mal implementation is *not* identical to Clojure for
these cases.

I know the clojure mal impl is broken. Will wait for travis results to see what's the situation in other impls (c, ruby, python and racket have passed OK).

This will probably need some fixing because when serializing hash-map (step9) the order of keys might change. But I want to verify that no commas are inserted (current clojure impl does it).