### PR TITLE
python: Fix equality of unicode/normal strings in Python 2.x

### DIFF
--- a/python/core.py
+++ b/python/core.py
@@ -23,8 +23,7 @@ def prn(*args):
     return None
 
 def println(*args):
-    line = " ".join(map(lambda exp: printer._pr_str(exp, False), args))
-    print(line.replace('\\n', '\n'))
+    print(" ".join(map(lambda exp: printer._pr_str(exp, False), args)))
     return None
 
 

--- a/python/mal_types.py
+++ b/python/mal_types.py
@@ -18,6 +18,8 @@ else:
 
 def _equal_Q(a, b):
     ota, otb = type(a), type(b)
+    if _string_Q(a) and _string_Q(b):
+        return a == b
     if not (ota == otb or (_sequential_Q(a) and _sequential_Q(b))):
         return False;
     if _symbol_Q(a):

--- a/tests/step7_quote.mal
+++ b/tests/step7_quote.mal
@@ -94,6 +94,8 @@
 ;=>false
 (= "abc" 'abc)
 ;=>false
+(= "abc" (str 'abc))
+;=>true
 
 ;;;;; Test quine
 ;;; TODO: needs expect line length fix


### PR DESCRIPTION
Python 2.6.6 and 2.7.10 fail the self-hosting tests of step4:

    make MAL_IMPL=python test^mal^step4

Maybe we should add the self-hosting tests to Travis-CI? Also I'm not sure if Travis runs Python 2 or 3.

I reduced one of the problems to the following:

```
Mal [python]
user> "abc"
"abc"
user> (str 'abc)
"abc"
user> (= "abc" (str 'abc))
false
```

The reason is that `"abc"` is stored as python type 'unicode' whereas the result of the `str` invocation is stored as python type 'str'. The _equal_Q function sees the different types and decides the objects are not equal - this is now fixed.

I added this as a test case in step7 (in which we introduce `quote`).