### PR TITLE
Update guide.md

### DIFF
--- a/process/guide.md
+++ b/process/guide.md
@@ -200,7 +200,7 @@ make-a-lisp process.
   interpreter REPL. Many languages have a library/module that provide
   line editing support. Another option if your language supports it is
   to use an FFI (foreign function interface) to load and call directly
-  into GNU readline, editline, or libnoise library. Add line
+  into GNU readline, editline, or linenoise library. Add line
   editing interface code to `readline.qx`
 
 


### PR DESCRIPTION
Fix typo; libnoise is a noise generating library.