### PR TITLE
Ada patches sep16

### DIFF
--- a/ada/Makefile
+++ b/ada/Makefile
@@ -1,36 +1,22 @@
 DIRS=obj
 PROGS=step0_repl step1_read_print step2_eval step3_env step4_if_fn_do \
-      step5_tco step6_file step7_quote step8_macros step9_try stepA_mal
+      step5_tco step6_file step7_quote step8_macros step9_try
 
-STEP0_DEPS=${DIRS}
-STEP1_DEPS=${STEP0_DEPS} types.ad[bs] types-vector.ad[bs] types-hash_map.ad[bs] \
-	   reader.ad[bs] printer.ad[bs] smart_pointers.ad[bs]
-STEP2_DEPS=${STEP1_DEPS}
-STEP3_DEPS=${STEP2_DEPS} envs.ad[bs] eval_callback.ads
-STEP4_DEPS=${STEP3_DEPS} core.ad[bs]
+SOURCES_LISP=envs.ad[bs] eval_callback.ads core.ad[bs] stepa_mal.adb
+SOURCES=$(SOURCES_LISP) \
+        types.ad[bs] types-vector.ad[bs] types-hash_map.ad[bs] \
+	reader.ad[bs] printer.ad[bs] smart_pointers.ad[bs]
 
-SOURCES = $(filter-out $(STEP0_DEPS),$(STEP4_DEPS)) stepa_mal.adb
-SOURCES_LISP = $(filter-out $(STEP2_DEPS),$(SOURCES))
-
-all:	${DIRS} ${PROGS}
+all:	${DIRS} ${PROGS} stepA_mal
 
 ${DIRS}:
 	mkdir -p $@
 
-step%:
+# stepA_mal is awkward because GNAT requires the filename to be lowercase
+${PROGS} stepa_mal:	force
 	gnatmake -O3 -gnata $@.adb -D obj
 
-step0_repl:	step0_repl.adb ${STEP0_DEPS}
-step1_read_print:	step1_read_print.adb ${STEP1_DEPS}
-step2_eval:	step2_eval.adb ${STEP2_DEPS}
-step3_env:	step3_env.adb eval_callback.ads ${STEP3_DEPS}
-step4_if_fn_do:	step4_if_fn_do.adb ${STEP4_DEPS}
-step5_tco:	step5_tco.adb ${STEP4_DEPS}
-step6_file:	step6_file.adb ${STEP4_DEPS}
-step7_quote:	step7_quote.adb ${STEP4_DEPS}
-step8_macros:	step8_macros.adb ${STEP4_DEPS}
-step9_try:	step9_try.adb ${STEP4_DEPS}
-stepa_mal:	stepa_mal.adb ${STEP4_DEPS}
+# so we make stepa_mal and just move it.
 stepA_mal:	stepa_mal
 	mv $< $@
 
@@ -38,7 +24,7 @@ clean:
 	rm -f ${PROGS}
 	rm -rf obj
 
-.PHONY: stats stats-lisp
+.PHONY: stats stats-lisp force
 
 stats: $(SOURCES)
 	@wc $^
@@ -48,3 +34,4 @@ stats-lisp: $(SOURCES_LISP)
 	@wc $^
 	@printf "%5s %5s %5s %s\n" `grep -E "^[[:space:]]*--|^[[:space:]]*$$" $^ | wc` "[comments/blanks]"
 
+force:

--- a/ada/Makefile
+++ b/ada/Makefile
@@ -9,7 +9,7 @@ STEP2_DEPS=${STEP1_DEPS}
 STEP3_DEPS=${STEP2_DEPS} envs.ad[bs] eval_callback.ads
 STEP4_DEPS=${STEP3_DEPS} core.ad[bs]
 
-SOURCES = $(filter-out $(STEP0_DEPS),$(STEP4_DEPS)) stepA_mal.gpr stepa_mal.adb
+SOURCES = $(filter-out $(STEP0_DEPS),$(STEP4_DEPS)) stepa_mal.adb
 SOURCES_LISP = $(filter-out $(STEP2_DEPS),$(SOURCES))
 
 all:	${DIRS} ${PROGS}
