### PR TITLE
erlang: Fix nested list/vector/map equality

### DIFF
--- a/erlang/src/core.erl
+++ b/erlang/src/core.erl
@@ -84,13 +84,34 @@ equal_q(Args) ->
         [{string, S}, {string, T}] -> S == T;
         [{keyword, K}, {keyword, J}] -> K == J;
         [{symbol, S}, {symbol, T}] -> S == T;
-        [{list, L1, _M1}, {list, L2, _M2}] -> L1 == L2;
-        [{vector, L1, _M1}, {vector, L2, _M2}] -> L1 == L2;
-        [{list, L1, _M1}, {vector, L2, _M2}] -> L1 == L2;
-        [{vector, L1, _M1}, {list, L2, _M2}] -> L1 == L2;
-        [{map, M1, _M1}, {map, M2, _M2}] -> M1 == M2;
+        [{list, L1, _M1}, {list, L2, _M2}] -> equal_seqs(L1, L2);
+        [{vector, L1, _M1}, {vector, L2, _M2}] -> equal_seqs(L1, L2);
+        [{list, L1, _M1}, {vector, L2, _M2}] -> equal_seqs(L1, L2);
+        [{vector, L1, _M1}, {list, L2, _M2}] -> equal_seqs(L1, L2);
+        [{map, M1, _M1}, {map, M2, _M2}] -> equal_maps(M1, M2);
         [_A, _B] -> false;
         _ -> {error, "equal? expects two arguments"}
+    end.
+
+equal_seqs([], []) ->
+    true;
+equal_seqs([X|Xs], [Y|Ys]) ->
+    equal_q([X, Y]) andalso equal_seqs(Xs, Ys);
+equal_seqs(_, _) ->
+    false.
+
+equal_maps(M1, M2) ->
+    maps:size(M1) == maps:size(M2) andalso equal_maps_for_keys(maps:keys(M1), M1, M2).
+
+equal_maps_for_keys([], _M1, _M2) ->
+    true;
+equal_maps_for_keys([K|Ks], M1, M2) ->
+    equal_values_for_key(K, M1, M2) andalso equal_maps_for_keys(Ks, M1, M2).
+
+equal_values_for_key(K, M1, M2) ->
+    case [maps:find(K, M1), maps:find(K, M2)] of
+        [{ok, V1}, {ok, V2}] -> equal_q([V1, V2]);
+        _ -> false
     end.
 
 int_op(F, [A0,A1]) ->

--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -317,6 +317,8 @@
 ;=>false
 (= {:a 11 :b 22} (hash-map :a 11))
 ;=>false
+(= {:a [11 22]} {:a (list 11 22)})
+;=>true
 (= {:a 11 :b 22} (list :a 11 :b 22))
 ;=>false
 (= {} [])


### PR DESCRIPTION
As described in #123 .

I also found another test case not covered, so I added it to the soft-tests in step9. We might see other impls soft-fail there if the map values weren't compared properly.
