### PR TITLE
ruby: concat should not modify its argument

### DIFF
--- a/ruby/core.rb
+++ b/ruby/core.rb
@@ -46,7 +46,7 @@ $core_ns = {
 
     :sequential? => lambda {|a| sequential?(a)},
     :cons =>      lambda {|a,b| List.new(b.clone.insert(0,a))},
-    :concat =>    lambda {|*a| List.new(a && a.reduce(:concat) || [])},
+    :concat =>    lambda {|*a| List.new(a && a.reduce(:+) || [])},
     :nth =>       lambda {|a,b| raise "nth: index out of range" if b >= a.size; a[b]},
     :first =>     lambda {|a| a.nil? ? nil : a[0]},
     :rest =>      lambda {|a| List.new(a.nil? || a.size == 0 ? [] : a.drop(1))},

--- a/tests/step7_quote.mal
+++ b/tests/step7_quote.mal
@@ -8,6 +8,12 @@
 (cons (list 1) (list 2 3))
 ;=>((1) 2 3)
 
+(def! a (list 2 3))
+(cons 1 a)
+;=>(1 2 3)
+a
+;=>(2 3)
+
 ;; Testing concat function
 (concat)
 ;=>()
@@ -20,6 +26,14 @@
 (concat (concat))
 ;=>()
 
+(def! a (list 1 2))
+(def! b (list 3 4))
+(concat a b (list 5 6))
+;=>(1 2 3 4 5 6)
+a
+;=>(1 2)
+b
+;=>(3 4)
 
 ;; Testing regular quote
 (quote 7)


### PR DESCRIPTION
Before the fix:

```
Mal [ruby]
user> (def! a [1 2])
[1 2]
user> (concat a [3 4])
(1 2 3 4)
user> a
[1 2 3 4]
```

After the fix:

```
Mal [ruby]
user> (def! a [1 2])
[1 2]
user> (concat a [3 4])
(1 2 3 4)
user> a
[1 2]
```