@@ -18,7 +18,7 @@ ${DIRS}:
 	mkdir -p $@
 
 step%:
-	gnatmake -O3 -gnata -o $@ -P$@
+	gnatmake -O3 -gnata $@.adb -D obj
 
 step0_repl:	step0_repl.adb ${STEP0_DEPS}
 step1_read_print:	step1_read_print.adb ${STEP1_DEPS}
@@ -30,7 +30,9 @@ step6_file:	step6_file.adb ${STEP4_DEPS}
 step7_quote:	step7_quote.adb ${STEP4_DEPS}
 step8_macros:	step8_macros.adb ${STEP4_DEPS}
 step9_try:	step9_try.adb ${STEP4_DEPS}
-stepA_mal:	stepa_mal.adb ${STEP4_DEPS}
+stepa_mal:	stepa_mal.adb ${STEP4_DEPS}
+stepA_mal:	stepa_mal
+	mv $< $@
 
 clean:
 	rm -f ${PROGS}

--- a/ada/core.adb
+++ b/ada/core.adb
@@ -30,9 +30,9 @@ package body Core is
       Res : Boolean;
    begin
       case Deref (MH).Sym_Type is
-         when Bool => 
+         when Bool =>
             Res := Deref_Bool (MH).Get_Bool;
-         when Nil => 
+         when Nil =>
             Res := False;
 --         when List =>
 --            declare
@@ -489,7 +489,7 @@ package body Core is
                 ((1 => Func_Handle,
                   2 => Make_New_List
                          ((1 => Car (Deref_List_Class (List_Handle).all)))));
- 
+
             List_Handle := Cdr (Deref_List_Class (List_Handle).all);
 
             Append
@@ -838,16 +838,13 @@ package body Core is
    return Types.Mal_Handle is
       Rest_List : Types.List_Mal_Type;
       First_Param : Mal_Handle;
-      S : String (1..Reader.Max_Line_Len);
-      Last : Natural;
    begin
       Rest_List := Deref_List (Rest_Handle).all;
       First_Param := Car (Rest_List);
       -- Output the prompt.
       Ada.Text_IO.Put (Deref_String (First_Param).Get_String);
       -- Get the text.
-      Ada.Text_IO.Get_Line (S, Last);
-      return New_String_Mal_Type (S (1 .. Last));
+      return New_String_Mal_Type (Ada.Text_IO.Get_Line);
    end Read_Line;
 
 
@@ -862,19 +859,20 @@ package body Core is
          Unquoted_Str : String := Deref_String (First_Param).Get_String;
          use Ada.Text_IO;
          Fn : Ada.Text_IO.File_Type;
-         Line_Str : String (1..Reader.Max_Line_Len);
          File_Str : Ada.Strings.Unbounded.Unbounded_String :=
            Ada.Strings.Unbounded.Null_Unbounded_String;
-         Last : Natural;
          I : Natural := 0;
       begin
          Ada.Text_IO.Open (Fn, In_File, Unquoted_Str);
          while not End_Of_File (Fn) loop
-            Get_Line (Fn, Line_Str, Last);
-            if Last > 0 then
-               Ada.Strings.Unbounded.Append (File_Str, Line_Str (1 .. Last));
-               Ada.Strings.Unbounded.Append (File_Str, Ada.Characters.Latin_1.LF);
-            end if;
+            declare
+               Line_Str : constant String := Get_Line (Fn);
+            begin
+               if Line_Str'Length > 0 then
+                  Ada.Strings.Unbounded.Append (File_Str, Line_Str);
+                  Ada.Strings.Unbounded.Append (File_Str, Ada.Characters.Latin_1.LF);
+               end if;
+            end;
          end loop;
          Ada.Text_IO.Close (Fn);
          return New_String_Mal_Type (Ada.Strings.Unbounded.To_String (File_Str));

--- a/ada/reader.ads
+++ b/ada/reader.ads
@@ -2,11 +2,9 @@ with Types;
 
 package Reader is
 
