### PR TITLE
js: Fix interop, update web REPL page

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -6,7 +6,8 @@ if (typeof module === 'undefined') {
     var types = require('./types'),
         readline = require('./node_readline'),
         reader = require('./reader'),
-        printer = require('./printer');
+        printer = require('./printer'),
+        interop = require('./interop');
 }
 
 // Errors/Exceptions
@@ -174,6 +175,17 @@ function swap_BANG(atm, f) {
     return atm.val;
 }
 
+function js_eval(str) {
+    return interop.js_to_mal(eval(str.toString()));
+}
+
+function js_method_call(object_method_str) {
+    var args = Array.prototype.slice.call(arguments, 1),
+        r = interop.resolve_js(object_method_str),
+        obj = r[0], f = r[1];
+    var res = f.apply(obj, args);
+    return interop.js_to_mal(res);
+}
 
 // types.ns is namespace of type functions
 var ns = {'type': types._obj_type,
@@ -238,6 +250,10 @@ var ns = {'type': types._obj_type,
           'atom?': types._atom_Q,
           "deref": deref,
           "reset!": reset_BANG,
-          "swap!": swap_BANG};
+          "swap!": swap_BANG,
+
+          'js-eval': js_eval,
+          '.': js_method_call
+};
 
 exports.ns = core.ns = ns;

