### PR TITLE
Fix evaluation of hash-map keys

### DIFF
--- a/process/guide.md
+++ b/process/guide.md
@@ -543,6 +543,15 @@ make "test^quux^step2"
 
 You now have a simple prefix notation calculator!
 
+#### Deferrable:
+
+* `eval_ast` should evaluate elements of vectors and hash-maps.  Add the
+  following cases in `eval_ast`:
+  * If `ast` is a vector: return a new vector that is the result of calling
+    `EVAL` on each of the members of the vector.
+  * If `ast` is a hash-map: return a new hash-map that is the result of calling
+    `EVAL` on each of the keys and the values of the hash-map.
+
 
 <a name="step3"></a>
 

--- a/tests/step4_if_fn_do.mal
+++ b/tests/step4_if_fn_do.mal
@@ -453,3 +453,7 @@ nil
 ;=>true
 (= [1 2 (list 3 4 [5 6])] (list 1 2 [3 4 (list 5 6)]))
 ;=>true
+
+;; Test evaluation of hashmap keys and values
+{ (str "a" "b" 34) (+ 2 3) }
+;=>{"ab34" 5}


### PR DESCRIPTION
Add instructions to guide (in step 2) regarding evaluation of vector and hash-map elements.  These were already tested in step 2 tests.

The new test for hash-map keys evaluation in step 4 uses `str` which is introduced in step 4.

Travis will fail this PR on impls that don't evaluate the hash-map keys correctly. Failed impls:

* [ ] ada
* [ ] awk
* [ ] bash
* [ ] c
* [ ] cpp
* [ ] coffee
* [ ] cs
* [ ] crystal
* [ ] d
* [ ] elisp
* [ ] erlang
* [ ] es6
* [ ] fsharp
* [ ] go
* [ ] guile
* [ ] haskell
* [ ] haxe
* [ ] io
* [ ] java
* [ ] js
* [ ] kotlin
* [ ] make
* [ ] mal
* [ ] matlab
* [ ] miniMAL
* [ ] nim
* [ ] objpascal
* [ ] objc
* [ ] perl
* [ ] php
* [ ] ps
* [ ] python
* [ ] r
* [ ] racket
* [ ] rpython
* [ ] rust
* [ ] scala
* [ ] swift3
* [ ] tcl
* [ ] vb
* [ ] vimscript