-   Max_Line_Len : constant := 2048;
-
    -- This is the Parser (returns an AST)
    function Read_Str (S : String) return Types.Mal_Handle;
-   
+
 private
 
    procedure Lex_Init (S : String);

--- a/ada/step0_repl.adb
+++ b/ada/step0_repl.adb
@@ -1,5 +1,4 @@
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 
 procedure Step0_Repl is
 
@@ -24,20 +23,12 @@ procedure Step0_Repl is
       Print_Str : String := Print (Eval_Str);
    begin
       return Print_Str;
-   end Rep; 
-
-   S : String (1..1024);
-   Last : Natural;
+   end Rep;
 
 begin
-
    loop
       Ada.Text_IO.Put ("user> ");
-      Ada.Text_IO.Get_Line (S, Last);
-      Ada.Text_IO.Put_Line (Rep (S (1..Last)));
+      exit when Ada.Text_IO.End_Of_File;
+      Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line));
    end loop;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step0_Repl;

--- a/ada/step0_repl.gpr
+++ b/ada/step0_repl.gpr
@@ -1,7 +1,0 @@
-project Step0_Repl is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step0_repl.adb");
-
-end Step0_Repl;

--- a/ada/step1_read_print.adb
+++ b/ada/step1_read_print.adb
@@ -1,5 +1,4 @@
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Printer;
 with Reader;
 with Types;
@@ -34,20 +33,12 @@ procedure Step1_Read_Print is
          return Print (Evaluated_AST);
       end if;
 
-   end Rep; 
-
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
+   end Rep;
 
 begin
-
    loop
       Ada.Text_IO.Put ("user> ");
-      Ada.Text_IO.Get_Line (S, Last);
-      Ada.Text_IO.Put_Line (Rep (S (1..Last)));
+      exit when Ada.Text_IO.End_Of_File;
+      Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line));
    end loop;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step1_Read_Print;

--- a/ada/step1_read_print.gpr
+++ b/ada/step1_read_print.gpr
@@ -1,7 +1,0 @@
-project Step1_Read_Print is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step1_read_print.adb");
-
-end Step1_Read_Print;

--- a/ada/step2_eval.adb
+++ b/ada/step2_eval.adb
@@ -1,7 +1,6 @@
 with Ada.Containers.Hashed_Maps;
 with Ada.Strings.Unbounded.Hash;
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Ada.Exceptions;
 with Printer;
 with Reader;
@@ -198,11 +197,7 @@ procedure Step2_Eval is
         return Print (Evaluated_AST);
      end if;
 
-   end Rep; 
-
-
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
+   end Rep;
 
 begin
 
@@ -229,18 +224,13 @@ begin
    loop
       begin
          Ada.Text_IO.Put ("user> ");
-         Ada.Text_IO.Get_Line (S, Last);
-         Ada.Text_IO.Put_Line (Rep (S (1..Last), Repl_Env));
+         exit when Ada.Text_IO.End_Of_File;
+         Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line, Repl_Env));
       exception
-         when Ada.IO_Exceptions.End_Error => raise;
          when E : others =>
             Ada.Text_IO.Put_Line
               (Ada.Text_IO.Standard_Error,
                Ada.Exceptions.Exception_Information (E));
       end;
    end loop;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step2_Eval;

--- a/ada/step2_eval.gpr
+++ b/ada/step2_eval.gpr
@@ -1,7 +1,0 @@
-project Step2_Eval is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step2_eval.adb");
-
-end Step2_Eval;

--- a/ada/step3_env.adb
+++ b/ada/step3_env.adb
@@ -1,6 +1,5 @@
 with Ada.Command_Line;
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Envs;
 with Eval_Callback;
 with Printer;
@@ -211,7 +210,7 @@ procedure Step3_Env is
          return Print (Evaluated_AST);
       end if;
 
-   end Rep; 
+   end Rep;
 
 
    procedure Init (Env : Envs.Env_Handle) is
@@ -237,9 +236,6 @@ procedure Step3_Env is
 
 
    Repl_Env : Envs.Env_Handle;
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
-
 begin
 
    -- Save a function pointer back to the Eval function.
