### PR TITLE
Crystal 0.18.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ coffee ./stepX_YYY
 
 *The Crystal implementation of mal was created by [Linda_pp](https://github.com/rhysd)*
 
-The Crystal implementation of mal has been tested with Crystal 0.17.4.
+The Crystal implementation of mal has been tested with Crystal 0.18.4.
 
 ```
 cd crystal

--- a/crystal/Makefile
+++ b/crystal/Makefile
@@ -13,7 +13,7 @@ mal: $(LAST_STEP_BIN)
 	cp $< $@
 
 $(STEP_BINS): %: %.cr $(MAL_LIB)
-	crystal build --release $<
+	crystal compile --release $<
 
 clean:
 	rm -rf $(STEP_BINS) mal .crystal

--- a/crystal/core.cr
+++ b/crystal/core.cr
@@ -11,7 +11,7 @@ module Mal
 macro calc_op(op)
   -> (args : Array(Mal::Type)) {
     x, y = args[0].unwrap, args[1].unwrap
-    eval_error "invalid arguments for binary operator {{op.id}}" unless x.is_a?(Int32) && y.is_a?(Int32)
+    eval_error "invalid arguments for binary operator {{op.id}}" unless x.is_a?(Int64) && y.is_a?(Int64)
     Mal::Type.new(x {{op.id}} y)
   }
 end
@@ -33,9 +33,9 @@ def self.count(args)
   a = args.first.unwrap
   case a
   when Array
-    a.size as Int32
+    a.size.to_i64
   when Nil
-    0
+    0i64
   else
     eval_error "invalid argument for function 'count'"
   end
@@ -92,7 +92,7 @@ end
 def self.nth(args)
   a0, a1 = args[0].unwrap, args[1].unwrap
   eval_error "1st argument of nth must be list or vector" unless a0.is_a? Array
-  eval_error "2nd argument of nth must be integer" unless a1.is_a? Int32
+  eval_error "2nd argument of nth must be integer" unless a1.is_a? Int64
   a0[a1]
 end
 
@@ -362,7 +362,7 @@ def self.seq(args)
 end
 
 def self.time_ms(args)
-  Time.now.epoch_ms.to_i32
+  Time.now.epoch_ms.to_i64
 end
 
 # Note:

--- a/crystal/printer.cr
+++ b/crystal/printer.cr
@@ -4,7 +4,7 @@ def pr_str(value, print_readably = true)
   case value
   when Nil          then "nil"
   when Bool         then value.to_s
-  when Int32        then value.to_s
+  when Int64        then value.to_s
   when Mal::List    then "(#{value.map{|v| pr_str(v, print_readably) as String}.join(" ")})"
   when Mal::Vector  then "[#{value.map{|v| pr_str(v, print_readably) as String}.join(" ")}]"
   when Mal::Symbol  then value.str.to_s

--- a/crystal/reader.cr
+++ b/crystal/reader.cr
@@ -77,7 +77,7 @@ class Reader
     parse_error "expected Atom but got EOF" unless token
 
     Mal::Type.new case
-    when token =~ /^-?\d+$/ then token.to_i
+    when token =~ /^-?\d+$/ then token.to_i64
     when token == "true"    then true
     when token == "false"   then false
     when token == "nil"     then nil

--- a/crystal/step2_eval.cr
+++ b/crystal/step2_eval.cr
@@ -18,7 +18,7 @@ module Mal
   def num_func(func)
     -> (args : Array(Mal::Type)) {
       x, y = args[0].unwrap, args[1].unwrap
-      eval_error "invalid arguments" unless x.is_a?(Int32) && y.is_a?(Int32)
+      eval_error "invalid arguments" unless x.is_a?(Int64) && y.is_a?(Int64)
       Mal::Type.new func.call(x, y)
     }
   end
@@ -79,10 +79,10 @@ module Mal
 end
 
 $repl_env = {
-  "+" => Mal.num_func(->(x : Int32, y : Int32){ x + y }),
-  "-" => Mal.num_func(->(x : Int32, y : Int32){ x - y }),
-  "*" => Mal.num_func(->(x : Int32, y : Int32){ x * y }),
-  "/" => Mal.num_func(->(x : Int32, y : Int32){ x / y }),
+  "+" => Mal.num_func(->(x : Int64, y : Int64){ x + y }),
+  "-" => Mal.num_func(->(x : Int64, y : Int64){ x - y }),
+  "*" => Mal.num_func(->(x : Int64, y : Int64){ x * y }),
+  "/" => Mal.num_func(->(x : Int64, y : Int64){ x / y }),
 } of String => Mal::Func
 
 while line = my_readline("user> ")

--- a/crystal/step3_env.cr
+++ b/crystal/step3_env.cr
@@ -16,16 +16,16 @@ end
 def num_func(func)
   -> (args : Array(Mal::Type)) {
     x, y = args[0].unwrap, args[1].unwrap
-    eval_error "invalid arguments" unless x.is_a?(Int32) && y.is_a?(Int32)
+    eval_error "invalid arguments" unless x.is_a?(Int64) && y.is_a?(Int64)
     Mal::Type.new func.call(x, y)
   }
 end
 
 $repl_env = Mal::Env.new nil
-$repl_env.set("+", Mal::Type.new num_func(->(x : Int32, y : Int32){ x + y }))
-$repl_env.set("-", Mal::Type.new num_func(->(x : Int32, y : Int32){ x - y }))
-$repl_env.set("*", Mal::Type.new num_func(->(x : Int32, y : Int32){ x * y }))
-$repl_env.set("/", Mal::Type.new num_func(->(x : Int32, y : Int32){ x / y }))
+$repl_env.set("+", Mal::Type.new num_func(->(x : Int64, y : Int64){ x + y }))
+$repl_env.set("-", Mal::Type.new num_func(->(x : Int64, y : Int64){ x - y }))
+$repl_env.set("*", Mal::Type.new num_func(->(x : Int64, y : Int64){ x * y }))
+$repl_env.set("/", Mal::Type.new num_func(->(x : Int64, y : Int64){ x / y }))
 
 module Mal
   extend self

--- a/crystal/types.cr
+++ b/crystal/types.cr
@@ -38,7 +38,7 @@ module Mal
 
   class Type
     alias Func = (Array(Type) -> Type)
-    alias ValueType = Nil | Bool | Int32 | String | Symbol | List | Vector | HashMap | Func | Closure | Atom
+    alias ValueType = Nil | Bool | Int64 | String | Symbol | List | Vector | HashMap | Func | Closure | Atom
 
     property :is_macro, :meta
 
@@ -80,7 +80,7 @@ module Mal
       {% for op in ops %}
         def {{op.id}}(other : Mal::Type)
           l, r = @val, other.unwrap
-            {% for t in [Int32, String] %}
+            {% for t in [Int64, String] %}
               if l.is_a?({{t}}) && r.is_a?({{t}})
                 return (l) {{op.id}} (r)
               end


### PR DESCRIPTION
I fixed Crystal implementation for Crystal 0.18.4.

I found that a test case for `time_ms` failed because it requires 64bit integer.  So I changed underlying type of `int` to `Int64`.  Now it works.