### PR TITLE
racket: Set *ARGV* correctly

### DIFF
--- a/racket/step6_file.rkt
+++ b/racket/step6_file.rkt
@@ -75,7 +75,7 @@
 ;; core.rkt: defined using Racket
 (hash-for-each core_ns (lambda (k v) (send repl-env set k v)))
 (send repl-env set 'eval (lambda [ast] (EVAL ast repl-env)))
-(send repl-env set '*ARGV* (list))
+(send repl-env set '*ARGV* (_rest (current-command-line-arguments)))
 
 ;; core.mal: defined using the language itself
 (rep "(def! not (fn* (a) (if a false true)))")

--- a/racket/step7_quote.rkt
+++ b/racket/step7_quote.rkt
@@ -97,7 +97,7 @@
 ;; core.rkt: defined using Racket
 (hash-for-each core_ns (lambda (k v) (send repl-env set k v)))
 (send repl-env set 'eval (lambda [ast] (EVAL ast repl-env)))
-(send repl-env set '*ARGV* (list))
+(send repl-env set '*ARGV* (_rest (current-command-line-arguments)))
 
 ;; core.mal: defined using the language itself
 (rep "(def! not (fn* (a) (if a false true)))")

--- a/racket/step8_macros.rkt
+++ b/racket/step8_macros.rkt
@@ -120,7 +120,7 @@
 ;; core.rkt: defined using Racket
 (hash-for-each core_ns (lambda (k v) (send repl-env set k v)))
 (send repl-env set 'eval (lambda [ast] (EVAL ast repl-env)))
-(send repl-env set '*ARGV* (list))
+(send repl-env set '*ARGV* (_rest (current-command-line-arguments)))
 
 ;; core.mal: defined using the language itself
 (rep "(def! not (fn* (a) (if a false true)))")

--- a/racket/step9_try.rkt
+++ b/racket/step9_try.rkt
@@ -135,7 +135,7 @@
 ;; core.rkt: defined using Racket
 (hash-for-each core_ns (lambda (k v) (send repl-env set k v)))
 (send repl-env set 'eval (lambda [ast] (EVAL ast repl-env)))
-(send repl-env set '*ARGV* (list))
+(send repl-env set '*ARGV* (_rest (current-command-line-arguments)))
 
 ;; core.mal: defined using the language itself
 (rep "(def! not (fn* (a) (if a false true)))")

--- a/racket/stepA_mal.rkt
+++ b/racket/stepA_mal.rkt
@@ -135,7 +135,7 @@
 ;; core.rkt: defined using Racket
 (hash-for-each core_ns (lambda (k v) (send repl-env set k v)))
 (send repl-env set 'eval (lambda [ast] (EVAL ast repl-env)))
-(send repl-env set '*ARGV* (list))
+(send repl-env set '*ARGV* (_rest (current-command-line-arguments)))
 
 ;; core.mal: defined using the language itself
 (rep "(def! *host-language* \"racket\")")


### PR DESCRIPTION
I started working on automatic test for `*ARGV*` (expect a PR soon) and while testing I found that Racket wasn't setting *ARGV* at all. Now fixed.