@@ -259,11 +255,7 @@ begin
 
    loop
       Ada.Text_IO.Put ("user> ");
-      Ada.Text_IO.Get_Line (S, Last);
-      Ada.Text_IO.Put_Line (Rep (S (1..Last), Repl_Env));
+      exit when Ada.Text_IO.End_Of_File;
+      Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line, Repl_Env));
    end loop;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step3_Env;

--- a/ada/step3_env.gpr
+++ b/ada/step3_env.gpr
@@ -1,7 +1,0 @@
-project Step3_Env is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step3_env.adb");
-
-end Step3_Env;

--- a/ada/step4_if_fn_do.adb
+++ b/ada/step4_if_fn_do.adb
@@ -1,7 +1,6 @@
 with Ada.Command_Line;
 with Ada.Exceptions;
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Core;
 with Envs;
 with Eval_Callback;
@@ -75,7 +74,7 @@ procedure Step4_If_Fn_Do is
       Res : Boolean;
    begin
       case Deref (MH).Sym_Type is
-         when Bool => 
+         when Bool =>
             Res := Deref_Bool (MH).Get_Bool;
          when Nil =>
             return False;
@@ -263,7 +262,7 @@ procedure Step4_If_Fn_Do is
          return Print (Evaluated_AST);
       end if;
 
-   end Rep; 
+   end Rep;
 
 
    Repl_Env : Envs.Env_Handle;
@@ -279,8 +278,6 @@ procedure Step4_If_Fn_Do is
    end RE;
 
 
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
    Cmd_Args : Natural;
 
 begin
@@ -309,18 +306,13 @@ begin
    loop
       begin
          Ada.Text_IO.Put ("user> ");
-         Ada.Text_IO.Get_Line (S, Last);
-         Ada.Text_IO.Put_Line (Rep (S (1..Last), Repl_Env));
+         exit when Ada.Text_IO.End_Of_File;
+         Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line, Repl_Env));
       exception
-         when Ada.IO_Exceptions.End_Error => raise;
          when E : others =>
             Ada.Text_IO.Put_Line
               (Ada.Text_IO.Standard_Error,
                Ada.Exceptions.Exception_Information (E));
       end;
    end loop;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step4_If_Fn_Do;

--- a/ada/step4_if_fn_do.gpr
+++ b/ada/step4_if_fn_do.gpr
@@ -1,7 +1,0 @@
-project Step4_If_Fn_Do is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step4_if_fn_do.adb");
-
-end Step4_If_Fn_Do;

--- a/ada/step5_tco.adb
+++ b/ada/step5_tco.adb
@@ -1,7 +1,6 @@
 with Ada.Command_Line;
 with Ada.Exceptions;
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Core;
 with Envs;
 with Eval_Callback;
@@ -44,7 +43,7 @@ procedure Step5_TCO is
       Res : Boolean;
    begin
       case Deref (MH).Sym_Type is
-         when Bool => 
+         when Bool =>
             Res := Deref_Bool (MH).Get_Bool;
          when Nil =>
             return False;
@@ -261,7 +260,7 @@ procedure Step5_TCO is
 			Param := L.Get_Expr;
                         Env := E;
 			goto Tail_Call_Opt;
-                        -- was: return Eval (L.Get_Expr, E); 
+                        -- was: return Eval (L.Get_Expr, E);
 
                      else
 
@@ -306,7 +305,7 @@ procedure Step5_TCO is
         return Print (Evaluated_AST);
      end if;
 
-   end Rep; 
+   end Rep;
 
    Repl_Env : Envs.Env_Handle;
 
@@ -331,9 +330,6 @@ procedure Step5_TCO is
       return Eval_Callback.Eval.all (First_Param, Repl_Env);
    end Do_Eval;
 
-
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
    Cmd_Args : Natural;
 
 begin
@@ -362,18 +358,13 @@ begin
    loop
       begin
          Ada.Text_IO.Put ("user> ");
-         Ada.Text_IO.Get_Line (S, Last);
-         Ada.Text_IO.Put_Line (Rep (S (1..Last), Repl_Env));
+         exit when Ada.Text_IO.End_Of_File;
+         Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line, Repl_Env));
       exception
