### PR TITLE
Fix macro eval in 24 impls

### DIFF
--- a/bash/step8_macros.sh
+++ b/bash/step8_macros.sh
@@ -118,7 +118,10 @@ EVAL () {
     # apply list
     MACROEXPAND "${ast}" "${env}"
     ast="${r}"
-    if ! _list? "${ast}"; then return; fi
+    if ! _list? "${ast}"; then
+        EVAL_AST "${ast}" "${env}"
+        return
+    fi
     _nth "${ast}" 0; local a0="${r}"
     _nth "${ast}" 1; local a1="${r}"
     _nth "${ast}" 2; local a2="${r}"

--- a/bash/step9_try.sh
+++ b/bash/step9_try.sh
@@ -118,7 +118,10 @@ EVAL () {
     # apply list
     MACROEXPAND "${ast}" "${env}"
     ast="${r}"
-    if ! _list? "${ast}"; then return; fi
+    if ! _list? "${ast}"; then
+        EVAL_AST "${ast}" "${env}"
+        return
+    fi
     _nth "${ast}" 0; local a0="${r}"
     _nth "${ast}" 1; local a1="${r}"
     _nth "${ast}" 2; local a2="${r}"

--- a/bash/stepA_mal.sh
+++ b/bash/stepA_mal.sh
@@ -118,7 +118,10 @@ EVAL () {
     # apply list
     MACROEXPAND "${ast}" "${env}"
     ast="${r}"
-    if ! _list? "${ast}"; then return; fi
+    if ! _list? "${ast}"; then
+        EVAL_AST "${ast}" "${env}"
+        return
+    fi
     _nth "${ast}" 0; local a0="${r}"
     _nth "${ast}" 1; local a1="${r}"
     _nth "${ast}" 2; local a2="${r}"

--- a/c/step8_macros.c
+++ b/c/step8_macros.c
@@ -123,7 +123,9 @@ MalVal *EVAL(MalVal *ast, Env *env) {
     //g_print("EVAL apply list: %s\n", _pr_str(ast,1));
     ast = macroexpand(ast, env);
     if (!ast || mal_error) return NULL;
-    if (ast->type != MAL_LIST) { return ast; }
+    if (ast->type != MAL_LIST) {
+        return eval_ast(ast, env);
+    }
     if (_count(ast) == 0) { return ast; }
 
     int i, len;

--- a/c/step9_try.c
+++ b/c/step9_try.c
@@ -124,7 +124,9 @@ MalVal *EVAL(MalVal *ast, Env *env) {
     //g_print("EVAL apply list: %s\n", _pr_str(ast,1));
     ast = macroexpand(ast, env);
     if (!ast || mal_error) return NULL;
-    if (ast->type != MAL_LIST) { return ast; }
+    if (ast->type != MAL_LIST) {
+        return eval_ast(ast, env);
+    }
     if (_count(ast) == 0) { return ast; }
 
     int i, len;

--- a/c/stepA_mal.c
+++ b/c/stepA_mal.c
@@ -124,7 +124,9 @@ MalVal *EVAL(MalVal *ast, Env *env) {
     //g_print("EVAL apply list: %s\n", _pr_str(ast,1));
     ast = macroexpand(ast, env);
     if (!ast || mal_error) return NULL;
-    if (ast->type != MAL_LIST) { return ast; }
+    if (ast->type != MAL_LIST) {
+        return eval_ast(ast, env);
+    }
     if (_count(ast) == 0) { return ast; }
 
     int i, len;

--- a/coffee/step8_macros.coffee
+++ b/coffee/step8_macros.coffee
@@ -47,8 +47,8 @@ EVAL = (ast, env) ->
   if !types._list_Q ast then return eval_ast ast, env
 
   # apply list
-  ast = macroexpand ast, env 
-  if !types._list_Q ast then return ast
+  ast = macroexpand ast, env
+  if !types._list_Q ast then return eval_ast ast, env
 
   [a0, a1, a2, a3] = ast
   switch a0.name

--- a/coffee/step9_try.coffee
+++ b/coffee/step9_try.coffee
@@ -47,8 +47,8 @@ EVAL = (ast, env) ->
   if !types._list_Q ast then return eval_ast ast, env
 
   # apply list
-  ast = macroexpand ast, env 
-  if !types._list_Q ast then return ast
+  ast = macroexpand ast, env
+  if !types._list_Q ast then return eval_ast ast, env
 
   [a0, a1, a2, a3] = ast
   switch a0.name

--- a/coffee/stepA_mal.coffee
+++ b/coffee/stepA_mal.coffee
@@ -47,8 +47,8 @@ EVAL = (ast, env) ->
   if !types._list_Q ast then return eval_ast ast, env
 
   # apply list
-  ast = macroexpand ast, env 
-  if !types._list_Q ast then return ast
+  ast = macroexpand ast, env
+  if !types._list_Q ast then return eval_ast ast, env
 
   [a0, a1, a2, a3] = ast
   switch a0.name

--- a/crystal/step8_macros.cr
+++ b/crystal/step8_macros.cr
@@ -143,7 +143,7 @@ module Mal
 
       list = ast.unwrap
 
-      return ast unless list.is_a? Mal::List
+      return eval_ast(ast, env) unless list.is_a? Mal::List
       return ast if list.empty?
 
       head = list.first.unwrap

--- a/crystal/step9_try.cr
+++ b/crystal/step9_try.cr
@@ -143,7 +143,7 @@ module Mal
 
       list = ast.unwrap
 
-      return ast unless list.is_a? Mal::List
+      return eval_ast(ast, env) unless list.is_a? Mal::List
       return ast if list.empty?
 
       head = list.first.unwrap

--- a/crystal/stepA_mal.cr
+++ b/crystal/stepA_mal.cr
@@ -150,7 +150,7 @@ module Mal
 
       list = ast.unwrap
 
-      return ast unless list.is_a? Mal::List
+      return eval_ast(ast, env) unless list.is_a? Mal::List
       return ast if list.empty?
 
       head = list.first.unwrap

--- a/d/step8_macros.d
+++ b/d/step8_macros.d
@@ -127,7 +127,7 @@ MalType EVAL(MalType ast, Env env)
         ast_list = cast(MalList) ast;
         if (ast_list is null)
         {
-            return ast;
+            return eval_ast(ast, env);
         }
 
         auto aste = ast_list.elements;

--- a/d/step9_try.d
+++ b/d/step9_try.d
@@ -127,7 +127,7 @@ MalType EVAL(MalType ast, Env env)
         ast_list = cast(MalList) ast;
         if (ast_list is null)
         {
-            return ast;
+            return eval_ast(ast, env);
         }
 
         auto aste = ast_list.elements;

--- a/d/stepA_mal.d
+++ b/d/stepA_mal.d
@@ -127,7 +127,7 @@ MalType EVAL(MalType ast, Env env)
         ast_list = cast(MalList) ast;
         if (ast_list is null)
         {
-            return ast;
+            return eval_ast(ast, env);
         }
 
         auto aste = ast_list.elements;

--- a/elixir/lib/mix/tasks/step8_macros.ex
+++ b/elixir/lib/mix/tasks/step8_macros.ex
@@ -162,7 +162,7 @@ defmodule Mix.Tasks.Step8Macros do
   defp eval({:list, _list, _meta} = ast, env) do
     case macroexpand(ast, env) do
       {:list, list, meta} -> eval_list(list, env, meta)
-      result -> result
+      result -> eval_ast(result, env)
     end
   end
   defp eval(ast, env), do: eval_ast(ast, env)

--- a/elixir/lib/mix/tasks/step9_try.ex
+++ b/elixir/lib/mix/tasks/step9_try.ex
@@ -162,7 +162,7 @@ defmodule Mix.Tasks.Step9Try do
   defp eval({:list, _list, _meta} = ast, env) do
     case macroexpand(ast, env) do
       {:list, list, meta} -> eval_list(list, env, meta)
-      result -> result
+      result -> eval_ast(result, env)
     end
   end
   defp eval(ast, env), do: eval_ast(ast, env)

--- a/elixir/lib/mix/tasks/stepA_mal.ex
+++ b/elixir/lib/mix/tasks/stepA_mal.ex
@@ -166,7 +166,7 @@ defmodule Mix.Tasks.StepAMal do
   defp eval({:list, _list, _meta} = ast, env) do
     case macroexpand(ast, env) do
       {:list, list, meta} -> eval_list(list, env, meta)
-      result -> result
+      result -> eval_ast(result, env)
     end
   end
   defp eval(ast, env), do: eval_ast(ast, env)

--- a/erlang/src/step8_macros.erl
+++ b/erlang/src/step8_macros.erl
@@ -50,7 +50,7 @@ eval(Value, Env) ->
         {list, _L1, _M1} ->
             case macroexpand(Value, Env) of
                 {list, _L2, _M2} = List -> eval_list(List, Env);
-                AST -> AST
+                AST -> eval_ast(AST, Env)
             end;
         _ -> eval_ast(Value, Env)
     end.

--- a/erlang/src/step9_try.erl
+++ b/erlang/src/step9_try.erl
@@ -50,7 +50,7 @@ eval(Value, Env) ->
         {list, _L1, _M1} ->
             case macroexpand(Value, Env) of
                 {list, _L2, _M2} = List -> eval_list(List, Env);
-                AST -> AST
+                AST -> eval_ast(AST, Env)
             end;
         _ -> eval_ast(Value, Env)
     end.

--- a/erlang/src/stepA_mal.erl
+++ b/erlang/src/stepA_mal.erl
@@ -54,7 +54,7 @@ eval(Value, Env) ->
         {list, _L1, _M1} ->
             case macroexpand(Value, Env) of
                 {list, _L2, _M2} = List -> eval_list(List, Env);
-                AST -> AST
+                AST -> eval_ast(AST, Env)
             end;
         _ -> eval_ast(Value, Env)
     end.

--- a/es6/step8_macros.js
+++ b/es6/step8_macros.js
@@ -64,7 +64,7 @@ const EVAL = (ast, env) => {
     if (!_list_Q(ast)) { return eval_ast(ast, env) }
 
     ast = macroexpand(ast, env)
-    if (!_list_Q(ast)) { return ast; }
+    if (!_list_Q(ast)) { return eval_ast(ast, env) }
 
     const [a0, a1, a2, a3] = ast
     const a0sym = _symbol_Q(a0) ? Symbol.keyFor(a0) : Symbol(':default')

--- a/es6/step9_try.js
+++ b/es6/step9_try.js
@@ -64,7 +64,7 @@ const EVAL = (ast, env) => {
     if (!_list_Q(ast)) { return eval_ast(ast, env) }
 
     ast = macroexpand(ast, env)
-    if (!_list_Q(ast)) { return ast; }
+    if (!_list_Q(ast)) { return eval_ast(ast, env) }
 
     const [a0, a1, a2, a3] = ast
     const a0sym = _symbol_Q(a0) ? Symbol.keyFor(a0) : Symbol(':default')

--- a/es6/stepA_mal.js
+++ b/es6/stepA_mal.js
@@ -64,7 +64,7 @@ const EVAL = (ast, env) => {
     if (!_list_Q(ast)) { return eval_ast(ast, env) }
 
     ast = macroexpand(ast, env)
-    if (!_list_Q(ast)) { return ast; }
+    if (!_list_Q(ast)) { return eval_ast(ast, env) }
 
     const [a0, a1, a2, a3] = ast
     const a0sym = _symbol_Q(a0) ? Symbol.keyFor(a0) : Symbol(':default')

--- a/factor/step8_macros/step8_macros.factor
+++ b/factor/step8_macros/step8_macros.factor
@@ -102,7 +102,7 @@ M: callable apply call( x -- y ) f ;
                 [ drop '[ _ EVAL ] map unclip apply ]
             } case [ EVAL ] when*
         ] [
-            drop
+            eval-ast
         ] if
     ] [
         eval-ast

--- a/factor/step9_try/step9_try.factor
+++ b/factor/step9_try/step9_try.factor
@@ -110,7 +110,7 @@ M: callable apply call( x -- y ) f ;
                 [ drop '[ _ EVAL ] map unclip apply ]
             } case [ EVAL ] when*
         ] [
-            drop
+            eval-ast
         ] if
     ] [
         eval-ast

--- a/factor/stepA_mal/stepA_mal.factor
+++ b/factor/stepA_mal/stepA_mal.factor
@@ -110,7 +110,7 @@ M: callable apply call( x -- y ) f ;
                 [ drop '[ _ EVAL ] map unclip apply ]
             } case [ EVAL ] when*
         ] [
-            drop
+            eval-ast
         ] if
     ] [
         eval-ast

--- a/go/src/step8_macros/step8_macros.go
+++ b/go/src/step8_macros/step8_macros.go
@@ -153,7 +153,7 @@ func EVAL(ast MalType, env EnvType) (MalType, error) {
 			return nil, e
 		}
 		if !List_Q(ast) {
-			return ast, nil
+			return eval_ast(ast, env)
 		}
 
 		a0 := ast.(List).Val[0]

--- a/go/src/step9_try/step9_try.go
+++ b/go/src/step9_try/step9_try.go
@@ -153,7 +153,7 @@ func EVAL(ast MalType, env EnvType) (MalType, error) {
 			return nil, e
 		}
 		if !List_Q(ast) {
-			return ast, nil
+			return eval_ast(ast, env)
 		}
 
 		a0 := ast.(List).Val[0]

--- a/go/src/stepA_mal/stepA_mal.go
+++ b/go/src/stepA_mal/stepA_mal.go
@@ -153,7 +153,7 @@ func EVAL(ast MalType, env EnvType) (MalType, error) {
 			return nil, e
 		}
 		if !List_Q(ast) {
-			return ast, nil
+			return eval_ast(ast, env)
 		}
 
 		a0 := ast.(List).Val[0]

--- a/js/step8_macros.js
+++ b/js/step8_macros.js
@@ -78,7 +78,9 @@ function _EVAL(ast, env) {
 
     // apply list
     ast = macroexpand(ast, env);
-    if (!types._list_Q(ast)) { return ast; }
+    if (!types._list_Q(ast)) {
+        return eval_ast(ast, env);
+    }
 
     var a0 = ast[0], a1 = ast[1], a2 = ast[2], a3 = ast[3];
     switch (a0.value) {

--- a/js/step9_try.js
+++ b/js/step9_try.js
@@ -78,7 +78,9 @@ function _EVAL(ast, env) {
 
     // apply list
     ast = macroexpand(ast, env);
-    if (!types._list_Q(ast)) { return ast; }
+    if (!types._list_Q(ast)) {
+        return eval_ast(ast, env);
+    }
 
     var a0 = ast[0], a1 = ast[1], a2 = ast[2], a3 = ast[3];
     switch (a0.value) {

--- a/js/stepA_mal.js
+++ b/js/stepA_mal.js
@@ -79,7 +79,9 @@ function _EVAL(ast, env) {
 
     // apply list
     ast = macroexpand(ast, env);
-    if (!types._list_Q(ast)) { return ast; }
+    if (!types._list_Q(ast)) {
+        return eval_ast(ast, env);
+    }
 
     var a0 = ast[0], a1 = ast[1], a2 = ast[2], a3 = ast[3];
     switch (a0.value) {

--- a/lua/step8_macros.lua
+++ b/lua/step8_macros.lua
@@ -81,7 +81,7 @@ function EVAL(ast, env)
 
     -- apply list
     ast = macroexpand(ast, env)
-    if not types._list_Q(ast) then return ast end
+    if not types._list_Q(ast) then return eval_ast(ast, env) end
 
     local a0,a1,a2,a3 = ast[1], ast[2],ast[3],ast[4]
     local a0sym = types._symbol_Q(a0) and a0.val or ""

--- a/lua/step9_try.lua
+++ b/lua/step9_try.lua
@@ -81,7 +81,7 @@ function EVAL(ast, env)
 
     -- apply list
     ast = macroexpand(ast, env)
-    if not types._list_Q(ast) then return ast end
+    if not types._list_Q(ast) then return eval_ast(ast, env) end
 
     local a0,a1,a2,a3 = ast[1], ast[2],ast[3],ast[4]
     local a0sym = types._symbol_Q(a0) and a0.val or ""

--- a/lua/stepA_mal.lua
+++ b/lua/stepA_mal.lua
@@ -81,7 +81,7 @@ function EVAL(ast, env)
 
     -- apply list
     ast = macroexpand(ast, env)
-    if not types._list_Q(ast) then return ast end
+    if not types._list_Q(ast) then return eval_ast(ast, env) end
 
     local a0,a1,a2,a3 = ast[1], ast[2],ast[3],ast[4]
     local a0sym = types._symbol_Q(a0) and a0.val or ""

--- a/make/step8_macros.mk
+++ b/make/step8_macros.mk
@@ -127,7 +127,7 @@ $(strip $(if $(__ERROR),,\
     $(foreach ast,$(call MACROEXPAND,$(1),$(2)),
       $(if $(call _list?,$(ast)),\
         $(word 1,$(strip $(call EVAL_INVOKE,$(ast),$(2)) $(__nil))),\
-	$(ast))),\
+	$(call EVAL_AST,$(ast),$(2)))),\
     $(call EVAL_AST,$(1),$(2)))))
 endef
 

--- a/make/step9_try.mk
+++ b/make/step9_try.mk
@@ -142,7 +142,7 @@ $(strip $(if $(__ERROR),,\
     $(foreach ast,$(call MACROEXPAND,$(1),$(2)),
       $(if $(call _list?,$(ast)),\
         $(word 1,$(strip $(call EVAL_INVOKE,$(ast),$(2)) $(__nil))),\
-	$(ast))),\
+	$(call EVAL_AST,$(ast),$(2)))),\
     $(call EVAL_AST,$(1),$(2)))))
 endef
 

--- a/make/stepA_mal.mk
+++ b/make/stepA_mal.mk
@@ -146,7 +146,7 @@ $(strip $(if $(__ERROR),,\
     $(foreach ast,$(call MACROEXPAND,$(1),$(2)),
       $(if $(call _list?,$(ast)),\
         $(word 1,$(strip $(call EVAL_INVOKE,$(ast),$(2)) $(__nil))),\
-	$(ast))),\
+	$(call EVAL_AST,$(ast),$(2)))),\
     $(call EVAL_AST,$(1),$(2)))))
 endef
 

--- a/mal/step8_macros.mal
+++ b/mal/step8_macros.mal
@@ -74,7 +74,7 @@
     ;; apply list
     (let* [ast (MACROEXPAND ast env)]
       (if (not (list? ast))
-        ast
+        (eval-ast ast env)
 
         (let* [a0 (first ast)]
           (cond

--- a/mal/step9_try.mal
+++ b/mal/step9_try.mal
@@ -74,7 +74,7 @@
     ;; apply list
     (let* [ast (MACROEXPAND ast env)]
       (if (not (list? ast))
-        ast
+        (eval-ast ast env)
 
         (let* [a0 (first ast)]
           (cond

--- a/mal/stepA_mal.mal
+++ b/mal/stepA_mal.mal
@@ -74,7 +74,7 @@
     ;; apply list
     (let* [ast (MACROEXPAND ast env)]
       (if (not (list? ast))
-        ast
+        (eval-ast ast env)
 
         (let* [a0 (first ast)]
           (cond

--- a/miniMAL/step8_macros.json
+++ b/miniMAL/step8_macros.json
@@ -73,7 +73,7 @@
     ["eval-ast", "ast", "env"],
     ["let", ["ast", ["macroexpand", "ast", "env"]],
       ["if", ["not", ["list?", "ast"]],
-        "ast",
+        ["eval-ast", "ast", "env"],
         ["let", ["a0", ["get", ["first", "ast"], ["`", "val"]]],
           ["if", ["=", ["`", "def!"], "a0"],
             ["env-set", "env", ["nth", "ast", 1],

--- a/miniMAL/step9_try.json
+++ b/miniMAL/step9_try.json
@@ -73,7 +73,7 @@
     ["eval-ast", "ast", "env"],
     ["let", ["ast", ["macroexpand", "ast", "env"]],
       ["if", ["not", ["list?", "ast"]],
-        "ast",
+        ["eval-ast", "ast", "env"],
         ["let", ["a0", ["get", ["first", "ast"], ["`", "val"]]],
           ["if", ["=", ["`", "def!"], "a0"],
             ["env-set", "env", ["nth", "ast", 1],

--- a/miniMAL/stepA_mal.json
+++ b/miniMAL/stepA_mal.json
@@ -73,7 +73,7 @@
     ["eval-ast", "ast", "env"],
     ["let", ["ast", ["macroexpand", "ast", "env"]],
       ["if", ["not", ["list?", "ast"]],
-        "ast",
+        ["eval-ast", "ast", "env"],
         ["let", ["a0", ["get", ["first", "ast"], ["`", "val"]]],
           ["if", ["=", ["`", "def!"], "a0"],
             ["env-set", "env", ["nth", "ast", 1],

--- a/nim/step8_macros.nim
+++ b/nim/step8_macros.nim
@@ -61,7 +61,7 @@ proc eval(ast: MalType, env: Env): MalType =
     if ast.kind != List: return ast.eval_ast(env)
 
     ast = ast.macroexpand(env)
-    if ast.kind != List: return ast
+    if ast.kind != List: return ast.eval_ast(env)
     if ast.list.len == 0: return ast
 
     let a0 = ast.list[0]

--- a/nim/step9_try.nim
+++ b/nim/step9_try.nim
@@ -61,7 +61,7 @@ proc eval(ast: MalType, env: Env): MalType =
     if ast.kind != List: return ast.eval_ast(env)
 
     ast = ast.macroexpand(env)
-    if ast.kind != List: return ast
+    if ast.kind != List: return ast.eval_ast(env)
     if ast.list.len == 0: return ast
 
     let a0 = ast.list[0]

--- a/nim/stepA_mal.nim
+++ b/nim/stepA_mal.nim
@@ -61,7 +61,7 @@ proc eval(ast: MalType, env: Env): MalType =
     if ast.kind != List: return ast.eval_ast(env)
 
     ast = ast.macroexpand(env)
-    if ast.kind != List: return ast
+    if ast.kind != List: return ast.eval_ast(env)
     if ast.list.len == 0: return ast
 
     let a0 = ast.list[0]

--- a/perl/step8_macros.pl
+++ b/perl/step8_macros.pl
@@ -105,7 +105,9 @@ sub EVAL {
 
     # apply list
     $ast = macroexpand($ast, $env);
-    if (! _list_Q($ast)) { return $ast; }
+    if (! _list_Q($ast)) {
+        return eval_ast($ast, $env);
+    }
 
     my ($a0, $a1, $a2, $a3) = @{$ast->{val}};
     given ((ref $a0) =~ /^Symbol/ ? $$a0 : $a0) {

--- a/perl/step9_try.pl
+++ b/perl/step9_try.pl
@@ -106,7 +106,9 @@ sub EVAL {
 
     # apply list
     $ast = macroexpand($ast, $env);
-    if (! _list_Q($ast)) { return $ast; }
+    if (! _list_Q($ast)) {
+        return eval_ast($ast, $env);
+    }
 
     my ($a0, $a1, $a2, $a3) = @{$ast->{val}};
     given ((ref $a0) =~ /^Symbol/ ? $$a0 : $a0) {

--- a/perl/stepA_mal.pl
+++ b/perl/stepA_mal.pl
@@ -106,7 +106,9 @@ sub EVAL {
 
     # apply list
     $ast = macroexpand($ast, $env);
-    if (! _list_Q($ast)) { return $ast; }
+    if (! _list_Q($ast)) {
+        return eval_ast($ast, $env);
+    }
 
     my ($a0, $a1, $a2, $a3) = @{$ast->{val}};
     given ((ref $a0) =~ /^Symbol/ ? $$a0 : $a0) {

--- a/php/step8_macros.php
+++ b/php/step8_macros.php
@@ -80,7 +80,9 @@ function MAL_EVAL($ast, $env) {
 
     // apply list
     $ast = macroexpand($ast, $env);
-    if (!_list_Q($ast)) { return $ast; }
+    if (!_list_Q($ast)) {
+        return eval_ast($ast, $env);
+    }
 
     $a0 = $ast[0];
     $a0v = (_symbol_Q($a0) ? $a0->value : $a0);

--- a/php/step9_try.php
+++ b/php/step9_try.php
@@ -80,7 +80,9 @@ function MAL_EVAL($ast, $env) {
 
     // apply list
     $ast = macroexpand($ast, $env);
-    if (!_list_Q($ast)) { return $ast; }
+    if (!_list_Q($ast)) {
+        return eval_ast($ast, $env);
+    }
 
     $a0 = $ast[0];
     $a0v = (_symbol_Q($a0) ? $a0->value : $a0);

--- a/php/stepA_mal.php
+++ b/php/stepA_mal.php
@@ -80,7 +80,9 @@ function MAL_EVAL($ast, $env) {
 
     // apply list
     $ast = macroexpand($ast, $env);
-    if (!_list_Q($ast)) { return $ast; }
+    if (!_list_Q($ast)) {
+        return eval_ast($ast, $env);
+    }
 
     $a0 = $ast[0];
     $a0v = (_symbol_Q($a0) ? $a0->value : $a0);

--- a/ps/step8_macros.ps
+++ b/ps/step8_macros.ps
@@ -108,7 +108,7 @@ end } def
     }{ %else apply the list
       /ast ast env macroexpand def
       ast _list? not { %if no longer a list
-          ast
+          ast env eval_ast
       }{ %else still a list
         /a0 ast 0 _nth def
         /def! a0 eq { %if def!

--- a/ps/step9_try.ps
+++ b/ps/step9_try.ps
@@ -108,7 +108,7 @@ end } def
     }{ %else apply the list
       /ast ast env macroexpand def
       ast _list? not { %if no longer a list
-          ast
+          ast env eval_ast
       }{ %else still a list
         /a0 ast 0 _nth def
         /def! a0 eq { %if def!

--- a/ps/stepA_mal.ps
+++ b/ps/stepA_mal.ps
@@ -108,7 +108,7 @@ end } def
     }{ %else apply the list
       /ast ast env macroexpand def
       ast _list? not { %if no longer a list
-          ast
+          ast env eval_ast
       }{ %else still a list
         /a0 ast 0 _nth def
         /def! a0 eq { %if def!

--- a/python/step8_macros.py
+++ b/python/step8_macros.py
@@ -64,7 +64,8 @@ def EVAL(ast, env):
 
         # apply list
         ast = macroexpand(ast, env)
-        if not types._list_Q(ast): return ast
+        if not types._list_Q(ast):
+            return eval_ast(ast, env)
         if len(ast) == 0: return ast
         a0 = ast[0]
 

--- a/python/step9_try.py
+++ b/python/step9_try.py
@@ -64,7 +64,8 @@ def EVAL(ast, env):
 
         # apply list
         ast = macroexpand(ast, env)
-        if not types._list_Q(ast): return ast
+        if not types._list_Q(ast):
+            return eval_ast(ast, env)
         if len(ast) == 0: return ast
         a0 = ast[0]
 

--- a/python/stepA_mal.py
+++ b/python/stepA_mal.py
@@ -64,7 +64,8 @@ def EVAL(ast, env):
 
         # apply list
         ast = macroexpand(ast, env)
-        if not types._list_Q(ast): return ast
+        if not types._list_Q(ast):
+            return eval_ast(ast, env)
         if len(ast) == 0: return ast
         a0 = ast[0]
 

--- a/racket/step8_macros.rkt
+++ b/racket/step8_macros.rkt
@@ -54,7 +54,7 @@
 
     (let ([ast (macroexpand ast env)])
       (if (not (list? ast))
-        ast
+        (eval-ast ast env)
         (let ([a0 (_nth ast 0)])
           (cond
             [(eq? 'def! a0)

--- a/racket/step9_try.rkt
+++ b/racket/step9_try.rkt
@@ -55,7 +55,7 @@
 
     (let ([ast (macroexpand ast env)])
       (if (not (list? ast))
-        ast
+        (eval-ast ast env)
         (let ([a0 (_nth ast 0)])
           (cond
             [(eq? 'def! a0)

--- a/racket/stepA_mal.rkt
+++ b/racket/stepA_mal.rkt
@@ -55,7 +55,7 @@
 
     (let ([ast (macroexpand ast env)])
       (if (not (list? ast))
-        ast
+        (eval-ast ast env)
         (let ([a0 (_nth ast 0)])
           (cond
             [(eq? 'def! a0)

--- a/ruby/step8_macros.rb
+++ b/ruby/step8_macros.rb
@@ -71,7 +71,9 @@ def EVAL(ast, env)
 
     # apply list
     ast = macroexpand(ast, env)
-    return ast if not ast.is_a? List
+    if not ast.is_a? List
+        return eval_ast(ast, env)
+    end
 
     a0,a1,a2,a3 = ast
     case a0

--- a/ruby/step9_try.rb
+++ b/ruby/step9_try.rb
@@ -71,7 +71,9 @@ def EVAL(ast, env)
 
     # apply list
     ast = macroexpand(ast, env)
-    return ast if not ast.is_a? List
+    if not ast.is_a? List
+        return eval_ast(ast, env)
+    end
 
     a0,a1,a2,a3 = ast
     case a0

--- a/ruby/stepA_mal.rb
+++ b/ruby/stepA_mal.rb
@@ -71,7 +71,9 @@ def EVAL(ast, env)
 
     # apply list
     ast = macroexpand(ast, env)
-    return ast if not ast.is_a? List
+    if not ast.is_a? List
+        return eval_ast(ast, env)
+    end
 
     a0,a1,a2,a3 = ast
     case a0

--- a/tcl/step8_macros.tcl
+++ b/tcl/step8_macros.tcl
@@ -102,7 +102,7 @@ proc EVAL {ast env} {
 
         set ast [macroexpand $ast $env]
         if {![list_q $ast]} {
-            return $ast
+            return [eval_ast $ast $env]
         }
 
         lassign [obj_val $ast] a0 a1 a2 a3

--- a/tcl/step9_try.tcl
+++ b/tcl/step9_try.tcl
@@ -102,7 +102,7 @@ proc EVAL {ast env} {
 
         set ast [macroexpand $ast $env]
         if {![list_q $ast]} {
-            return $ast
+            return [eval_ast $ast $env]
         }
 
         lassign [obj_val $ast] a0 a1 a2 a3

--- a/tcl/stepA_mal.tcl
+++ b/tcl/stepA_mal.tcl
@@ -102,7 +102,7 @@ proc EVAL {ast env} {
 
         set ast [macroexpand $ast $env]
         if {![list_q $ast]} {
-            return $ast
+            return [eval_ast $ast $env]
         }
 
         lassign [obj_val $ast] a0 a1 a2 a3

--- a/vimscript/step8_macros.vim
+++ b/vimscript/step8_macros.vim
@@ -94,7 +94,7 @@ function EVAL(ast, env)
 
     let ast = MacroExpand(ast, env)
     if !ListQ(ast)
-      return ast
+      return EvalAst(ast, env)
     end
 
     let first = ListFirst(ast)

--- a/vimscript/step9_try.vim
+++ b/vimscript/step9_try.vim
@@ -108,7 +108,7 @@ function EVAL(ast, env)
 
     let ast = MacroExpand(ast, env)
     if !ListQ(ast)
-      return ast
+      return EvalAst(ast, env)
     end
 
     let first = ListFirst(ast)

--- a/vimscript/stepA_mal.vim
+++ b/vimscript/stepA_mal.vim
@@ -108,7 +108,7 @@ function EVAL(ast, env)
 
     let ast = MacroExpand(ast, env)
     if !ListQ(ast)
-      return ast
+      return EvalAst(ast, env)
     end
 
     let first = ListFirst(ast)


### PR DESCRIPTION
Fix issue #142 in: bash, c, coffee, crystal, d, elixir, erlang, es6, factor, go, js, lua, make, mal, miniMAL, nim, perl, php, ps, python, racket, ruby, tcl, vimscript
