### PR TITLE
c: Add Boehm garbage collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ bash stepX_YYY.sh
 ### C
 
 The C implementation of mal requires the following libraries (lib and
-header packages): glib, libffi6 and either the libedit or GNU readline library.
+header packages): glib, libffi6, libgc, and either the libedit or GNU readline
+library.
 
 ```
 cd c

--- a/c/Dockerfile
+++ b/c/Dockerfile
@@ -25,4 +25,4 @@ WORKDIR /mal
 RUN apt-get -y install g++
 
 # Libraries needed for the C impl
-RUN apt-get -y install libglib2.0 libglib2.0-dev libffi-dev
+RUN apt-get -y install libglib2.0 libglib2.0-dev libffi-dev libgc-dev

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,4 +1,5 @@
 USE_READLINE ?=
+USE_GC ?= 1
 CFLAGS += -g -O2
 LDFLAGS += -g
 
@@ -36,6 +37,12 @@ RL_LIBRARY ?= edit
 else
 RL_LIBRARY ?= readline
 CFLAGS += -DUSE_READLINE=1
+endif
+
+ifeq (,$(USE_GC))
+else
+CFLAGS += -DUSE_GC=1
+LDFLAGS += -lgc
 endif
 
 CFLAGS += $(GLIB_CFLAGS)

--- a/c/core.c
+++ b/c/core.c
@@ -96,8 +96,8 @@ MalVal *prn(MalVal *args) {
     assert_type(args, MAL_LIST|MAL_VECTOR,
                 "prn called with non-sequential args");
     char *repr = _pr_str_args(args, " ", 1);
-    g_print("%s\n", repr);
-    free(repr);
+    puts(repr);
+    MAL_GC_FREE(repr);
     return &mal_nil;
 }
 
@@ -107,8 +107,8 @@ MalVal *println(MalVal *args) {
     assert_type(args, MAL_LIST|MAL_VECTOR,
                 "println called with non-sequential args");
     char *repr = _pr_str_args(args, " ", 0);
-    g_print("%s\n", repr);
-    free(repr);
+    puts(repr);
+    MAL_GC_FREE(repr);
     return &mal_nil;
 }
 
@@ -135,7 +135,7 @@ char *slurp_raw(char *path) {
     if (fstat(fd, &fst) < 0) {
         abort("slurp failed to stat '%s'", path);
     }
-    data = malloc(fst.st_size+1);
+    data = MAL_GC_MALLOC(fst.st_size+1);
     sz = read(fd, data, fst.st_size);
     if (sz < fst.st_size) {
         abort("slurp failed to read '%s'", path);

--- a/c/env.c
+++ b/c/env.c
@@ -4,7 +4,7 @@
 // Env
 
 Env *new_env(Env *outer, MalVal* binds, MalVal *exprs) {
-    Env *e = malloc(sizeof(Env));
+    Env *e = MAL_GC_MALLOC(sizeof(Env));
     e->table = g_hash_table_new(g_str_hash, g_str_equal);
     e->outer = outer;
 

--- a/c/printer.c
+++ b/c/printer.c
@@ -29,13 +29,13 @@ char *_pr_str_hash_map(MalVal *obj, int print_readably) {
         } else {
             repr_tmp2 = repr;
             repr = g_strdup_printf("%s %s %s", repr_tmp2, (char*)key2, repr_tmp1);
-            free(repr_tmp2);
+            MAL_GC_FREE(repr_tmp2);
         }
-        free(repr_tmp1);
+        MAL_GC_FREE(repr_tmp1);
     }
     repr_tmp2 = repr;
     repr = g_strdup_printf("%s}", repr_tmp2);
-    free(repr_tmp2);
+    MAL_GC_FREE(repr_tmp2);
     return repr;
 }
 
@@ -51,13 +51,13 @@ char *_pr_str_list(MalVal *obj, int print_readably, char start, char end) {
         } else {
             repr_tmp2 = repr;
             repr = g_strdup_printf("%s %s", repr_tmp2, repr_tmp1);
-            free(repr_tmp2);
+            MAL_GC_FREE(repr_tmp2);
         }
-        free(repr_tmp1);
+        MAL_GC_FREE(repr_tmp1);
     }
     repr_tmp2 = repr;
     repr = g_strdup_printf("%s%c", repr_tmp2, end);
-    free(repr_tmp2);
+    MAL_GC_FREE(repr_tmp2);
     return repr;
 }
 
@@ -84,7 +84,7 @@ char *_pr_str(MalVal *obj, int print_readably) {
         } else if (print_readably) {
             char *repr_tmp = g_strescape(obj->val.string, "");
             repr = g_strdup_printf("\"%s\"", repr_tmp);
-            free(repr_tmp);
+            MAL_GC_FREE(repr_tmp);
         } else {
             repr = g_strdup_printf("%s", obj->val.string);
         }
@@ -139,13 +139,16 @@ char *_pr_str_args(MalVal *args, char *sep, int print_readably) {
         if (i != 0) {
             repr2 = repr;
             repr = g_strdup_printf("%s%s", repr2, sep);
-            free(repr2);
+            MAL_GC_FREE(repr2);
         }
         repr2 = repr;
         repr = g_strdup_printf("%s%s",
                                repr2, _pr_str(obj, print_readably));
-        free(repr2);
+        MAL_GC_FREE(repr2);
     }
-    return repr;
+    char* res = MAL_GC_STRDUP(repr);
+    MAL_GC_FREE(repr);
+    // TODO - check why STRDUP was needed here
+    return res;
 }
 

--- a/c/step0_repl.c
+++ b/c/step0_repl.c
@@ -37,7 +37,7 @@ int main()
         ast = READ(prompt);
         if (!ast) return 0;
         exp = EVAL(ast, NULL);
-        g_print("%s\n", PRINT(exp));
+        puts(PRINT(exp));
  
         free(ast); // Free input string
     }

--- a/c/step1_read_print.c
+++ b/c/step1_read_print.c
@@ -21,7 +21,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -62,6 +62,8 @@ int main()
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt
     snprintf(prompt, sizeof(prompt), "user> ");
  
@@ -74,8 +76,8 @@ int main()
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/step2_eval.c
+++ b/c/step2_eval.c
@@ -24,7 +24,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -130,6 +130,8 @@ int main()
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt and environment
     snprintf(prompt, sizeof(prompt), "user> ");
     init_repl_env();
@@ -143,8 +145,8 @@ int main()
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/step3_env.c
+++ b/c/step3_env.c
@@ -24,7 +24,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -156,6 +156,8 @@ int main()
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt and environment
     snprintf(prompt, sizeof(prompt), "user> ");
     init_repl_env();
@@ -169,8 +171,8 @@ int main()
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/step4_if_fn_do.c
+++ b/c/step4_if_fn_do.c
@@ -25,7 +25,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -195,6 +195,8 @@ int main()
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt and environment
     snprintf(prompt, sizeof(prompt), "user> ");
     init_repl_env();
@@ -208,8 +210,8 @@ int main()
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/step5_tco.c
+++ b/c/step5_tco.c
@@ -25,7 +25,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -208,6 +208,8 @@ int main()
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt and environment
     snprintf(prompt, sizeof(prompt), "user> ");
     init_repl_env();
@@ -221,8 +223,8 @@ int main()
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/step6_file.c
+++ b/c/step6_file.c
@@ -25,7 +25,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -222,6 +222,8 @@ int main(int argc, char *argv[])
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt and environment
     snprintf(prompt, sizeof(prompt), "user> ");
     init_repl_env(argc, argv);
@@ -241,8 +243,8 @@ int main(int argc, char *argv[])
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/step7_quote.c
+++ b/c/step7_quote.c
@@ -25,7 +25,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -259,6 +259,8 @@ int main(int argc, char *argv[])
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt and environment
     snprintf(prompt, sizeof(prompt), "user> ");
     init_repl_env(argc, argv);
@@ -278,8 +280,8 @@ int main(int argc, char *argv[])
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/step8_macros.c
+++ b/c/step8_macros.c
@@ -26,7 +26,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -303,6 +303,8 @@ int main(int argc, char *argv[])
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt and environment
     snprintf(prompt, sizeof(prompt), "user> ");
     init_repl_env(argc, argv);
@@ -322,8 +324,8 @@ int main(int argc, char *argv[])
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/step9_try.c
+++ b/c/step9_try.c
@@ -27,7 +27,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -325,6 +325,8 @@ int main(int argc, char *argv[])
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt and environment
     snprintf(prompt, sizeof(prompt), "user> ");
     init_repl_env(argc, argv);
@@ -344,8 +346,8 @@ int main(int argc, char *argv[])
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/stepA_mal.c
+++ b/c/stepA_mal.c
@@ -27,7 +27,7 @@ MalVal *READ(char prompt[], char *str) {
         }
     }
     ast = read_str(line);
-    if (!str) { free(line); }
+    if (!str) { MAL_GC_FREE(line); }
     return ast;
 }
 
@@ -332,6 +332,8 @@ int main(int argc, char *argv[])
     char *output;
     char prompt[100];
 
+    MAL_GC_SETUP();
+
     // Set the initial prompt and environment
     snprintf(prompt, sizeof(prompt), "user> ");
     init_repl_env(argc, argv);
@@ -352,8 +354,8 @@ int main(int argc, char *argv[])
         output = PRINT(exp);
 
         if (output) { 
-            g_print("%s\n", output);
-            free(output);        // Free output string
+            puts(output);
+            MAL_GC_FREE(output);        // Free output string
         }
 
         //malval_free(exp);    // Free evaluated expression

--- a/c/types.h
+++ b/c/types.h
@@ -3,6 +3,24 @@
 
 #include <glib.h>
 
+#ifdef USE_GC
+
+#include <gc/gc.h>
+char* GC_strdup(const char *src);
+#define MAL_GC_SETUP()  GC_setup()
+#define MAL_GC_MALLOC   GC_MALLOC
+#define MAL_GC_FREE     nop_free
+#define MAL_GC_STRDUP   GC_strdup
+
+#else
+
+#include <string.h>
+#define MAL_GC_SETUP()
+#define MAL_GC_MALLOC   malloc
+#define MAL_GC_FREE     free
+#define MAL_GC_STRDUP   strdup
+
+#endif
 
 struct MalVal; // pre-declare
 


### PR DESCRIPTION
Add the [Boehm garbage collector](http://hboehm.info/gc/) to the C implementation. The README and Dockerfile changes describe the new dependency for building.

## Build

By default, garbage collection is enabled.  You can disable the garbage collection by building with an empty `USE_GC` setting:

    make USE_GC=

## Testing

Performance testing used to cause OOM killer on the `stepA_mal` process in my VM:

    Performance test for c:
    Running: ../c/stepA_mal ../tests/perf1.mal
    "Elapsed time: 2 msecs"
    Running: ../c/stepA_mal ../tests/perf2.mal
    "Elapsed time: 2 msecs"
    Running: ../c/stepA_mal ../tests/perf3.mal
    Killed

Here are the relevant syslog lines:

    [938589.062424] Out of memory: Kill process 3769 (stepA_mal) score 877 or sacrifice child
    [938589.063582] Killed process 3769 (stepA_mal) total-vm:957152kB, anon-rss:891592kB, file-rss:64kB

and now it completes OK:

    Performance test for c:
    Running: ../c/stepA_mal ../tests/perf1.mal
    "Elapsed time: 1 msecs"
    Running: ../c/stepA_mal ../tests/perf2.mal
    "Elapsed time: 2 msecs"
    Running: ../c/stepA_mal ../tests/perf3.mal
    iters/s: 5248

I also tried this endless loop:

    (def! silent-loop (fn* [n] (if (> n 0) (silent-loop (- n 1)))))
    (def! loop (fn* [n] (do (prn n) (silent-loop 100000) (loop (+ 1 n)))))
    (loop 1)

Before this addition, this used to hog the VM's memory:

     $ ./stepA_mal endless.mal
     1
     2
     3
     4
     5
     6
     7

and with garbage collection it keeps running as far as I was willing to wait.

Note that it's still possible that some Mal functions/flows are still leaking
memory (especially with the interaction with glib); maybe we need to run all
the regression functional tests in a loop (inside one Mal process) and monitor
memory growth to find such a situation.