-         when Ada.IO_Exceptions.End_Error => raise;
          when E : others =>
             Ada.Text_IO.Put_Line
               (Ada.Text_IO.Standard_Error,
                Ada.Exceptions.Exception_Information (E));
       end;
    end loop;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step5_TCO;

--- a/ada/step5_tco.gpr
+++ b/ada/step5_tco.gpr
@@ -1,7 +1,0 @@
-project Step5_TCO is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step5_tco.adb");
-
-end Step5_TCO;

--- a/ada/step6_file.adb
+++ b/ada/step6_file.adb
@@ -1,7 +1,6 @@
 with Ada.Command_Line;
 with Ada.Exceptions;
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Core;
 with Envs;
 with Eval_Callback;
@@ -49,7 +48,7 @@ procedure Step6_File is
       Res : Boolean;
    begin
       case Deref (MH).Sym_Type is
-         when Bool => 
+         when Bool =>
             Res := Deref_Bool (MH).Get_Bool;
          when Nil =>
             return False;
@@ -266,7 +265,7 @@ procedure Step6_File is
 			Param := L.Get_Expr;
                         Env := E;
 			goto Tail_Call_Opt;
-                        -- was: return Eval (L.Get_Expr, E); 
+                        -- was: return Eval (L.Get_Expr, E);
 
                      else
 
@@ -312,7 +311,7 @@ procedure Step6_File is
          return Print (Evaluated_AST);
       end if;
 
-   end Rep; 
+   end Rep;
 
 
    Repl_Env : Envs.Env_Handle;
@@ -339,8 +338,6 @@ procedure Step6_File is
    end Do_Eval;
 
 
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
    Cmd_Args, File_Param : Natural;
    Command_Args : Types.Mal_Handle;
    Command_List : Types.List_Ptr;
@@ -396,10 +393,9 @@ begin
       loop
          begin
             Ada.Text_IO.Put ("user> ");
-            Ada.Text_IO.Get_Line (S, Last);
-            Ada.Text_IO.Put_Line (Rep (S (1..Last), Repl_Env));
+            exit when Ada.Text_IO.End_Of_File;
+            Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line, Repl_Env));
          exception
-            when Ada.IO_Exceptions.End_Error => raise;
             when E : others =>
                Ada.Text_IO.Put_Line
                  (Ada.Text_IO.Standard_Error,
@@ -407,8 +403,4 @@ begin
          end;
       end loop;
    end if;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step6_File;

--- a/ada/step6_file.gpr
+++ b/ada/step6_file.gpr
@@ -1,7 +1,0 @@
-project Step6_File is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step6_file.adb");
-
-end Step6_File;

--- a/ada/step7_quote.adb
+++ b/ada/step7_quote.adb
@@ -1,7 +1,6 @@
 with Ada.Command_Line;
 with Ada.Exceptions;
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Core;
 with Envs;
 with Eval_Callback;
@@ -44,7 +43,7 @@ procedure Step7_Quote is
       Res : Boolean;
    begin
       case Deref (MH).Sym_Type is
-         when Bool => 
+         when Bool =>
             Res := Deref_Bool (MH).Get_Bool;
          when Nil =>
             return False;
@@ -357,7 +356,7 @@ procedure Step7_Quote is
 			Param := L.Get_Expr;
                         Env := E;
 			goto Tail_Call_Opt;
-                        -- was: return Eval (L.Get_Expr, E); 
+                        -- was: return Eval (L.Get_Expr, E);
 
                      else
 
@@ -402,7 +401,7 @@ procedure Step7_Quote is
          return Print (Evaluated_AST);
       end if;
 
-   end Rep; 
+   end Rep;
 
 
    Repl_Env : Envs.Env_Handle;
@@ -429,8 +428,6 @@ procedure Step7_Quote is
    end Do_Eval;
 
 
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
    Cmd_Args, File_Param : Natural;
    Command_Args : Types.Mal_Handle;
    Command_List : Types.List_Ptr;
@@ -486,10 +483,9 @@ begin
       loop
          begin
             Ada.Text_IO.Put ("user> ");
-            Ada.Text_IO.Get_Line (S, Last);
-            Ada.Text_IO.Put_Line (Rep (S (1..Last), Repl_Env));
+            exit when Ada.Text_IO.End_Of_File;
+            Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line, Repl_Env));
          exception
