### PR TITLE
ocaml: Clearer top-level exception handling

### DIFF
--- a/ocaml/step9_try.ml
+++ b/ocaml/step9_try.ml
@@ -138,7 +138,12 @@ let rec main =
     ignore (rep "(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) `(let* (or_FIXME ~(first xs)) (if or_FIXME or_FIXME (or ~@(rest xs))))))))" repl_env);
 
     if Array.length Sys.argv > 1 then
-      ignore (rep ("(load-file \"" ^ Sys.argv.(1) ^ "\")") repl_env)
+      try
+        ignore (rep ("(load-file \"" ^ Sys.argv.(1) ^ "\")") repl_env);
+      with
+        | Types.MalExn exc ->
+           output_string stderr ("Exception: " ^ (print exc) ^ "\n");
+           flush stderr
     else
       while true do
         print_string "user> ";
@@ -146,6 +151,9 @@ let rec main =
         try
           print_endline (rep line repl_env);
         with End_of_file -> ()
+           | Types.MalExn exc ->
+              output_string stderr ("Exception: " ^ (print exc) ^ "\n");
+              flush stderr
            | Invalid_argument x ->
               output_string stderr ("Invalid_argument exception: " ^ x ^ "\n");
               flush stderr

--- a/ocaml/stepA_mal.ml
+++ b/ocaml/stepA_mal.ml
@@ -141,7 +141,12 @@ let rec main =
     ignore (rep "(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) (let* (condvar (gensym)) `(let* (~condvar ~(first xs)) (if ~condvar ~condvar (or ~@(rest xs)))))))))" repl_env);
 
     if Array.length Sys.argv > 1 then
-      ignore (rep ("(load-file \"" ^ Sys.argv.(1) ^ "\")") repl_env)
+      try
+        ignore (rep ("(load-file \"" ^ Sys.argv.(1) ^ "\")") repl_env);
+      with
+        | Types.MalExn exc ->
+           output_string stderr ("Exception: " ^ (print exc) ^ "\n");
+           flush stderr
     else begin
         ignore (rep "(println (str \"Mal [\" *host-language* \"]\"))" repl_env);
         while true do
@@ -150,6 +155,9 @@ let rec main =
           try
             print_endline (rep line repl_env);
           with End_of_file -> ()
+             | Types.MalExn exc ->
+                output_string stderr ("Exception: " ^ (print exc) ^ "\n");
+                flush stderr
              | Invalid_argument x ->
                 output_string stderr ("Invalid_argument exception: " ^ x ^ "\n");
                 flush stderr


### PR DESCRIPTION
ocaml: Catch Mal exceptions at the top-level (both in repl and command-line file) and print the exception value clearly to stderr.

Before:

```
Mal [ocaml]
user> (throw "my error")
Erroringness!
```

After:

```
Mal [ocaml]
user> (throw "my error")
Exception: "my error"
```
