### PR TITLE
Squashed commits, updated to latest swift3 (swift-3.0-PREVIEW-2)

### DIFF
--- a/swift3/Sources/core.swift
+++ b/swift3/Sources/core.swift
@@ -6,7 +6,7 @@ import Glibc
 import Darwin
 #endif
 
-func IntOp(op: (Int, Int) -> Int, _ a: MalVal, _ b: MalVal) throws -> MalVal {
+func IntOp(_ op: (Int, Int) -> Int, _ a: MalVal, _ b: MalVal) throws -> MalVal {
     switch (a, b) {
     case (MV.MalInt(let i1), MV.MalInt(let i2)):
         return MV.MalInt(op(i1, i2))
@@ -15,7 +15,7 @@ func IntOp(op: (Int, Int) -> Int, _ a: MalVal, _ b: MalVal) throws -> MalVal {
     }
 }
 
-func CmpOp(op: (Int, Int) -> Bool, _ a: MalVal, _ b: MalVal) throws -> MalVal {
+func CmpOp(_ op: (Int, Int) -> Bool, _ a: MalVal, _ b: MalVal) throws -> MalVal {
     switch (a, b) {
     case (MV.MalInt(let i1), MV.MalInt(let i2)):
         return wraptf(op(i1, i2))
@@ -95,20 +95,20 @@ let core_ns: Dictionary<String,(Array<MalVal>) throws -> MalVal> = [
         //      let core_ns: [String: (Array<MalVal>) throws -> MalVal] = [
         //                                                                ^
 
-        let s = $0.map { pr_str($0,true) }.joinWithSeparator(" ")
+        let s = $0.map { pr_str($0,true) }.joined(separator: " ")
         return MV.MalString(s)
     },
     "str": {
         // The comment for "pr-str" applies here, too.
-        let s = $0.map { pr_str($0,false) }.joinWithSeparator("")
+        let s = $0.map { pr_str($0,false) }.joined(separator: "")
         return MV.MalString(s)
     },
     "prn": {
-        print($0.map { pr_str($0,true) }.joinWithSeparator(" "))
+        print($0.map { pr_str($0,true) }.joined(separator: " "))
         return MV.MalNil
     },
     "println": {
-        print($0.map { pr_str($0,false) }.joinWithSeparator(" "))
+        print($0.map { pr_str($0,false) }.joined(separator: " "))
         return MV.MalNil
     },
     "read-string": {
@@ -121,7 +121,7 @@ let core_ns: Dictionary<String,(Array<MalVal>) throws -> MalVal> = [
         switch $0[0] {
         case MV.MalString(let prompt):
             print(prompt, terminator: "")
-            let line = readLine(stripNewline: true)
+            let line = readLine(strippingNewline: true)
             if line == nil { return MV.MalNil }
             return MV.MalString(line!)
         default: throw MalError.General(msg: "Invalid readline call")
@@ -130,17 +130,7 @@ let core_ns: Dictionary<String,(Array<MalVal>) throws -> MalVal> = [
     "slurp": {
         switch $0[0] {
         case MV.MalString(let file):
-            // TODO: replace with this when it is available
-            // let data = try String(contentsOfFile: file, encoding: NSUTF8StringEncoding)
-
-            let BUFSIZE = 1024
-            var pp      = popen("cat " + file, "r")
-            var buf     = [CChar](count:BUFSIZE, repeatedValue:CChar(0))
-            var data    = String()
-             
-            while fgets(&buf, Int32(BUFSIZE), pp) != nil {
-                data = data + String.fromCString(buf)!;
-            }
+            let data = try String(contentsOfFile: file, encoding: String.Encoding.utf8)
             return MV.MalString(data)
         default: throw MalError.General(msg: "Invalid slurp call")
         }
@@ -156,7 +146,7 @@ let core_ns: Dictionary<String,(Array<MalVal>) throws -> MalVal> = [
     "*":  { try IntOp({ $0 * $1},  $0[0], $0[1]) },
     "/":  { try IntOp({ $0 / $1},  $0[0], $0[1]) },
     "time-ms": {
-        $0; // no parameters
+        let read = $0; // no parameters
 
         // TODO: replace with something more like this
         // return MV.MalInt(NSDate().timeIntervalSince1970 )
@@ -359,7 +349,7 @@ let core_ns: Dictionary<String,(Array<MalVal>) throws -> MalVal> = [
         if $0.count < 1 { throw MalError.General(msg: "Invalid conj call") }
         switch $0[0] {
         case MV.MalList(let lst, _):
-            let a = Array($0[1..<$0.endIndex]).reverse()
+            let a = Array($0[1..<$0.endIndex]).reversed()
             return list(a + lst)
         case MV.MalVector(let lst, _):
             return vector(lst + $0[1..<$0.endIndex])

--- a/swift3/Sources/env.swift
+++ b/swift3/Sources/env.swift
@@ -25,7 +25,7 @@ class Env {
                 let b = bs[pos]
                 switch b {
                 case MalVal.MalSymbol("&"):
-                    switch bs[pos.successor()] {
+                    switch bs[bs.index(after: pos)] {
                     case MalVal.MalSymbol(let sym):
                         if pos < es.endIndex {
                             let slc = es[pos..<es.endIndex]
@@ -43,12 +43,12 @@ class Env {
                 default:
                     throw MalError.General(msg: "Env binds has non-symbol")
                 }
-                pos = pos.successor()
+                pos = bs.index(after: pos)
             }
         }
     }
 
-    func find(key: MalVal) throws -> Env? {
+    func find(_ key: MalVal) throws -> Env? {
         switch key {
         case MalVal.MalSymbol(let str):
             if data[str] != nil {
@@ -63,7 +63,7 @@ class Env {
         }
     }
 
-    func get(key: MalVal) throws -> MalVal {
+    func get(_ key: MalVal) throws -> MalVal {
         switch key {
         case MalVal.MalSymbol(let str):
             let env = try self.find(key)
@@ -76,7 +76,7 @@ class Env {
         }
     }
 
-    func set(key: MalVal, _ val: MalVal) throws -> MalVal {
+    func set(_ key: MalVal, _ val: MalVal) throws -> MalVal {
         switch key {
         case MalVal.MalSymbol(let str):
             data[str] = val

--- a/swift3/Sources/printer.swift
+++ b/swift3/Sources/printer.swift
@@ -1,29 +1,26 @@
 
-func pr_str(obj: MalVal, _ print_readably: Bool = true) -> String {
+func pr_str(_ obj: MalVal, _ print_readably: Bool = true) -> String {
     switch obj {
     case MalVal.MalList(let lst, _):
         let elems = lst.map { pr_str($0, print_readably) }
-        return "(" + elems.joinWithSeparator(" ")  + ")"
+        return "(" + elems.joined(separator: " ")  + ")"
     case MalVal.MalVector(let lst, _):
         let elems = lst.map { pr_str($0, print_readably) }
-        return "[" + elems.joinWithSeparator(" ")  + "]"
+        return "[" + elems.joined(separator: " ")  + "]"
     case MalVal.MalHashMap(let dict, _):
         let elems = dict.map {
             pr_str(MalVal.MalString($0), print_readably) +
             " " + pr_str($1, print_readably)
         }
-        return "{" + elems.joinWithSeparator(" ")  + "}"
+        return "{" + elems.joined(separator: " ")  + "}"
     case MalVal.MalString(let str):
         //print("kw: '\(str[str.startIndex])'")
         if str.characters.count > 0 && str[str.startIndex] == "\u{029e}" {
-            return ":" + str[str.startIndex.successor()..<str.endIndex]
+            return ":" + str[str.index(after: str.startIndex)..<str.endIndex]
         } else if print_readably {
-            let s1 = str.stringByReplacingOccurrencesOfString(
-                "\\", withString: "\\\\")
-            let s2 = s1.stringByReplacingOccurrencesOfString(
-                "\"", withString: "\\\"")
-            let s3 = s2.stringByReplacingOccurrencesOfString(
-                "\n", withString: "\\n")
+            let s1 = str.replacingOccurrences(of: "\\", with: "\\\\")
+            let s2 = s1.replacingOccurrences(of: "\"", with: "\\\"")
+            let s3 = s2.replacingOccurrences(of: "\n", with: "\\n")
             return "\"" + s3 + "\""
         } else {
             return str

--- a/swift3/Sources/step0_repl/main.swift
+++ b/swift3/Sources/step0_repl/main.swift
@@ -2,7 +2,7 @@ import Foundation
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/step1_read_print/main.swift
+++ b/swift3/Sources/step1_read_print/main.swift
@@ -1,29 +1,29 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func EVAL(ast: MalVal, _ env: String) throws -> MalVal {
+func EVAL(_ ast: MalVal, _ env: String) throws -> MalVal {
     return ast
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), ""))
 }
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/step2_eval/main.swift
+++ b/swift3/Sources/step2_eval/main.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func eval_ast(ast: MalVal, _ env: Dictionary<String, MalVal>) throws -> MalVal {
+func eval_ast(_ ast: MalVal, _ env: Dictionary<String, MalVal>) throws -> MalVal {
     switch ast {
     case MalVal.MalSymbol(let sym):
         if env[sym] == nil {
@@ -26,7 +26,7 @@ func eval_ast(ast: MalVal, _ env: Dictionary<String, MalVal>) throws -> MalVal {
     }
 }
 
-func EVAL(ast: MalVal, _ env: Dictionary<String, MalVal>) throws -> MalVal {
+func EVAL(_ ast: MalVal, _ env: Dictionary<String, MalVal>) throws -> MalVal {
     switch ast {
     case MalVal.MalList(let lst, _): if lst.count == 0 { return ast }
     default: return try eval_ast(ast, env)
@@ -46,17 +46,17 @@ func EVAL(ast: MalVal, _ env: Dictionary<String, MalVal>) throws -> MalVal {
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), repl_env))
 }
 
-func IntOp(op: (Int, Int) -> Int, _ a: MalVal, _ b: MalVal) throws -> MalVal {
+func IntOp(_ op: (Int, Int) -> Int, _ a: MalVal, _ b: MalVal) throws -> MalVal {
     switch (a, b) {
     case (MalVal.MalInt(let i1), MalVal.MalInt(let i2)):
         return MalVal.MalInt(op(i1, i2))
@@ -74,7 +74,7 @@ var repl_env: Dictionary<String,MalVal> = [
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/step3_env/main.swift
+++ b/swift3/Sources/step3_env/main.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
+func eval_ast(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalSymbol:
         return try env.get(ast)
@@ -23,7 +23,7 @@ func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
     }
 }
 
-func EVAL(ast: MalVal, _ env: Env) throws -> MalVal {
+func EVAL(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalList(let lst, _): if lst.count == 0 { return ast }
     default: return try eval_ast(ast, env)
@@ -45,9 +45,9 @@ func EVAL(ast: MalVal, _ env: Env) throws -> MalVal {
             }
             var idx = binds.startIndex
             while idx < binds.endIndex {
-                let v = try EVAL(binds[idx.successor()], let_env)
+                let v = try EVAL(binds[binds.index(after: idx)], let_env)
                 try let_env.set(binds[idx], v)
-                idx = idx.successor().successor()
+                idx = binds.index(idx, offsetBy: 2)
             }
             return try EVAL(lst[2], let_env)
         default:
@@ -69,17 +69,17 @@ func EVAL(ast: MalVal, _ env: Env) throws -> MalVal {
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), repl_env))
 }
 
-func IntOp(op: (Int, Int) -> Int, _ a: MalVal, _ b: MalVal) throws -> MalVal {
+func IntOp(_ op: (Int, Int) -> Int, _ a: MalVal, _ b: MalVal) throws -> MalVal {
     switch (a, b) {
     case (MalVal.MalInt(let i1), MalVal.MalInt(let i2)):
         return MalVal.MalInt(op(i1, i2))
@@ -101,7 +101,7 @@ try repl_env.set(MalVal.MalSymbol("/"),
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/step4_if_fn_do/main.swift
+++ b/swift3/Sources/step4_if_fn_do/main.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
+func eval_ast(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalSymbol:
         return try env.get(ast)
@@ -23,7 +23,7 @@ func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
     }
 }
 
-func EVAL(ast: MalVal, _ env: Env) throws -> MalVal {
+func EVAL(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalList(let lst, _): if lst.count == 0 { return ast }
     default: return try eval_ast(ast, env)
@@ -45,16 +45,16 @@ func EVAL(ast: MalVal, _ env: Env) throws -> MalVal {
             }
             var idx = binds.startIndex
             while idx < binds.endIndex {
-                let v = try EVAL(binds[idx.successor()], let_env)
+                let v = try EVAL(binds[binds.index(after: idx)], let_env)
                 try let_env.set(binds[idx], v)
-                idx = idx.successor().successor()
+                idx = binds.index(idx, offsetBy: 2)
             }
             return try EVAL(lst[2], let_env)
         case MalVal.MalSymbol("do"):
-            let slc = lst[lst.startIndex.successor()..<lst.endIndex]
+            let slc = lst[lst.index(after: lst.startIndex)..<lst.endIndex]
             switch try eval_ast(list(Array(slc)), env) {
             case MalVal.MalList(let elst, _):
-                return elst[elst.endIndex.predecessor()]
+                return elst[elst.index(before: elst.endIndex)]
             default:
                 throw MalError.General(msg: "Invalid do form")
             }
@@ -93,13 +93,13 @@ func EVAL(ast: MalVal, _ env: Env) throws -> MalVal {
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), repl_env))
 }
 
@@ -116,7 +116,7 @@ try rep("(def! not (fn* (a) (if a false true)))")
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/step5_tco/main.swift
+++ b/swift3/Sources/step5_tco/main.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
+func eval_ast(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalSymbol:
         return try env.get(ast)
@@ -23,7 +23,7 @@ func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
     }
 }
 
-func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
+func EVAL(_ orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
   var ast = orig_ast, env = orig_env
   while true {
     switch ast {
@@ -47,16 +47,16 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
             }
             var idx = binds.startIndex
             while idx < binds.endIndex {
-                let v = try EVAL(binds[idx.successor()], let_env)
+                let v = try EVAL(binds[binds.index(after: idx)], let_env)
                 try let_env.set(binds[idx], v)
-                idx = idx.successor().successor()
+                idx = binds.index(idx, offsetBy: 2)
             }
             env = let_env
             ast = lst[2] // TCO
         case MalVal.MalSymbol("do"):
-            let slc = lst[1..<lst.endIndex.predecessor()]
+            let slc = lst[1..<lst.index(before: lst.endIndex)]
             try eval_ast(list(Array(slc)), env)
-            ast = lst[lst.endIndex.predecessor()] // TCO
+            ast = lst[lst.index(before: lst.endIndex)] // TCO
         case MalVal.MalSymbol("if"):
             switch try EVAL(lst[1], env) {
             case MalVal.MalFalse, MalVal.MalNil:
@@ -98,13 +98,13 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), repl_env))
 }
 
@@ -121,7 +121,7 @@ try rep("(def! not (fn* (a) (if a false true)))")
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/step6_file/main.swift
+++ b/swift3/Sources/step6_file/main.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
+func eval_ast(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalSymbol:
         return try env.get(ast)
@@ -23,7 +23,7 @@ func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
     }
 }
 
-func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
+func EVAL(_ orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
   var ast = orig_ast, env = orig_env
   while true {
     switch ast {
@@ -47,16 +47,16 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
             }
             var idx = binds.startIndex
             while idx < binds.endIndex {
-                let v = try EVAL(binds[idx.successor()], let_env)
+                let v = try EVAL(binds[binds.index(after: idx)], let_env)
                 try let_env.set(binds[idx], v)
-                idx = idx.successor().successor()
+                idx = binds.index(idx, offsetBy: 2)
             }
             env = let_env
             ast = lst[2] // TCO
         case MalVal.MalSymbol("do"):
-            let slc = lst[1..<lst.endIndex.predecessor()]
+            let slc = lst[1..<lst.index(before: lst.endIndex)]
             try eval_ast(list(Array(slc)), env)
-            ast = lst[lst.endIndex.predecessor()] // TCO
+            ast = lst[lst.index(before: lst.endIndex)] // TCO
         case MalVal.MalSymbol("if"):
             switch try EVAL(lst[1], env) {
             case MalVal.MalFalse, MalVal.MalNil:
@@ -98,13 +98,13 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), repl_env))
 }
 
@@ -119,8 +119,8 @@ try repl_env.set(MalVal.MalSymbol("eval"),
 let pargs = Process.arguments.map { MalVal.MalString($0) }
 // TODO: weird way to get empty list, fix this
 var args = pargs[pargs.startIndex..<pargs.startIndex]
-if pargs.startIndex.advancedBy(2) < pargs.endIndex {
-    args = pargs[pargs.startIndex.advancedBy(2)..<pargs.endIndex]
+if pargs.index(pargs.startIndex, offsetBy:2) < pargs.endIndex {
+    args = pargs[pargs.index(pargs.startIndex, offsetBy:2)..<pargs.endIndex]
 }
 try repl_env.set(MalVal.MalSymbol("*ARGV*"), list(Array(args)))
 
@@ -136,7 +136,7 @@ if Process.arguments.count > 1 {
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/step7_quote/main.swift
+++ b/swift3/Sources/step7_quote/main.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func is_pair(ast: MalVal) -> Bool {
+func is_pair(_ ast: MalVal) -> Bool {
     switch ast {
     case MalVal.MalList(let lst, _):   return lst.count > 0
     case MalVal.MalVector(let lst, _): return lst.count > 0
@@ -14,7 +14,7 @@ func is_pair(ast: MalVal) -> Bool {
     }
 }
 
-func quasiquote(ast: MalVal) -> MalVal {
+func quasiquote(_ ast: MalVal) -> MalVal {
     if !is_pair(ast) {
         return list([MalVal.MalSymbol("quote"), ast])
     }
@@ -40,7 +40,7 @@ func quasiquote(ast: MalVal) -> MalVal {
                  quasiquote(try! rest(ast))])
 }
 
-func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
+func eval_ast(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalSymbol:
         return try env.get(ast)
@@ -57,7 +57,7 @@ func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
     }
 }
 
-func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
+func EVAL(_ orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
   var ast = orig_ast, env = orig_env
   while true {
     switch ast {
@@ -81,9 +81,9 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
             }
             var idx = binds.startIndex
             while idx < binds.endIndex {
-                let v = try EVAL(binds[idx.successor()], let_env)
+                let v = try EVAL(binds[binds.index(after: idx)], let_env)
                 try let_env.set(binds[idx], v)
-                idx = idx.successor().successor()
+                idx = binds.index(idx, offsetBy: 2)
             }
             env = let_env
             ast = lst[2] // TCO
@@ -92,9 +92,9 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
         case MalVal.MalSymbol("quasiquote"):
             ast = quasiquote(lst[1]) // TCO
         case MalVal.MalSymbol("do"):
-            let slc = lst[1..<lst.endIndex.predecessor()]
+            let slc = lst[1..<lst.index(before: lst.endIndex)]
             try eval_ast(list(Array(slc)), env)
-            ast = lst[lst.endIndex.predecessor()] // TCO
+            ast = lst[lst.index(before: lst.endIndex)] // TCO
         case MalVal.MalSymbol("if"):
             switch try EVAL(lst[1], env) {
             case MalVal.MalFalse, MalVal.MalNil:
@@ -136,13 +136,13 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), repl_env))
 }
 
@@ -157,8 +157,8 @@ try repl_env.set(MalVal.MalSymbol("eval"),
 let pargs = Process.arguments.map { MalVal.MalString($0) }
 // TODO: weird way to get empty list, fix this
 var args = pargs[pargs.startIndex..<pargs.startIndex]
-if pargs.startIndex.advancedBy(2) < pargs.endIndex {
-    args = pargs[pargs.startIndex.advancedBy(2)..<pargs.endIndex]
+if pargs.index(pargs.startIndex, offsetBy:2) < pargs.endIndex {
+    args = pargs[pargs.index(pargs.startIndex, offsetBy:2)..<pargs.endIndex]
 }
 try repl_env.set(MalVal.MalSymbol("*ARGV*"), list(Array(args)))
 
@@ -174,7 +174,7 @@ if Process.arguments.count > 1 {
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/step8_macros/main.swift
+++ b/swift3/Sources/step8_macros/main.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func is_pair(ast: MalVal) -> Bool {
+func is_pair(_ ast: MalVal) -> Bool {
     switch ast {
     case MalVal.MalList(let lst, _):   return lst.count > 0
     case MalVal.MalVector(let lst, _): return lst.count > 0
@@ -14,7 +14,7 @@ func is_pair(ast: MalVal) -> Bool {
     }
 }
 
-func quasiquote(ast: MalVal) -> MalVal {
+func quasiquote(_ ast: MalVal) -> MalVal {
     if !is_pair(ast) {
         return list([MalVal.MalSymbol("quote"), ast])
     }
@@ -40,7 +40,7 @@ func quasiquote(ast: MalVal) -> MalVal {
                  quasiquote(try! rest(ast))])
 }
 
-func is_macro(ast: MalVal, _ env: Env) -> Bool {
+func is_macro(_ ast: MalVal, _ env: Env) -> Bool {
     switch ast {
     case MalVal.MalList(let lst, _) where lst.count > 0:
         let a0 = lst[lst.startIndex]
@@ -62,7 +62,7 @@ func is_macro(ast: MalVal, _ env: Env) -> Bool {
     }
 }
 
-func macroexpand(orig_ast: MalVal, _ env: Env) throws -> MalVal {
+func macroexpand(_ orig_ast: MalVal, _ env: Env) throws -> MalVal {
     var ast: MalVal = orig_ast
     while is_macro(ast, env) {
         switch try! env.get(try! _nth(ast, 0)) {
@@ -74,7 +74,7 @@ func macroexpand(orig_ast: MalVal, _ env: Env) throws -> MalVal {
     return ast
 }
 
-func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
+func eval_ast(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalSymbol:
         return try env.get(ast)
@@ -91,7 +91,7 @@ func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
     }
 }
 
-func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
+func EVAL(_ orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
   var ast = orig_ast, env = orig_env
   while true {
     switch ast {
@@ -121,9 +121,9 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
             }
             var idx = binds.startIndex
             while idx < binds.endIndex {
-                let v = try EVAL(binds[idx.successor()], let_env)
+                let v = try EVAL(binds[binds.index(after: idx)], let_env)
                 try let_env.set(binds[idx], v)
-                idx = idx.successor().successor()
+                idx = binds.index(idx, offsetBy: 2)
             }
             env = let_env
             ast = lst[2] // TCO
@@ -142,9 +142,9 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
         case MalVal.MalSymbol("macroexpand"):
             return try macroexpand(lst[1], env)
         case MalVal.MalSymbol("do"):
-            let slc = lst[1..<lst.endIndex.predecessor()]
+            let slc = lst[1..<lst.index(before: lst.endIndex)]
             try eval_ast(list(Array(slc)), env)
-            ast = lst[lst.endIndex.predecessor()] // TCO
+            ast = lst[lst.index(before: lst.endIndex)] // TCO
         case MalVal.MalSymbol("if"):
             switch try EVAL(lst[1], env) {
             case MalVal.MalFalse, MalVal.MalNil:
@@ -186,13 +186,13 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), repl_env))
 }
 
@@ -207,8 +207,8 @@ try repl_env.set(MalVal.MalSymbol("eval"),
 let pargs = Process.arguments.map { MalVal.MalString($0) }
 // TODO: weird way to get empty list, fix this
 var args = pargs[pargs.startIndex..<pargs.startIndex]
-if pargs.startIndex.advancedBy(2) < pargs.endIndex {
-    args = pargs[pargs.startIndex.advancedBy(2)..<pargs.endIndex]
+if pargs.index(pargs.startIndex, offsetBy:2) < pargs.endIndex {
+    args = pargs[pargs.index(pargs.startIndex, offsetBy:2)..<pargs.endIndex]
 }
 try repl_env.set(MalVal.MalSymbol("*ARGV*"), list(Array(args)))
 
@@ -226,7 +226,7 @@ if Process.arguments.count > 1 {
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/step9_try/main.swift
+++ b/swift3/Sources/step9_try/main.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func is_pair(ast: MalVal) -> Bool {
+func is_pair(_ ast: MalVal) -> Bool {
     switch ast {
     case MalVal.MalList(let lst, _):   return lst.count > 0
     case MalVal.MalVector(let lst, _): return lst.count > 0
@@ -14,7 +14,7 @@ func is_pair(ast: MalVal) -> Bool {
     }
 }
 
-func quasiquote(ast: MalVal) -> MalVal {
+func quasiquote(_ ast: MalVal) -> MalVal {
     if !is_pair(ast) {
         return list([MalVal.MalSymbol("quote"), ast])
     }
@@ -40,7 +40,7 @@ func quasiquote(ast: MalVal) -> MalVal {
                  quasiquote(try! rest(ast))])
 }
 
-func is_macro(ast: MalVal, _ env: Env) -> Bool {
+func is_macro(_ ast: MalVal, _ env: Env) -> Bool {
     switch ast {
     case MalVal.MalList(let lst, _) where lst.count > 0:
         let a0 = lst[lst.startIndex]
@@ -62,7 +62,7 @@ func is_macro(ast: MalVal, _ env: Env) -> Bool {
     }
 }
 
-func macroexpand(orig_ast: MalVal, _ env: Env) throws -> MalVal {
+func macroexpand(_ orig_ast: MalVal, _ env: Env) throws -> MalVal {
     var ast: MalVal = orig_ast
     while is_macro(ast, env) {
         switch try! env.get(try! _nth(ast, 0)) {
@@ -74,7 +74,7 @@ func macroexpand(orig_ast: MalVal, _ env: Env) throws -> MalVal {
     return ast
 }
 
-func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
+func eval_ast(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalSymbol:
         return try env.get(ast)
@@ -91,7 +91,7 @@ func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
     }
 }
 
-func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
+func EVAL(_ orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
   var ast = orig_ast, env = orig_env
   while true {
     switch ast {
@@ -121,9 +121,9 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
             }
             var idx = binds.startIndex
             while idx < binds.endIndex {
-                let v = try EVAL(binds[idx.successor()], let_env)
+                let v = try EVAL(binds[binds.index(after: idx)], let_env)
                 try let_env.set(binds[idx], v)
-                idx = idx.successor().successor()
+                idx = binds.index(idx, offsetBy: 2)
             }
             env = let_env
             ast = lst[2] // TCO
@@ -175,9 +175,9 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
                 throw exc
             }
         case MalVal.MalSymbol("do"):
-            let slc = lst[1..<lst.endIndex.predecessor()]
+            let slc = lst[1..<lst.index(before: lst.endIndex)]
             try eval_ast(list(Array(slc)), env)
-            ast = lst[lst.endIndex.predecessor()] // TCO
+            ast = lst[lst.index(before: lst.endIndex)] // TCO
         case MalVal.MalSymbol("if"):
             switch try EVAL(lst[1], env) {
             case MalVal.MalFalse, MalVal.MalNil:
@@ -219,13 +219,13 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), repl_env))
 }
 
@@ -240,8 +240,8 @@ try repl_env.set(MalVal.MalSymbol("eval"),
 let pargs = Process.arguments.map { MalVal.MalString($0) }
 // TODO: weird way to get empty list, fix this
 var args = pargs[pargs.startIndex..<pargs.startIndex]
-if pargs.startIndex.advancedBy(2) < pargs.endIndex {
-    args = pargs[pargs.startIndex.advancedBy(2)..<pargs.endIndex]
+if pargs.index(pargs.startIndex, offsetBy:2) < pargs.endIndex {
+    args = pargs[pargs.index(pargs.startIndex, offsetBy:2)..<pargs.endIndex]
 }
 try repl_env.set(MalVal.MalSymbol("*ARGV*"), list(Array(args)))
 
@@ -259,7 +259,7 @@ if Process.arguments.count > 1 {
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 

--- a/swift3/Sources/stepA_mal/main.swift
+++ b/swift3/Sources/stepA_mal/main.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 // read
-func READ(str: String) throws -> MalVal {
+func READ(_ str: String) throws -> MalVal {
     return try read_str(str)
 }
 
 // eval
-func is_pair(ast: MalVal) -> Bool {
+func is_pair(_ ast: MalVal) -> Bool {
     switch ast {
     case MalVal.MalList(let lst, _):   return lst.count > 0
     case MalVal.MalVector(let lst, _): return lst.count > 0
@@ -14,7 +14,7 @@ func is_pair(ast: MalVal) -> Bool {
     }
 }
 
-func quasiquote(ast: MalVal) -> MalVal {
+func quasiquote(_ ast: MalVal) -> MalVal {
     if !is_pair(ast) {
         return list([MalVal.MalSymbol("quote"), ast])
     }
@@ -40,7 +40,7 @@ func quasiquote(ast: MalVal) -> MalVal {
                  quasiquote(try! rest(ast))])
 }
 
-func is_macro(ast: MalVal, _ env: Env) -> Bool {
+func is_macro(_ ast: MalVal, _ env: Env) -> Bool {
     switch ast {
     case MalVal.MalList(let lst, _) where lst.count > 0:
         let a0 = lst[lst.startIndex]
@@ -62,7 +62,7 @@ func is_macro(ast: MalVal, _ env: Env) -> Bool {
     }
 }
 
-func macroexpand(orig_ast: MalVal, _ env: Env) throws -> MalVal {
+func macroexpand(_ orig_ast: MalVal, _ env: Env) throws -> MalVal {
     var ast: MalVal = orig_ast
     while is_macro(ast, env) {
         switch try! env.get(try! _nth(ast, 0)) {
@@ -74,7 +74,7 @@ func macroexpand(orig_ast: MalVal, _ env: Env) throws -> MalVal {
     return ast
 }
 
-func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
+func eval_ast(_ ast: MalVal, _ env: Env) throws -> MalVal {
     switch ast {
     case MalVal.MalSymbol:
         return try env.get(ast)
@@ -91,7 +91,7 @@ func eval_ast(ast: MalVal, _ env: Env) throws -> MalVal {
     }
 }
 
-func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
+func EVAL(_ orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
   var ast = orig_ast, env = orig_env
   while true {
     switch ast {
@@ -121,9 +121,9 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
             }
             var idx = binds.startIndex
             while idx < binds.endIndex {
-                let v = try EVAL(binds[idx.successor()], let_env)
+                let v = try EVAL(binds[binds.index(after: idx)], let_env)
                 try let_env.set(binds[idx], v)
-                idx = idx.successor().successor()
+                idx = binds.index(idx, offsetBy: 2)
             }
             env = let_env
             ast = lst[2] // TCO
@@ -175,9 +175,9 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
                 throw exc
             }
         case MalVal.MalSymbol("do"):
-            let slc = lst[1..<lst.endIndex.predecessor()]
+            let slc = lst[1..<lst.index(before: lst.endIndex)]
             try eval_ast(list(Array(slc)), env)
-            ast = lst[lst.endIndex.predecessor()] // TCO
+            ast = lst[lst.index(before: lst.endIndex)] // TCO
         case MalVal.MalSymbol("if"):
             switch try EVAL(lst[1], env) {
             case MalVal.MalFalse, MalVal.MalNil:
@@ -219,13 +219,13 @@ func EVAL(orig_ast: MalVal, _ orig_env: Env) throws -> MalVal {
 }
 
 // print
-func PRINT(exp: MalVal) -> String {
+func PRINT(_ exp: MalVal) -> String {
     return pr_str(exp, true)
 }
 
 
 // repl
-func rep(str:String) throws -> String {
+func rep(_ str:String) throws -> String {
     return PRINT(try EVAL(try READ(str), repl_env))
 }
 
@@ -240,8 +240,8 @@ try repl_env.set(MalVal.MalSymbol("eval"),
 let pargs = Process.arguments.map { MalVal.MalString($0) }
 // TODO: weird way to get empty list, fix this
 var args = pargs[pargs.startIndex..<pargs.startIndex]
-if pargs.startIndex.advancedBy(2) < pargs.endIndex {
-    args = pargs[pargs.startIndex.advancedBy(2)..<pargs.endIndex]
+if pargs.index(pargs.startIndex, offsetBy:2) < pargs.endIndex {
+    args = pargs[pargs.index(pargs.startIndex, offsetBy:2)..<pargs.endIndex]
 }
 try repl_env.set(MalVal.MalSymbol("*ARGV*"), list(Array(args)))
 
@@ -262,7 +262,7 @@ if Process.arguments.count > 1 {
 
 while true {
     print("user> ", terminator: "")
-    let line = readLine(stripNewline: true)
+    let line = readLine(strippingNewline: true)
     if line == nil { break }
     if line == "" { continue }
 


### PR DESCRIPTION
Main changes:
* consistency of func arguments, while every argument has both an outer and an inner name,
  but the first argument's outer was "unnamed" by default in swift<2. now all arguments are consistent
  and requires the initial "_" to declare the outer "unnamed" for the first argument
* indexes are now simpler types, the Array.index function computes successor/predecessor
* many, many API changes, that result in shorter "verb" names of functions with named arguments
  ex: Array.joinWithSeparator(String) -> Array.joined(separator: String)