### PR TITLE
Port swift3 to OSX.

### DIFF
--- a/swift3/Makefile
+++ b/swift3/Makefile
@@ -1,3 +1,9 @@
+ifneq ($(shell which xcrun),)
+	SWIFT = xcrun -sdk macosx swiftc
+else
+	SWIFT = swiftc
+endif
+
 STEP3_DEPS = Sources/types.swift Sources/reader.swift Sources/printer.swift Sources/env.swift
 STEP4_DEPS = $(STEP3_DEPS) Sources/core.swift
 
@@ -19,7 +25,7 @@ step1_read_print step2_eval step3_env: $(STEP3_DEPS)
 step4_if_fn_do step5_tco step6_file step7_quote step8_macros step9_try stepA_mal: $(STEP4_DEPS)
 
 step%: Sources/step%/main.swift
-	swiftc $+ -o $@
+	$(SWIFT) $+ -o $@
 
 clean:
 	rm -f $(STEPS) mal

--- a/swift3/Sources/core.swift
+++ b/swift3/Sources/core.swift
@@ -1,5 +1,10 @@
 // TODO: remove this once time-ms and slurp use standard library calls
+
+#if os(Linux)
 import Glibc
+#else
+import Darwin
+#endif
 
 func IntOp(op: (Int, Int) -> Int, _ a: MalVal, _ b: MalVal) throws -> MalVal {
     switch (a, b) {
@@ -82,10 +87,21 @@ let core_ns: Dictionary<String,(Array<MalVal>) throws -> MalVal> = [
     },
 
     "pr-str":  {
-        return MV.MalString($0.map { pr_str($0,true) }.joinWithSeparator(" "))
+        // TODO: if the following two statements are combined into one, we get
+        // the following error message. It's not clear to me that there's
+        // actually any error, so this might be a compiler issue.
+        //
+        //      Sources/core.swift:29:59: error: type of expression is ambiguous without more context
+        //      let core_ns: [String: (Array<MalVal>) throws -> MalVal] = [
+        //                                                                ^
+
+        let s = $0.map { pr_str($0,true) }.joinWithSeparator(" ")
+        return MV.MalString(s)
     },
     "str": {
-        return MV.MalString($0.map { pr_str($0,false) }.joinWithSeparator(""))
+        // The comment for "pr-str" applies here, too.
+        let s = $0.map { pr_str($0,false) }.joinWithSeparator("")
+        return MV.MalString(s)
     },
     "prn": {
         print($0.map { pr_str($0,true) }.joinWithSeparator(" "))


### PR DESCRIPTION
Here are some changes to get swift3 compiling and running under OSX. There were only a few tweaks, so it should be pretty easy to vet.

I'm not sure why I had problems with the implementations of "pr-str" and "str". Perhaps it's because the compiler I'm using (DEVELOPMENT-SNAPSHOT-2016-03-24-a) is more recent than the one used for original development.