### PR TITLE
Bump Kotlin version to 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ julia stepX_YYY.jl
 
 *The Kotlin implementation was created by [Javier Fernandez-Ivern](https://github.com/ivern)*
 
-The Kotlin implementation of mal has been tested with Kotlin 1.0.0-beta.
+The Kotlin implementation of mal has been tested with Kotlin 1.0.
 
 ```
 cd kotlin

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -25,10 +25,10 @@ WORKDIR /mal
 RUN apt-get -y install openjdk-7-jdk
 RUN apt-get -y install unzip
 
-RUN curl -O -J -L https://github.com/JetBrains/kotlin/releases/download/build-1.0.0-beta-4584/kotlin-compiler-1.0.0-beta-4584.zip
+RUN curl -O -J -L https://github.com/JetBrains/kotlin/releases/download/build-1.0.0/kotlin-compiler-1.0.0.zip
 
 RUN mkdir -p /kotlin-compiler
-RUN unzip kotlin-compiler-1.0.0-beta-4584.zip -d /kotlin-compiler
+RUN unzip kotlin-compiler-1.0.0.zip -d /kotlin-compiler
 
 ENV KOTLIN_HOME /kotlin-compiler/kotlinc
 ENV PATH $KOTLIN_HOME/bin:$PATH

--- a/kotlin/src/mal/reader.kt
+++ b/kotlin/src/mal/reader.kt
@@ -95,7 +95,7 @@ fun read_hashmap(reader: Reader): MalType {
         }
 
         if (key != null) {
-            hashMap.assoc_BANG(key as MalString, value as MalType)
+            hashMap.assoc_BANG(key, value as MalType)
         }
     } while (key != null)
 


### PR DESCRIPTION
Kotlin 1.0 released today!

* Update Kotlin version to 1.0. All tests passed without modifying code.
* Remove one unnecessary cast

Thanks!