--- a/js/interop.js
+++ b/js/interop.js
@@ -7,15 +7,18 @@ if (typeof module === 'undefined') {
 
 function resolve_js(str) {
     if (str.match(/\./)) {
-        var re = /^(.*)\.([^\.]*)$/,
+        var re = /^(.*)\.[^\.]*$/,
             match = re.exec(str);
-        return [eval(match[0]), eval(str)];
+        return [eval(match[1]), eval(str)];
     } else {
         return [GLOBAL, eval(str)];
     }
 }
 
 function js_to_mal(obj) {
+    if (obj === null || obj === undefined) {
+        return null;
+    }
     var cache = [];
     var str = JSON.stringify(obj, function(key, value) {
         if (typeof value === 'object' && value !== null) {

--- a/js/stepA_mal.js
+++ b/js/stepA_mal.js
@@ -5,7 +5,6 @@ if (typeof module !== 'undefined') {
     var printer = require('./printer');
     var Env = require('./env').Env;
     var core = require('./core');
-    var interop = require('./interop');
 }
 
 // read
@@ -110,15 +109,6 @@ function _EVAL(ast, env) {
         return env.set(a1, func);
     case 'macroexpand':
         return macroexpand(a1, env);
-    case "js*":
-        return eval(a1.toString());
-    case ".":
-        var el = eval_ast(ast.slice(2), env),
-            r = interop.resolve_js(a1.toString()),
-            obj = r[0], f = r[1];
-        var res = f.apply(obj, el);
-        console.log("DEBUG3:", res);
-        return interop.js_to_mal(res);
     case "try*":
         try {
             return EVAL(a1, env);

--- a/js/tests/stepA_mal.mal
+++ b/js/tests/stepA_mal.mal
@@ -1,24 +1,39 @@
 ;; Testing basic bash interop
 
-(js* "7")
+(js-eval "7")
 ;=>7
 
-(js* "'7'")
+(js-eval "'7'")
 ;=>"7"
 
-(js* "[7,8,9]")
+(js-eval "[7,8,9]")
 ;=>(7 8 9)
 
-(js* "console.log('hello');")
+(js-eval "console.log('hello');")
 ; hello
 ;=>nil
 
-(js* "foo=8;")
-(js* "foo;")
+(js-eval "foo=8;")
+(js-eval "foo;")
 ;=>8
 
-(js* "['a','b','c'].map(function(x){return 'X'+x+'Y'}).join(' ')")
+(js-eval "['a','b','c'].map(function(x){return 'X'+x+'Y'}).join(' ')")
 ;=>"XaY XbY XcY"
 
-(js* "[1,2,3].map(function(x){return 1+x})")
+(js-eval "[1,2,3].map(function(x){return 1+x})")
 ;=>(2 3 4)
+
+(js-eval (str "3 * " (* 4 5)))
+;=>60
+
+(. "console.log" "abc" 123 '(4 5 6) {"kk" "vv"} (= 1 1) nil)
+; abc 123 [ 4, 5, 6 ] { kk: 'vv' } true null
+;=>nil
+
+(js-eval "myobj = { v: 10, myfunc: function(a,b,c) { return a * b * c * this.v; } }")
+(. "myobj.myfunc" 2 3 4)
+;=>240
+
+(js-eval "myarray = [1,2,3,4,5]")
+(. "myarray.join" "#")
+;=>"1#2#3#4#5"

--- a/mal.html
+++ b/mal.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
 Copyright (c) 2014 Joel Martin
 Copyright (c) 2012 Fogus, Jen Myers and Relevance Inc.
@@ -12,6 +13,7 @@ this software.
 
 <html>
 <head>
+  <meta charset="UTF-8" />
   <link rel="stylesheet" type="text/css" href="js/web/base.css" />
   <link rel="stylesheet" type="text/css" href="js/web/layout.css" />
   <link rel="stylesheet" type="text/css" href="js/web/skeleton.css" />
@@ -65,17 +67,17 @@ this software.
             <td class="row-label">Maps</td>
             <td>{"key1" "val1", "key2" 123}</td>
           </tr>
-          <tr class="row-one">
+          <tr>
             <td class="row-label">Lists</td>
             <td>(1 2 3 "four")</td>
           </tr>
-          <tr>
+          <tr class="row-one">
             <td class="row-label">Vectors</td>
             <td>[1 2 3 4 "a" "b" "c" 1 2]</td>
           </tr>
           <tr>
             <td class="row-label">Scalars</td>
-            <td>a-symbol, "a string", 123, nil, true, false</td>
+            <td>a-symbol, "a string", :a_keyword, 123, nil, true, false</td>
           </tr>
         </table>
       </div><!-- /cheat-box -->
@@ -92,13 +94,13 @@ this software.
             <td>(def! <span class="ebnf">&lt;name&gt;</span> 
                   (fn*
                   [<span class="ebnf">&lt;args*&gt;</span>]
-                  <span class="ebnf">&lt;action*&gt;</span>))</td>
+                  <span class="ebnf">&lt;action&gt;</span>))</td>
           </tr>
           <tr class="row-one">
             <td class="row-label">Anonymous function</td>
-            <td>(fn* <span class="ebnf">|name|</span>
+            <td>(fn*
                   [<span class="ebnf">&lt;args*&gt;</span>]
-                  <span class="ebnf">&lt;action*&gt;</span>)</td>
+                  <span class="ebnf">&lt;action&gt;</span>)</td>
           </tr>
         </table>
       </div><!-- /cheat-box -->
@@ -124,6 +126,14 @@ this software.
             <td class="row-label">Defining things</td>
             <td>def! defmacro! let*</td>
           </tr>
+          <tr>
+            <td class="row-label">Quoting</td>
+            <td>' ` ~ ~@</td>
+          </tr>
+          <tr class="row-one">
+            <td class="row-label">Examining macros</td>
+            <td>macroexpand</td>
+          </tr>
 	</table>
       </div>
     </div><!-- /cheat-box-container -->
@@ -142,7 +152,7 @@ this software.
           </tr>
           <tr class="row-one">
             <td class="row-label">Predicates</td>
-            <td>nil? true? false? symbol? list? vector? map? sequential?</td>
+            <td>nil? true? false? symbol? keyword? string? list? vector? map? sequential?</td>
           </tr>
           <tr>
             <td class="row-label">Data processing</td>
@@ -162,11 +172,27 @@ this software.
           </tr>
           <tr>
             <td class="row-label">Lists and Vectors</td>
-            <td>first rest nth</td></td>
+            <td>first rest nth seq</td></td>
           </tr>
           <tr class="row-one">
             <td class="row-label">Hash Maps</td>
             <td>get keys vals contains?</td></td>
+          </tr>
+          <tr>
+            <td class="row-label">Strings</td>
+            <td>str pr-str seq</td></td>
+          </tr>
+          <tr class="row-one">
+            <td class="row-label">Atoms</td>
+            <td>atom atom? deref[@] reset! swap!</td></td>
+          </tr>
+          <tr>
+            <td class="row-label">Meta</td>
+            <td>meta with-meta[^]</td></td>
+          </tr>
+          <tr class="row-one">
+            <td class="row-label">Output</td>
+            <td>println prn</td></td>
           </tr>
         </table>
       </div><!-- /cheat-box -->
@@ -175,7 +201,7 @@ this software.
         <table>
           <tr class="row-one">
             <td class="row-label">Evaluate JavaScript</td>
-            <td>(js* "JS string to eval")</td>
+            <td>(js-eval "JS string to eval")</td>
           </tr>
           <tr>
             <td class="row-label">Method call/access</td>


### PR DESCRIPTION
* `js*` renamed to `js-eval` and is no longer a special form (just a normal   function in core.js)
* `.` is no longer a special form (just a normal function in core.js)
* fixed object/method parsing of first argument to `.`
* added tests for `.`
* updated mal.html: "Mal at a glance" shows all Mal functions

Probably solves #152 .