### PR TITLE
python: Fix interop (py*, py!*)

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -113,9 +113,6 @@ Postscript:
     - fix blank line after comments
     - fix command line arg processing (doesn't run file specified)
 
-Python:
-    - interop tests
-
 R:
     - tracebacks in errors
     - fix running from different directory

--- a/python/mal_types.py
+++ b/python/mal_types.py
@@ -132,3 +132,9 @@ class Atom(object):
         self.val = val
 def _atom(val): return Atom(val)
 def _atom_Q(exp):   return type(exp) == Atom
+
+def py_to_mal(obj):
+        if type(obj) == list:   return List(obj)
+        if type(obj) == tuple:  return List(obj)
+        elif type(obj) == dict: return Hash_Map(obj)
+        else:                   return obj

--- a/python/stepA_mal.py
+++ b/python/stepA_mal.py
@@ -93,13 +93,10 @@ def EVAL(ast, env):
         elif 'macroexpand' == a0:
             return macroexpand(ast[1], env)
         elif "py!*" == a0:
-            if sys.version_info[0] >= 3:
-                exec(compile(ast[1], '', 'single'), globals())
-            else:
-                exec(compile(ast[1], '', 'single') in globals())
+            exec(compile(ast[1], '', 'single'), globals())
             return None
         elif "py*" == a0:
-            return eval(ast[1])
+            return types.py_to_mal(eval(ast[1]))
         elif "." == a0:
             el = eval_ast(ast[2:], env)
             f = eval(ast[1])

--- a/python/tests/stepA_mal.mal
+++ b/python/tests/stepA_mal.mal
@@ -1,0 +1,23 @@
+;; Testing Python interop
+
+;; Testing Python experesions
+(py* "7")
+;=>7
+(py* "'7'")
+;=>"7"
+(py* "[7,8,9]")
+;=>(7 8 9)
+(py* "' '.join(['X'+c+'Y' for c in ['a','b','c']])")
+;=>"XaY XbY XcY"
+(py* "[1 + x for x in [1,2,3]]")
+;=>(2 3 4)
+
+;; Testing Python statements
+(py!* "print('hello')")
+; hello
+;=>nil
+
+(py!* "foo = 19 % 4")
+;=>nil
+(py* "foo")
+;=>3


### PR DESCRIPTION
`py!*`: Fix to work on both Python 2 and 3.

`py*`: Python types are converted to Mal types where applicable.

Added tests for Python interop.