### PR TITLE
ps: Fix ps* interop

### DIFF
--- a/ps/stepA_mal.ps
+++ b/ps/stepA_mal.ps
@@ -146,14 +146,7 @@ end } def
             ast 1 _nth env macroexpand
         }{ /ps* a0 eq { %if ps*
             count /stackcnt exch def
-            ast 1 _nth
-            {
-                token not { exit } if
-                exch
-                count stackcnt sub 1 roll % send leftover string to bottom
-                exec
-                count stackcnt sub -1 roll % bring leftover string to top
-            } loop
+            ast 1 _nth cvx exec
             count stackcnt gt { % if new operands on stack
                 % return an list of new operands
                 count stackcnt sub array astore

--- a/ps/tests/stepA_mal.mal
+++ b/ps/tests/stepA_mal.mal
@@ -13,7 +13,7 @@
 ;=>(true)
 
 (ps* "/sym")
-;=>sym
+;=>(sym)
 
 (ps* "1 1 eq { (yep) }{ (nope) } ifelse")
 ;=>("yep")
@@ -21,3 +21,5 @@
 (ps* "1 0 eq { (yep) }{ (nope) } ifelse")
 ;=>("nope")
 
+(ps* "1 2 3 pop pop pop")
+;=>nil


### PR DESCRIPTION
* Simplify postscript code parsing by using the `cvx` (convert to
  executable) function.
* Tweak the test cases to match reality (returns list of stack operands,
  or nil if stack is empty after exec).

Here's the diff on stepA_mal.ps:

```diff
diff --git a/ps/stepA_mal.ps b/ps/stepA_mal.ps
index ae39447..5925ef3 100644
--- a/ps/stepA_mal.ps
+++ b/ps/stepA_mal.ps
@@ -146,14 +146,7 @@ end } def
             ast 1 _nth env macroexpand
         }{ /ps* a0 eq { %if ps*
             count /stackcnt exch def
-            ast 1 _nth
-            {
-                token not { exit } if
-                exch
-                count stackcnt sub 1 roll % send leftover string to bottom
-                exec
-                count stackcnt sub -1 roll % bring leftover string to top
-            } loop
+            ast 1 _nth cvx exec
             count stackcnt gt { % if new operands on stack
                 % return an list of new operands
                 count stackcnt sub array astore
```