### PR TITLE
Replace elisp* with elisp-eval

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -217,4 +217,6 @@
                             mal-nil))
                          (t
                           mal-nil))))))
+
+    (elisp-eval . ,(mal-fn (lambda (string) (mal-string (format "%S" (eval (read (mal-value string))))))))
     ))

--- a/elisp/stepA_mal.el
+++ b/elisp/stepA_mal.el
@@ -113,8 +113,6 @@
             (throw 'return (mal-env-set env identifier value))))
          ((eq a0* 'macroexpand)
           (throw 'return (MACROEXPAND a1 env)))
-         ((eq a0* 'elisp*)
-          (throw 'return (mal-string (format "%S" (eval (read (mal-value a1)))))))
          ((eq a0* 'try*)
           (condition-case err
               (throw 'return (EVAL a1 env))

--- a/elisp/tests/stepA_mal.mal
+++ b/elisp/tests/stepA_mal.mal
@@ -1,21 +1,21 @@
 ;; Testing basic elisp interop
 
-(elisp* "42")
+(elisp-eval "42")
 ;=>"42"
 
-(elisp* "(+ 1 1)")
+(elisp-eval "(+ 1 1)")
 ;=>"2"
 
-(elisp* "[foo bar baz]")
+(elisp-eval "[foo bar baz]")
 ;=>"[foo bar baz]"
 
-(elisp* "(mapcar '1+ (number-sequence 0 2))")
+(elisp-eval "(mapcar '1+ (number-sequence 0 2))")
 ;=>"(1 2 3)"
 
-(elisp* "(progn (princ \"Hello World!\n\") nil)")
+(elisp-eval "(progn (princ \"Hello World!\n\") nil)")
 ; Hello World!
 ;=>"nil"
 
-(elisp* "(setq emacs-version-re \"24\\\.[[:digit:]]\\\.[[:digit:]]\")")
-(elisp* "(and (string-match-p emacs-version-re emacs-version) t)")
+(elisp-eval "(setq emacs-version-re (rx \"24.\" digit \".\" digit))")
+(elisp-eval "(and (string-match-p emacs-version-re emacs-version) t)")
 ;=>"t"


### PR DESCRIPTION
While I was at it, I made elisp-eval a core function (as opposed to a special form) and made that one interop test more readable.