-            when Ada.IO_Exceptions.End_Error => raise;
             when E : others =>
                Ada.Text_IO.Put_Line
                  (Ada.Text_IO.Standard_Error,
@@ -497,8 +493,4 @@ begin
          end;
       end loop;
    end if;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step7_Quote;

--- a/ada/step7_quote.gpr
+++ b/ada/step7_quote.gpr
@@ -1,7 +1,0 @@
-project Step7_Quote is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step7_quote.adb");
-
-end Step7_Quote;

--- a/ada/step8_macros.adb
+++ b/ada/step8_macros.adb
@@ -1,7 +1,6 @@
 with Ada.Command_Line;
 with Ada.Exceptions;
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Core;
 with Envs;
 with Eval_Callback;
@@ -91,7 +90,7 @@ procedure Step8_Macros is
 	     Params := Deref_List (LP.Get_Params).all;
 	     if Envs.Bind (E, Params, Deref_List (Fn_List).all) then
 
-	        Res := Eval (LP.Get_Expr, E); 
+	        Res := Eval (LP.Get_Expr, E);
 
              end if;
 
@@ -108,7 +107,7 @@ procedure Step8_Macros is
       Res : Boolean;
    begin
       case Deref (MH).Sym_Type is
-         when Bool => 
+         when Bool =>
             Res := Deref_Bool (MH).Get_Bool;
          when Nil =>
             return False;
@@ -476,7 +475,7 @@ procedure Step8_Macros is
          return Print (Evaluated_AST);
       end if;
 
-   end Rep; 
+   end Rep;
 
 
    Repl_Env : Envs.Env_Handle;
@@ -503,8 +502,6 @@ procedure Step8_Macros is
    end Do_Eval;
 
 
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
    Cmd_Args, File_Param : Natural;
    Command_Args : Types.Mal_Handle;
    Command_List : Types.List_Ptr;
@@ -561,10 +558,9 @@ begin
       loop
          begin
             Ada.Text_IO.Put ("user> ");
-            Ada.Text_IO.Get_Line (S, Last);
-            Ada.Text_IO.Put_Line (Rep (S (1..Last), Repl_Env));
+            exit when Ada.Text_IO.End_Of_Line;
+            Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line, Repl_Env));
          exception
-            when Ada.IO_Exceptions.End_Error => raise;
             when E : others =>
                Ada.Text_IO.Put_Line
                  (Ada.Text_IO.Standard_Error,
@@ -572,8 +568,4 @@ begin
          end;
       end loop;
    end if;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step8_Macros;

--- a/ada/step8_macros.gpr
+++ b/ada/step8_macros.gpr
@@ -1,7 +1,0 @@
-project Step8_Macros is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step8_macros.adb");
-
-end Step8_Macros;

--- a/ada/step9_try.adb
+++ b/ada/step9_try.adb
@@ -1,7 +1,6 @@
 with Ada.Command_Line;
 with Ada.Exceptions;
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Core;
 with Envs;
 with Eval_Callback;
@@ -91,7 +90,7 @@ procedure Step9_Try is
 	     Params := Deref_List (LP.Get_Params).all;
 	     if Envs.Bind (E, Params, Deref_List (Fn_List).all) then
 
-	        Res := Eval (LP.Get_Expr, E); 
+	        Res := Eval (LP.Get_Expr, E);
 
              end if;
 
@@ -108,7 +107,7 @@ procedure Step9_Try is
       Res : Boolean;
    begin
       case Deref (MH).Sym_Type is
-         when Bool => 
+         when Bool =>
             Res := Deref_Bool (MH).Get_Bool;
          when Nil =>
             return False;
@@ -526,7 +525,7 @@ procedure Step9_Try is
          return Print (Evaluated_AST);
       end if;
 
-   end Rep; 
+   end Rep;
 
 
    Repl_Env : Envs.Env_Handle;
@@ -553,8 +552,6 @@ procedure Step9_Try is
    end Do_Eval;
 
 
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
    Cmd_Args, File_Param : Natural;
    Command_Args : Types.Mal_Handle;
    Command_List : Types.List_Ptr;
@@ -611,10 +608,9 @@ begin
       loop
          begin
             Ada.Text_IO.Put ("user> ");
-            Ada.Text_IO.Get_Line (S, Last);
-            Ada.Text_IO.Put_Line (Rep (S (1..Last), Repl_Env));
+            exit when Ada.Text_IO.End_Of_File;
+            Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line, Repl_Env));
          exception
