### PR TITLE
Update ffi dep in js implementation

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -3,6 +3,6 @@
     "version": "0.0.1",
     "description": "Make a Lisp (mal) language implemented in Javascript",
     "dependencies": {
-        "ffi": "1.3.x"
+        "ffi": "2.0.x"
     }
 }


### PR DESCRIPTION
The js dep won't compile cleanly without this bump because the old ffi version won't build properly 
(using latest Arch Linux as of Mar 14 2016, probably failing on other distros as well).  

ffi 2.0.0 builds cleanly.