### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ mono ./stepX_YYY.exe
 *The Factor implementation was created by [Jordan Lewis (jordanlewis)](https://github.com/jordanlewis)*
 
 The Factor implementation of mal has been tested with Factor 0.97
-([factorcode.org](factorcode.org)).
+([factorcode.org](http://factorcode.org)).
 
 ```
 cd factor


### PR DESCRIPTION
Previously, this would link to https://github.com/kanaka/mal/blob/master/factorcode.org