### PR TITLE
Remove incorrect return in test case

### DIFF
--- a/tests/step6_file.mal
+++ b/tests/step6_file.mal
@@ -50,7 +50,6 @@
 (def! inc3 (fn* (a) (+ 3 a)))
 
 (def! a (atom 2))
-;=>(atom 2)
 
 (atom? a)
 ;=>true


### PR DESCRIPTION
@kanaka Is this test correct?
`(def! a (atom 2))` shouldn't output `(atom 2)`, right?
