### PR TITLE
Add Lua interop and describe interop in the guide

### DIFF
--- a/lua/tests/stepA_mal.mal
+++ b/lua/tests/stepA_mal.mal
@@ -1,0 +1,38 @@
+;; Testing basic Lua interop
+
+;;; lua-eval adds the string "return " to the beginning of the evaluated string
+;;; and supplies that to Lua's loadstring().  If complex programs are needed,
+;;; those can be wrapped by an anonymous function which is called immediately
+;;; (see the foo = 8 example below).
+
+(lua-eval "7")
+;=>7
+
+(lua-eval "'7'")
+;=>"7"
+
+(lua-eval "123 == 123")
+;=>true
+
+(lua-eval "123 == 456")
+;=>false
+
+(lua-eval "{7,8,9}")
+;=>(7 8 9)
+
+(lua-eval "{abc = 789}")
+;=>{"abc" 789}
+
+(lua-eval "print('hello')")
+; hello
+;=>nil
+
+(lua-eval "(function() foo = 8 end)()")
+(lua-eval "foo")
+;=>8
+
+(lua-eval "string.gsub('This sentence has five words', '%w+', function(w) return '*'..#w..'*' end)")
+;=>"*4* *8* *3* *4* *5*"
+
+(lua-eval "table.concat({3, 'a', 45, 'b'}, '|')")
+;=>"3|a|45|b"

--- a/process/guide.md
+++ b/process/guide.md
@@ -1624,6 +1624,16 @@ For extra information read [Peter Seibel's thorough discussion about
     converted into a list, and a string is converted to a list that
     containing the original string split into single character
     strings.
+* For interop with the target language, add this core function:
+  * `quux-eval`: takes a string, evaluates it in the target language,
+    and returns the result converted to the relevant Mal type. You
+    may also add other interop functions as you see fit; Clojure, for
+    example, has a function called `.` which allows calling Java
+    methods. If the target language is a static language, consider
+    using FFI or some language-specific reflection mechanism, if
+    available. The tests for `quux-eval` and any other interop
+    function should be added in `quux/tests/stepA_mal.mal` (see the
+    [tests for `lua-eval`](../lua/tests/stepA_mal.mal) as an example).
 
 
 ## TODO:


### PR DESCRIPTION
First commit adds `lua-eval` core function and tests. Note that in Lua both "lists" and "hashmaps" are tables, so if the evaluated function returned an empty table we always return an empty Mal list. If it's not empty, we decide whether the table is a "list" or "hashmap" according to the first key - if it's numeric it'll be a Mal list, otherwise a Mal hashmap.

Second commit adds description of the optional `quux-eval` core function to the guide.