-            when Ada.IO_Exceptions.End_Error => raise;
             when E : others =>
                Ada.Text_IO.Put_Line
                  (Ada.Text_IO.Standard_Error,
@@ -622,8 +618,4 @@ begin
          end;
       end loop;
    end if;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end Step9_Try;

--- a/ada/step9_try.gpr
+++ b/ada/step9_try.gpr
@@ -1,7 +1,0 @@
-project Step9_Try is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("step9_try.adb");
-
-end Step9_Try;

--- a/ada/stepA_mal.gpr
+++ b/ada/stepA_mal.gpr
@@ -1,7 +1,0 @@
-project StepA_Mal is
-
-   for Object_Dir use "obj";
-   for Exec_Dir use ".";
-   for Main use ("stepa_mal.adb");
-
-end StepA_Mal;

--- a/ada/stepa_mal.adb
+++ b/ada/stepa_mal.adb
@@ -1,7 +1,6 @@
 with Ada.Command_Line;
 with Ada.Exceptions;
 with Ada.Text_IO;
-with Ada.IO_Exceptions;
 with Core;
 with Envs;
 with Eval_Callback;
@@ -527,7 +526,7 @@ procedure StepA_Mal is
         return Print (Evaluated_AST);
      end if;
 
-   end Rep; 
+   end Rep;
 
 
    Repl_Env : Envs.Env_Handle;
@@ -554,8 +553,6 @@ procedure StepA_Mal is
    end Do_Eval;
 
 
-   S : String (1..Reader.Max_Line_Len);
-   Last : Natural;
    Cmd_Args, File_Param : Natural;
    Command_Args : Types.Mal_Handle;
    Command_List : Types.List_Ptr;
@@ -617,10 +614,9 @@ begin
       loop
          begin
             Ada.Text_IO.Put ("user> ");
-            Ada.Text_IO.Get_Line (S, Last);
-            Ada.Text_IO.Put_Line (Rep (S (1..Last), Repl_Env));
+            exit when Ada.Text_IO.End_Of_File;
+            Ada.Text_IO.Put_Line (Rep (Ada.Text_IO.Get_Line, Repl_Env));
          exception
-            when Ada.IO_Exceptions.End_Error => raise;
             when E : others =>
                Ada.Text_IO.Put_Line
                  (Ada.Text_IO.Standard_Error,
@@ -628,8 +624,4 @@ begin
          end;
       end loop;
    end if;
-
-exception
-   when Ada.IO_Exceptions.End_Error => null;
-   -- i.e. exit without textual output
 end StepA_Mal;


### PR DESCRIPTION
Hi,

I recently received four PATCHes from Nicholas Boulenguez :
0001-Replace-all-GNAT-projects-with-D-gnatmake-option.patch - Removes project files and changes the Makefile to compensate.  Applied with some changes for stepA_mal.
0002-Delegate-obj-directory-creatinon-to-gnatmake-p-optio.patch - Doesn't work because of patch 0001!
0003-Delegate-Ada-dependency-handling-to-gnatmake-instead.patch - gnatmake works out its own dependencies so there's no need to repeat them in the Makefile.  Applied in spirit.
0004-Use-Get_Line-fonction-instead-of-insisting-on-a-maxi.patch - Removes explicit limit on string length.  Applied with some minor changes.

Both sets of tests pass.  I compared the stats before and after 0003.  They were the same.
Regards,
Chris
