### PR TITLE
Pass extra function arguments (after &) as a Mal List

### DIFF
--- a/clojure/src/env.clj
+++ b/clojure/src/env.clj
@@ -11,12 +11,12 @@
       (cond
         (= nil b)
         env
-        
+
         (= '& (first b))
         (assoc env (nth b 1) e)
-  
+
         :else
-        (recur (assoc env (first b) (first e)) (next b) (next e))))))
+        (recur (assoc env (first b) (first e)) (next b) (rest e))))))
 
 (defn env-find [env k]
   (cond

--- a/clojure/src/step4_if_fn_do.clj
+++ b/clojure/src/step4_if_fn_do.clj
@@ -56,7 +56,7 @@
 
         'fn*
         (fn [& args]
-          (EVAL a2 (env/env env a1 args)))
+          (EVAL a2 (env/env env a1 (or args '()))))
 
         ;; apply
         (let [el (eval-ast ast env)

--- a/clojure/src/step5_tco.clj
+++ b/clojure/src/step5_tco.clj
@@ -60,7 +60,7 @@
           'fn*
           (with-meta
             (fn [& args]
-              (EVAL a2 (env/env env a1 args)))
+              (EVAL a2 (env/env env a1 (or args '()))))
             {:expression a2
              :environment env
              :parameters a1})

--- a/clojure/src/step6_file.clj
+++ b/clojure/src/step6_file.clj
@@ -60,7 +60,7 @@
           'fn*
           (with-meta
             (fn [& args]
-              (EVAL a2 (env/env env a1 args)))
+              (EVAL a2 (env/env env a1 (or args '()))))
             {:expression a2
              :environment env
              :parameters a1})

--- a/clojure/src/step7_quote.clj
+++ b/clojure/src/step7_quote.clj
@@ -83,7 +83,7 @@
           'fn*
           (with-meta
             (fn [& args]
-              (EVAL a2 (env/env env a1 args)))
+              (EVAL a2 (env/env env a1 (or args '()))))
             {:expression a2
              :environment env
              :parameters a1})

--- a/clojure/src/step8_macros.clj
+++ b/clojure/src/step8_macros.clj
@@ -109,7 +109,7 @@
               'fn*
               (with-meta
                 (fn [& args]
-                  (EVAL a2 (env/env env a1 args)))
+                  (EVAL a2 (env/env env a1 (or args '()))))
                 {:expression a2
                  :environment env
                  :parameters a1})

--- a/clojure/src/step9_try.clj
+++ b/clojure/src/step9_try.clj
@@ -123,7 +123,7 @@
               'fn*
               (with-meta
                 (fn [& args]
-                  (EVAL a2 (env/env env a1 args)))
+                  (EVAL a2 (env/env env a1 (or args '()))))
                 {:expression a2
                  :environment env
                  :parameters a1})

--- a/clojure/src/stepA_mal.clj
+++ b/clojure/src/stepA_mal.clj
@@ -126,7 +126,7 @@
               'fn*
               (with-meta
                 (fn [& args]
-                  (EVAL a2 (env/env env a1 args)))
+                  (EVAL a2 (env/env env a1 (or args '()))))
                 {:expression a2
                  :environment env
                  :parameters a1})

--- a/docs/TODO
+++ b/docs/TODO
@@ -116,7 +116,6 @@ Postscript:
     - formatting messed up with mal/clojurewest2014.mal
 
 Python:
-    - error: python ../python/stepA_mal.py ../mal/stepA_mal.mal ../mal/stepA_mal.mal
     - interop tests
 
 R:

--- a/forth/step4_if_fn_do.fs
+++ b/forth/step4_if_fn_do.fs
@@ -120,8 +120,8 @@ MalUserFn
 
     f-args-list MalList/start @ { f-args }
     f-args-list MalList/count @ ?dup 0= if else
-        \ pass nil for last arg, unless overridden below
-        1- cells f-args + @ mal-nil env env/set
+        \ pass empty list for last arg, unless overridden below
+        1- cells f-args + @ MalList new env env/set
     endif
     argc 0 ?do
         f-args i cells + @

--- a/forth/step5_tco.fs
+++ b/forth/step5_tco.fs
@@ -131,8 +131,8 @@ MalUserFn
 
     f-args-list MalList/start @ { f-args }
     f-args-list MalList/count @ ?dup 0= if else
-        \ pass nil for last arg, unless overridden below
-        1- cells f-args + @ mal-nil env env/set
+        \ pass empty list for last arg, unless overridden below
+        1- cells f-args + @ MalList new env env/set
     endif
     argc 0 ?do
         f-args i cells + @

--- a/forth/step6_file.fs
+++ b/forth/step6_file.fs
@@ -129,8 +129,8 @@ s" &" MalSymbol. constant &-sym
 
     f-args-list MalList/start @ { f-args }
     f-args-list MalList/count @ ?dup 0= if else
-        \ pass nil for last arg, unless overridden below
-        1- cells f-args + @ mal-nil env env/set
+        \ pass empty list for last arg, unless overridden below
+        1- cells f-args + @ MalList new env env/set
     endif
     argc 0 ?do
         f-args i cells + @

--- a/forth/step7_quote.fs
+++ b/forth/step7_quote.fs
@@ -171,8 +171,8 @@ s" &" MalSymbol. constant &-sym
 
     f-args-list MalList/start @ { f-args }
     f-args-list MalList/count @ ?dup 0= if else
-        \ pass nil for last arg, unless overridden below
-        1- cells f-args + @ mal-nil env env/set
+        \ pass empty list for last arg, unless overridden below
+        1- cells f-args + @ MalList new env env/set
     endif
     argc 0 ?do
         f-args i cells + @

--- a/forth/step8_macros.fs
+++ b/forth/step8_macros.fs
@@ -179,8 +179,8 @@ s" &" MalSymbol. constant &-sym
 
     f-args-list MalList/start @ { f-args }
     f-args-list MalList/count @ ?dup 0= if else
-        \ pass nil for last arg, unless overridden below
-        1- cells f-args + @ mal-nil env env/set
+        \ pass empty list for last arg, unless overridden below
+        1- cells f-args + @ MalList new env env/set
     endif
     argc 0 ?do
         f-args i cells + @

--- a/forth/step9_try.fs
+++ b/forth/step9_try.fs
@@ -188,8 +188,8 @@ s" &" MalSymbol. constant &-sym
 
     f-args-list MalList/start @ { f-args }
     f-args-list MalList/count @ ?dup 0= if else
-        \ pass nil for last arg, unless overridden below
-        1- cells f-args + @ mal-nil env env/set
+        \ pass empty list for last arg, unless overridden below
+        1- cells f-args + @ MalList new env env/set
     endif
     argc 0 ?do
         f-args i cells + @

--- a/forth/stepA_mal.fs
+++ b/forth/stepA_mal.fs
@@ -188,8 +188,8 @@ s" &" MalSymbol. constant &-sym
 
     f-args-list MalList/start @ { f-args }
     f-args-list MalList/count @ ?dup 0= if else
-        \ pass nil for last arg, unless overridden below
-        1- cells f-args + @ mal-nil env env/set
+        \ pass empty list for last arg, unless overridden below
+        1- cells f-args + @ MalList new env env/set
     endif
     argc 0 ?do
         f-args i cells + @

--- a/julia/step4_if_fn_do.jl
+++ b/julia/step4_if_fn_do.jl
@@ -51,7 +51,7 @@ function EVAL(ast, env)
             EVAL(ast[3], env)
         end
     elseif symbol("fn*") == ast[1]
-        (args...) -> EVAL(ast[3], Env(env, ast[2], args))
+        (args...) -> EVAL(ast[3], Env(env, ast[2], Any[args...]))
     else
         el = eval_ast(ast, env)
         f, args = el[1], el[2:end]

--- a/julia/step5_tco.jl
+++ b/julia/step5_tco.jl
@@ -61,7 +61,7 @@ function EVAL(ast, env)
         end
     elseif symbol("fn*") == ast[1]
         return MalFunc(
-            (args...) -> EVAL(ast[3], Env(env, ast[2], args)),
+            (args...) -> EVAL(ast[3], Env(env, ast[2], Any[args...])),
             ast[3], env, ast[2])
     else
         el = eval_ast(ast, env)

--- a/julia/step6_file.jl
+++ b/julia/step6_file.jl
@@ -61,7 +61,7 @@ function EVAL(ast, env)
         end
     elseif symbol("fn*") == ast[1]
         return MalFunc(
-            (args...) -> EVAL(ast[3], Env(env, ast[2], args)),
+            (args...) -> EVAL(ast[3], Env(env, ast[2], Any[args...])),
             ast[3], env, ast[2])
     else
         el = eval_ast(ast, env)

--- a/julia/step7_quote.jl
+++ b/julia/step7_quote.jl
@@ -82,7 +82,7 @@ function EVAL(ast, env)
         end
     elseif symbol("fn*") == ast[1]
         return MalFunc(
-            (args...) -> EVAL(ast[3], Env(env, ast[2], args)),
+            (args...) -> EVAL(ast[3], Env(env, ast[2], Any[args...])),
             ast[3], env, ast[2])
     else
         el = eval_ast(ast, env)

--- a/julia/step8_macros.jl
+++ b/julia/step8_macros.jl
@@ -107,7 +107,7 @@ function EVAL(ast, env)
         end
     elseif symbol("fn*") == ast[1]
         return MalFunc(
-            (args...) -> EVAL(ast[3], Env(env, ast[2], args)),
+            (args...) -> EVAL(ast[3], Env(env, ast[2], Any[args...])),
             ast[3], env, ast[2])
     else
         el = eval_ast(ast, env)

--- a/julia/step9_try.jl
+++ b/julia/step9_try.jl
@@ -125,7 +125,7 @@ function EVAL(ast, env)
         end
     elseif symbol("fn*") == ast[1]
         return MalFunc(
-            (args...) -> EVAL(ast[3], Env(env, ast[2], args)),
+            (args...) -> EVAL(ast[3], Env(env, ast[2], Any[args...])),
             ast[3], env, ast[2])
     else
         el = eval_ast(ast, env)

--- a/julia/stepA_mal.jl
+++ b/julia/stepA_mal.jl
@@ -125,7 +125,7 @@ function EVAL(ast, env)
         end
     elseif symbol("fn*") == ast[1]
         return MalFunc(
-            (args...) -> EVAL(ast[3], Env(env, ast[2], args)),
+            (args...) -> EVAL(ast[3], Env(env, ast[2], Any[args...])),
             ast[3], env, ast[2])
     else
         el = eval_ast(ast, env)

--- a/python/mal_types.py
+++ b/python/mal_types.py
@@ -81,7 +81,7 @@ def _keyword_Q(exp):
 # Functions
 def _function(Eval, Env, ast, env, params):
     def fn(*args):
-        return Eval(ast, Env(env, params, args))
+        return Eval(ast, Env(env, params, List(args)))
     fn.__meta__ = None
     fn.__ast__ = ast
     fn.__gen_env__ = lambda args: Env(env, params, args)

--- a/ruby/step4_if_fn_do.rb
+++ b/ruby/step4_if_fn_do.rb
@@ -59,7 +59,7 @@ def EVAL(ast, env)
         end
     when :"fn*"
         return lambda {|*args|
-            EVAL(a2, Env.new(env, a1, args))
+            EVAL(a2, Env.new(env, a1, List.new(args)))
         }
     else
         el = eval_ast(ast, env)

--- a/ruby/step5_tco.rb
+++ b/ruby/step5_tco.rb
@@ -62,7 +62,7 @@ def EVAL(ast, env)
         end
     when :"fn*"
         return Function.new(a2, env, a1) {|*args|
-            EVAL(a2, Env.new(env, a1, args))
+            EVAL(a2, Env.new(env, a1, List.new(args)))
         }
     else
         el = eval_ast(ast, env)

--- a/ruby/step6_file.rb
+++ b/ruby/step6_file.rb
@@ -62,7 +62,7 @@ def EVAL(ast, env)
         end
     when :"fn*"
         return Function.new(a2, env, a1) {|*args|
-            EVAL(a2, Env.new(env, a1, args))
+            EVAL(a2, Env.new(env, a1, List.new(args)))
         }
     else
         el = eval_ast(ast, env)

--- a/ruby/step7_quote.rb
+++ b/ruby/step7_quote.rb
@@ -82,7 +82,7 @@ def EVAL(ast, env)
         end
     when :"fn*"
         return Function.new(a2, env, a1) {|*args|
-            EVAL(a2, Env.new(env, a1, args))
+            EVAL(a2, Env.new(env, a1, List.new(args)))
         }
     else
         el = eval_ast(ast, env)

--- a/ruby/step8_macros.rb
+++ b/ruby/step8_macros.rb
@@ -109,7 +109,7 @@ def EVAL(ast, env)
         end
     when :"fn*"
         return Function.new(a2, env, a1) {|*args|
-            EVAL(a2, Env.new(env, a1, args))
+            EVAL(a2, Env.new(env, a1, List.new(args)))
         }
     else
         el = eval_ast(ast, env)

--- a/ruby/step9_try.rb
+++ b/ruby/step9_try.rb
@@ -124,7 +124,7 @@ def EVAL(ast, env)
         end
     when :"fn*"
         return Function.new(a2, env, a1) {|*args|
-            EVAL(a2, Env.new(env, a1, args))
+            EVAL(a2, Env.new(env, a1, List.new(args)))
         }
     else
         el = eval_ast(ast, env)

--- a/ruby/stepA_mal.rb
+++ b/ruby/stepA_mal.rb
@@ -130,7 +130,7 @@ def EVAL(ast, env)
         end
     when :"fn*"
         return Function.new(a2, env, a1) {|*args|
-            EVAL(a2, Env.new(env, a1, args))
+            EVAL(a2, Env.new(env, a1, List.new(args)))
         }
     else
         el = eval_ast(ast, env)

--- a/tests/step4_if_fn_do.mal
+++ b/tests/step4_if_fn_do.mal
@@ -166,14 +166,20 @@
 
 ( (fn* (& more) (count more)) 1 2 3)
 ;=>3
+( (fn* (& more) (list? more)) 1 2 3)
+;=>true
 ( (fn* (& more) (count more)) 1)
 ;=>1
 ( (fn* (& more) (count more)) )
 ;=>0
+( (fn* (& more) (list? more)) )
+;=>true
 ( (fn* (a & more) (count more)) 1 2 3)
 ;=>2
 ( (fn* (a & more) (count more)) 1)
 ;=>0
+( (fn* (a & more) (list? more)) 1)
+;=>true
 
 
 ;; Testing language defined not function

--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -291,6 +291,15 @@
 (or (= p "{:abc \"val1\" :def \"val2\"}") (= p "{:def \"val2\" :abc \"val1\"}"))
 ;=>true
 
+;;
+;; Test extra function arguments as Mal List (bypassing TCO with apply)
+(apply (fn* (& more) (list? more)) [1 2 3])
+;=>true
+(apply (fn* (& more) (list? more)) [])
+;=>true
+(apply (fn* (a & more) (list? more)) [1])
+;=>true
+
 ;; ------- Optional Functionality --------------
 ;; ------- (Not needed for self-hosting) -------
 ;>>> soft=True


### PR DESCRIPTION
When a function receives extra args (`& args`) these were stored as a
ruby/python array/tuple and not wrapped as a proper Mal List data type.
This works OK except when self-hosting *twice* (duck typing can only get
you that far :-).

Now these work OK:

```
python ../python/stepA_mal.py ../mal/stepA_mal.mal ../mal/stepA_mal.mal
ruby ../ruby/stepA_mal.rb ../mal/stepA_mal.mal ../mal/stepA_mal.mal
```

Tests were added in step4 to verify that the extra args parameter indeed
holds a Mal list.

- [x] clojure
- [x] forth
- [x] haxe (unrelated breakage, now fixed)
- [x] julia
- [x] python
- [x] ruby