### PR TITLE
Vimscript: Use Vim 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,8 +814,7 @@ make
 
 *The Vimscript implementation was created by [Dov Murik](https://github.com/dubek)*
 
-The Vimscript implementation of mal requires Vim to run.  It has been tested
-with Vim 7.4.
+The Vimscript implementation of mal requires Vim 8.0 to run.
 
 ```
 cd vimscript

--- a/vimscript/Dockerfile
+++ b/vimscript/Dockerfile
@@ -24,4 +24,11 @@ WORKDIR /mal
 # To build the readline plugin
 RUN apt-get -y install g++
 
-RUN apt-get -y install vim
+# Vim 8.0
+RUN apt-get -y install bzip2
+RUN cd /tmp && curl -O ftp://ftp.vim.org/pub/vim/unix/vim-8.0.tar.bz2 \
+    && tar xjf /tmp/vim-8.0.tar.bz2 \
+    && cd vim80 && make && make install \
+    && cd /tmp && rm -r /tmp/vim-8.0.tar.bz2 /tmp/vim80
+
+ENV HOME /mal

--- a/vimscript/core.vim
+++ b/vimscript/core.vim
@@ -1,82 +1,5 @@
 " core module
 
-function MalEqualQ(args)
-  return BoolNew(EqualQ(a:args[0], a:args[1]))
-endfunction
-
-function MalLt(args)
-  return BoolNew(ObjValue(a:args[0]) < ObjValue(a:args[1]))
-endfunction
-
-function MalLte(args)
-  return BoolNew(ObjValue(a:args[0]) <= ObjValue(a:args[1]))
-endfunction
-
-function MalGt(args)
-  return BoolNew(ObjValue(a:args[0]) > ObjValue(a:args[1]))
-endfunction
-
-function MalGte(args)
-  return BoolNew(ObjValue(a:args[0]) >= ObjValue(a:args[1]))
-endfunction
-
-function MalAdd(args)
-  return IntegerNew(ObjValue(a:args[0]) + ObjValue(a:args[1]))
-endfunction
-
-function MalSub(args)
-  return IntegerNew(ObjValue(a:args[0]) - ObjValue(a:args[1]))
-endfunction
-
-function MalMul(args)
-  return IntegerNew(ObjValue(a:args[0]) * ObjValue(a:args[1]))
-endfunction
-
-function MalDiv(args)
-  return IntegerNew(ObjValue(a:args[0]) / ObjValue(a:args[1]))
-endfunction
-
-function MalTimeMs(args)
-  " vimtimems() is implemented in vimextras.c
-  return IntegerNew(libcallnr("libvimextras.so", "vimtimems", 0))
-endfunction
-
-function MalList(args)
-  return ListNew(a:args)
-endfunction
-
-function MalListQ(args)
-  return BoolNew(ListQ(a:args[0]))
-endfunction
-
-function MalVector(args)
-  return VectorNew(a:args)
-endfunction
-
-function MalVectorQ(args)
-  return BoolNew(VectorQ(a:args[0]))
-endfunction
-
-function MalSequentialQ(args)
-  return BoolNew(SequentialQ(a:args[0]))
-endfunction
-
-function MalHashMap(args)
-  return HashBuild(a:args)
-endfunction
-
-function MalMapQ(args)
-  return BoolNew(HashQ(a:args[0]))
-endfunction
-
-function MalEmptyQ(args)
-  return BoolNew(EmptyQ(a:args[0]))
-endfunction
-
-function MalCount(args)
-  return IntegerNew(ListCount(a:args[0]))
-endfunction
-
 function MalAssoc(args)
   let hash = copy(ObjValue(a:args[0]))
   let new_elements = HashBuild(a:args[1:])
@@ -122,41 +45,9 @@ function MalKeys(args)
   return ListNew(listobjs)
 endfunction
 
-function MalVals(args)
-  return ListNew(values(ObjValue(a:args[0])))
-endfunction
-
-function MalPrStr(args)
-  return StringNew(join(map(copy(a:args), 'PrStr(v:val, 1)'), " "))
-endfunction
-
-function MalStr(args)
-  return StringNew(join(map(copy(a:args), 'PrStr(v:val, 0)'), ""))
-endfunction
-
-function MalPrn(args)
-  call PrintLn(join(map(copy(a:args), 'PrStr(v:val, 1)'), " "))
-  return g:MalNil
-endfunction
-
-function MalPrintLn(args)
-  call PrintLn(join(map(copy(a:args), 'PrStr(v:val, 0)'), " "))
-  return g:MalNil
-endfunction
-
-function MalReadString(args)
-  return ReadStr(ObjValue(a:args[0]))
-endfunction
-
 function MalReadLine(args)
   let [eof, line] = Readline(ObjValue(a:args[0]))
   return eof ? g:MalNil : StringNew(line)
-endfunction
-
-function MalSlurp(args)
-  let filename = ObjValue(a:args[0])
-  let lines = readfile(filename, "b")
-  return StringNew(join(lines, "\n"))
 endfunction
 
 function MalCons(args)
@@ -171,18 +62,6 @@ function MalConcat(args)
     let res = res + ObjValue(list)
   endfor
   return ListNew(res)
-endfunction
-
-function MalFirst(args)
-  return NilQ(a:args[0]) ? g:MalNil : ListFirst(a:args[0])
-endfunction
-
-function MalNth(args)
-  return ListNth(a:args[0], ObjValue(a:args[1]))
-endfunction
-
-function MalRest(args)
-  return NilQ(a:args[0]) ? ListNew([]) : ListRest(a:args[0])
 endfunction
 
 function MalApply(args)
@@ -227,38 +106,6 @@ function MalThrow(args)
   throw "__MalException__"
 endfunction
 
-function MalNilQ(args)
-  return BoolNew(NilQ(a:args[0]))
-endfunction
-
-function MalTrueQ(args)
-  return BoolNew(TrueQ(a:args[0]))
-endfunction
-
-function MalFalseQ(args)
-  return BoolNew(FalseQ(a:args[0]))
-endfunction
-
-function MalSymbol(args)
-  return SymbolNew(ObjValue(a:args[0]))
-endfunction
-
-function MalSymbolQ(args)
-  return BoolNew(SymbolQ(a:args[0]))
-endfunction
-
-function MalStringQ(args)
-  return BoolNew(StringQ(a:args[0]))
-endfunction
-
-function MalKeyword(args)
-  return KeywordNew(ObjValue(a:args[0]))
-endfunction
-
-function MalKeywordQ(args)
-  return BoolNew(KeywordQ(a:args[0]))
-endfunction
-
 function ConjList(list, elements)
   let newlist = a:list
   for e in a:elements
@@ -292,42 +139,9 @@ function MalSeq(args)
   elseif VectorQ(obj)
     return ListNew(ObjValue(obj))
   elseif StringQ(obj)
-    return ListNew(map(split(ObjValue(obj), '\zs'), 'StringNew(v:val)'))
+    return ListNew(map(split(ObjValue(obj), '\zs'), {_, c -> StringNew(c)}))
   endif
   throw "seq requires string or list or vector or nil"
-endfunction
-
-function MalMeta(args)
-  return ObjMeta(a:args[0])
-endfunction
-
-function MalWithMeta(args)
-  let obj = a:args[0]
-  return ObjNewWithMeta(ObjType(obj), copy(ObjValue(obj)), a:args[1])
-endfunction
-
-function MalAtom(args)
-  return AtomNew(a:args[0])
-endfunction
-
-function MalAtomQ(args)
-  return BoolNew(AtomQ(a:args[0]))
-endfunction
-
-function MalDeref(args)
-  return ObjValue(a:args[0])
-endfunction
-
-function MalResetBang(args)
-  return ObjSetValue(a:args[0], a:args[1])
-endfunction
-
-function MalSwapBang(args)
-  let atomval = ObjValue(a:args[0])
-  let funcobj = a:args[1]
-  let args = a:args[2:]
-  let res = MalApply([funcobj, ListNew([atomval] + args)])
-  return ObjSetValue(a:args[0], res)
 endfunction
 
 function VimToMal(e)
@@ -355,69 +169,63 @@ function VimToMal(e)
   endif
 endfunction
 
-function MalVimStar(args)
-  let vimexpr = ObjValue(a:args[0])
-  let vimres = eval(vimexpr)
-  return VimToMal(vimres)
-endfunction
-
 let CoreNs = {
-  \ "=":           NewNativeFn("MalEqualQ"),
-  \ "<":           NewNativeFn("MalLt"),
-  \ "<=":          NewNativeFn("MalLte"),
-  \ ">":           NewNativeFn("MalGt"),
-  \ ">=":          NewNativeFn("MalGte"),
-  \ "+":           NewNativeFn("MalAdd"),
-  \ "-":           NewNativeFn("MalSub"),
-  \ "*":           NewNativeFn("MalMul"),
-  \ "/":           NewNativeFn("MalDiv"),
-  \ "time-ms":     NewNativeFn("MalTimeMs"),
-  \ "nil?":        NewNativeFn("MalNilQ"),
-  \ "true?":       NewNativeFn("MalTrueQ"),
-  \ "false?":      NewNativeFn("MalFalseQ"),
-  \ "symbol":      NewNativeFn("MalSymbol"),
-  \ "symbol?":     NewNativeFn("MalSymbolQ"),
-  \ "string?":     NewNativeFn("MalStringQ"),
-  \ "keyword":     NewNativeFn("MalKeyword"),
-  \ "keyword?":    NewNativeFn("MalKeywordQ"),
-  \ "list":        NewNativeFn("MalList"),
-  \ "list?":       NewNativeFn("MalListQ"),
-  \ "vector":      NewNativeFn("MalVector"),
-  \ "vector?":     NewNativeFn("MalVectorQ"),
-  \ "sequential?": NewNativeFn("MalSequentialQ"),
-  \ "hash-map":    NewNativeFn("MalHashMap"),
-  \ "map?":        NewNativeFn("MalMapQ"),
-  \ "empty?":      NewNativeFn("MalEmptyQ"),
-  \ "count":       NewNativeFn("MalCount"),
+  \ "=":           NewNativeFnLambda({a -> BoolNew(EqualQ(a[0], a[1]))}),
+  \ "<":           NewNativeFnLambda({a -> BoolNew(ObjValue(a[0]) < ObjValue(a[1]))}),
+  \ "<=":          NewNativeFnLambda({a -> BoolNew(ObjValue(a[0]) <= ObjValue(a[1]))}),
+  \ ">":           NewNativeFnLambda({a -> BoolNew(ObjValue(a[0]) > ObjValue(a[1]))}),
+  \ ">=":          NewNativeFnLambda({a -> BoolNew(ObjValue(a[0]) >= ObjValue(a[1]))}),
+  \ "+":           NewNativeFnLambda({a -> IntegerNew(ObjValue(a[0]) + ObjValue(a[1]))}),
+  \ "-":           NewNativeFnLambda({a -> IntegerNew(ObjValue(a[0]) - ObjValue(a[1]))}),
+  \ "*":           NewNativeFnLambda({a -> IntegerNew(ObjValue(a[0]) * ObjValue(a[1]))}),
+  \ "/":           NewNativeFnLambda({a -> IntegerNew(ObjValue(a[0]) / ObjValue(a[1]))}),
+  \ "time-ms":     NewNativeFnLambda({a -> IntegerNew(libcallnr("libvimextras.so", "vimtimems", 0))}),
+  \ "nil?":        NewNativeFnLambda({a -> BoolNew(NilQ(a[0]))}),
+  \ "true?":       NewNativeFnLambda({a -> BoolNew(TrueQ(a[0]))}),
+  \ "false?":      NewNativeFnLambda({a -> BoolNew(FalseQ(a[0]))}),
+  \ "symbol":      NewNativeFnLambda({a -> SymbolNew(ObjValue(a[0]))}),
+  \ "symbol?":     NewNativeFnLambda({a -> BoolNew(SymbolQ(a[0]))}),
+  \ "string?":     NewNativeFnLambda({a -> BoolNew(StringQ(a[0]))}),
+  \ "keyword":     NewNativeFnLambda({a -> KeywordNew(ObjValue(a[0]))}),
+  \ "keyword?":    NewNativeFnLambda({a -> BoolNew(KeywordQ(a[0]))}),
+  \ "list":        NewNativeFnLambda({a -> ListNew(a)}),
+  \ "list?":       NewNativeFnLambda({a -> BoolNew(ListQ(a[0]))}),
+  \ "vector":      NewNativeFnLambda({a -> VectorNew(a)}),
+  \ "vector?":     NewNativeFnLambda({a -> BoolNew(VectorQ(a[0]))}),
+  \ "sequential?": NewNativeFnLambda({a -> BoolNew(SequentialQ(a[0]))}),
+  \ "hash-map":    NewNativeFnLambda({a -> HashBuild(a)}),
+  \ "map?":        NewNativeFnLambda({a -> BoolNew(HashQ(a[0]))}),
+  \ "empty?":      NewNativeFnLambda({a -> BoolNew(EmptyQ(a[0]))}),
+  \ "count":       NewNativeFnLambda({a -> IntegerNew(ListCount(a[0]))}),
   \ "assoc":       NewNativeFn("MalAssoc"),
   \ "dissoc":      NewNativeFn("MalDissoc"),
   \ "get":         NewNativeFn("MalGet"),
   \ "contains?":   NewNativeFn("MalContainsQ"),
   \ "keys":        NewNativeFn("MalKeys"),
-  \ "vals":        NewNativeFn("MalVals"),
-  \ "pr-str":      NewNativeFn("MalPrStr"),
-  \ "str":         NewNativeFn("MalStr"),
-  \ "prn":         NewNativeFn("MalPrn"),
-  \ "println":     NewNativeFn("MalPrintLn"),
-  \ "read-string": NewNativeFn("MalReadString"),
+  \ "vals":        NewNativeFnLambda({a -> ListNew(values(ObjValue(a[0])))}),
+  \ "pr-str":      NewNativeFnLambda({a -> StringNew(join(map(copy(a), {_, e -> PrStr(e, 1)}), " "))}),
+  \ "str":         NewNativeFnLambda({a -> StringNew(join(map(copy(a), {_, e -> PrStr(e, 0)}), ""))}),
+  \ "prn":         NewNativeFnLambda({a -> [PrintLn(join(map(copy(a), {_, e -> PrStr(e, 1)}), " ")), g:MalNil][1]}),
+  \ "println":     NewNativeFnLambda({a -> [PrintLn(join(map(copy(a), {_, e -> PrStr(e, 0)}), " ")), g:MalNil][1]}),
+  \ "read-string": NewNativeFnLambda({a -> ReadStr(ObjValue(a[0]))}),
   \ "readline":    NewNativeFn("MalReadLine"),
-  \ "slurp":       NewNativeFn("MalSlurp"),
+  \ "slurp":       NewNativeFnLambda({a -> StringNew(join(readfile(ObjValue(a[0]), "b"), "\n"))}),
   \ "cons":        NewNativeFn("MalCons"),
   \ "concat":      NewNativeFn("MalConcat"),
-  \ "first":       NewNativeFn("MalFirst"),
-  \ "nth":         NewNativeFn("MalNth"),
-  \ "rest":        NewNativeFn("MalRest"),
+  \ "first":       NewNativeFnLambda({a -> NilQ(a[0]) ? g:MalNil : ListFirst(a[0])}),
+  \ "nth":         NewNativeFnLambda({a -> ListNth(a[0], ObjValue(a[1]))}),
+  \ "rest":        NewNativeFnLambda({a -> NilQ(a[0]) ? ListNew([]) : ListRest(a[0])}),
   \ "apply":       NewNativeFn("MalApply"),
   \ "map":         NewNativeFn("MalMap"),
   \ "throw":       NewNativeFn("MalThrow"),
   \ "conj":        NewNativeFn("MalConj"),
   \ "seq":         NewNativeFn("MalSeq"),
-  \ "meta":        NewNativeFn("MalMeta"),
-  \ "with-meta":   NewNativeFn("MalWithMeta"),
-  \ "atom":        NewNativeFn("MalAtom"),
-  \ "atom?":       NewNativeFn("MalAtomQ"),
-  \ "deref":       NewNativeFn("MalDeref"),
-  \ "reset!":      NewNativeFn("MalResetBang"),
-  \ "swap!":       NewNativeFn("MalSwapBang"),
-  \ "vim*":        NewNativeFn("MalVimStar")
+  \ "meta":        NewNativeFnLambda({a -> ObjMeta(a[0])}),
+  \ "with-meta":   NewNativeFnLambda({a -> ObjNewWithMeta(ObjType(a[0]), copy(ObjValue(a[0])), a[1])}),
+  \ "atom":        NewNativeFnLambda({a -> AtomNew(a[0])}),
+  \ "atom?":       NewNativeFnLambda({a -> BoolNew(AtomQ(a[0]))}),
+  \ "deref":       NewNativeFnLambda({a -> ObjValue(a[0])}),
+  \ "reset!":      NewNativeFnLambda({a -> ObjSetValue(a[0], a[1])}),
+  \ "swap!":       NewNativeFnLambda({a -> ObjSetValue(a[0], MalApply([a[1], ListNew([ObjValue(a[0])] + a[2:])]))}),
+  \ "vim*":        NewNativeFnLambda({a -> VimToMal(eval(ObjValue(a[0])))})
   \ }

--- a/vimscript/core.vim
+++ b/vimscript/core.vim
@@ -221,7 +221,7 @@ let CoreNs = {
   \ "conj":        NewNativeFn("MalConj"),
   \ "seq":         NewNativeFn("MalSeq"),
   \ "meta":        NewNativeFnLambda({a -> ObjMeta(a[0])}),
-  \ "with-meta":   NewNativeFnLambda({a -> ObjNewWithMeta(ObjType(a[0]), copy(a[0].val), a[1])}),
+  \ "with-meta":   NewNativeFnLambda({a -> ObjNewWithMeta(a[0].type, copy(a[0].val), a[1])}),
   \ "atom":        NewNativeFnLambda({a -> AtomNew(a[0])}),
   \ "atom?":       NewNativeFnLambda({a -> BoolNew(AtomQ(a[0]))}),
   \ "deref":       NewNativeFnLambda({a -> a[0].val}),

--- a/vimscript/core.vim
+++ b/vimscript/core.vim
@@ -1,14 +1,14 @@
 " core module
 
 function MalAssoc(args)
-  let hash = copy(ObjValue(a:args[0]))
+  let hash = copy(a:args[0].val)
   let new_elements = HashBuild(a:args[1:])
-  call extend(hash, ObjValue(new_elements))
+  call extend(hash, new_elements.val)
   return HashNew(hash)
 endfunction
 
 function MalDissoc(args)
-  let hash = copy(ObjValue(a:args[0]))
+  let hash = copy(a:args[0].val)
   for keyobj in a:args[1:]
     let key = HashMakeKey(keyobj)
     if has_key(hash, key)
@@ -22,7 +22,7 @@ function MalGet(args)
   if !HashQ(a:args[0])
     return g:MalNil
   endif
-  let hash = ObjValue(a:args[0])
+  let hash = a:args[0].val
   let key = HashMakeKey(a:args[1])
   return get(hash, key, g:MalNil)
 endfunction
@@ -31,14 +31,14 @@ function MalContainsQ(args)
   if !HashQ(a:args[0])
     return FalseNew()
   endif
-  let hash = ObjValue(a:args[0])
+  let hash = a:args[0].val
   let key = HashMakeKey(a:args[1])
   return BoolNew(has_key(hash, key))
 endfunction
 
 function MalKeys(args)
   let listobjs = []
-  for keyname in keys(ObjValue(a:args[0]))
+  for keyname in keys(a:args[0].val)
     let keyobj = HashParseKey(keyname)
     call add(listobjs, keyobj)
   endfor
@@ -46,12 +46,12 @@ function MalKeys(args)
 endfunction
 
 function MalReadLine(args)
-  let [eof, line] = Readline(ObjValue(a:args[0]))
+  let [eof, line] = Readline(a:args[0].val)
   return eof ? g:MalNil : StringNew(line)
 endfunction
 
 function MalCons(args)
-  let items = copy(ObjValue(a:args[1]))
+  let items = copy(a:args[1].val)
   call insert(items, a:args[0])
   return ListNew(items)
 endfunction
@@ -59,7 +59,7 @@ endfunction
 function MalConcat(args)
   let res = []
   for list in a:args
-    let res = res + ObjValue(list)
+    let res = res + list.val
   endfor
   return ListNew(res)
 endfunction
@@ -70,9 +70,9 @@ function MalApply(args)
   if len(rest) == 0
     let funcargs = []
   elseif len(rest) == 1
-    let funcargs = ObjValue(rest[-1])
+    let funcargs = rest[-1].val
   else
-    let funcargs = rest[:-2] + ObjValue(rest[-1])
+    let funcargs = rest[:-2] + rest[-1].val
   endif
   if NativeFunctionQ(funcobj)
     return NativeFuncInvoke(funcobj, ListNew(funcargs))
@@ -86,7 +86,7 @@ endfunction
 function MalMap(args)
   let funcobj = a:args[0]
   let res = []
-  for item in ObjValue(a:args[1])
+  for item in a:args[1].val
     unlet! mappeditem
     if NativeFunctionQ(funcobj)
       let mappeditem = NativeFuncInvoke(funcobj, ListNew([item]))
@@ -115,7 +115,7 @@ function ConjList(list, elements)
 endfunction
 
 function ConjVector(vector, elements)
-  let items = copy(ObjValue(a:vector))
+  let items = copy(a:vector.val)
   for e in a:elements
     call add(items, e)
   endfor
@@ -137,9 +137,9 @@ function MalSeq(args)
   elseif ListQ(obj)
     return obj
   elseif VectorQ(obj)
-    return ListNew(ObjValue(obj))
+    return ListNew(obj.val)
   elseif StringQ(obj)
-    return ListNew(map(split(ObjValue(obj), '\zs'), {_, c -> StringNew(c)}))
+    return ListNew(map(split(obj.val, '\zs'), {_, c -> StringNew(c)}))
   endif
   throw "seq requires string or list or vector or nil"
 endfunction
@@ -171,22 +171,22 @@ endfunction
 
 let CoreNs = {
   \ "=":           NewNativeFnLambda({a -> BoolNew(EqualQ(a[0], a[1]))}),
-  \ "<":           NewNativeFnLambda({a -> BoolNew(ObjValue(a[0]) < ObjValue(a[1]))}),
-  \ "<=":          NewNativeFnLambda({a -> BoolNew(ObjValue(a[0]) <= ObjValue(a[1]))}),
-  \ ">":           NewNativeFnLambda({a -> BoolNew(ObjValue(a[0]) > ObjValue(a[1]))}),
-  \ ">=":          NewNativeFnLambda({a -> BoolNew(ObjValue(a[0]) >= ObjValue(a[1]))}),
-  \ "+":           NewNativeFnLambda({a -> IntegerNew(ObjValue(a[0]) + ObjValue(a[1]))}),
-  \ "-":           NewNativeFnLambda({a -> IntegerNew(ObjValue(a[0]) - ObjValue(a[1]))}),
-  \ "*":           NewNativeFnLambda({a -> IntegerNew(ObjValue(a[0]) * ObjValue(a[1]))}),
-  \ "/":           NewNativeFnLambda({a -> IntegerNew(ObjValue(a[0]) / ObjValue(a[1]))}),
+  \ "<":           NewNativeFnLambda({a -> BoolNew(a[0].val < a[1].val)}),
+  \ "<=":          NewNativeFnLambda({a -> BoolNew(a[0].val <= a[1].val)}),
+  \ ">":           NewNativeFnLambda({a -> BoolNew(a[0].val > a[1].val)}),
+  \ ">=":          NewNativeFnLambda({a -> BoolNew(a[0].val >= a[1].val)}),
+  \ "+":           NewNativeFnLambda({a -> IntegerNew(a[0].val + a[1].val)}),
+  \ "-":           NewNativeFnLambda({a -> IntegerNew(a[0].val - a[1].val)}),
+  \ "*":           NewNativeFnLambda({a -> IntegerNew(a[0].val * a[1].val)}),
+  \ "/":           NewNativeFnLambda({a -> IntegerNew(a[0].val / a[1].val)}),
   \ "time-ms":     NewNativeFnLambda({a -> IntegerNew(libcallnr("libvimextras.so", "vimtimems", 0))}),
   \ "nil?":        NewNativeFnLambda({a -> BoolNew(NilQ(a[0]))}),
   \ "true?":       NewNativeFnLambda({a -> BoolNew(TrueQ(a[0]))}),
   \ "false?":      NewNativeFnLambda({a -> BoolNew(FalseQ(a[0]))}),
-  \ "symbol":      NewNativeFnLambda({a -> SymbolNew(ObjValue(a[0]))}),
+  \ "symbol":      NewNativeFnLambda({a -> SymbolNew(a[0].val)}),
   \ "symbol?":     NewNativeFnLambda({a -> BoolNew(SymbolQ(a[0]))}),
   \ "string?":     NewNativeFnLambda({a -> BoolNew(StringQ(a[0]))}),
-  \ "keyword":     NewNativeFnLambda({a -> KeywordNew(ObjValue(a[0]))}),
+  \ "keyword":     NewNativeFnLambda({a -> KeywordNew(a[0].val)}),
   \ "keyword?":    NewNativeFnLambda({a -> BoolNew(KeywordQ(a[0]))}),
   \ "list":        NewNativeFnLambda({a -> ListNew(a)}),
   \ "list?":       NewNativeFnLambda({a -> BoolNew(ListQ(a[0]))}),
@@ -202,18 +202,18 @@ let CoreNs = {
   \ "get":         NewNativeFn("MalGet"),
   \ "contains?":   NewNativeFn("MalContainsQ"),
   \ "keys":        NewNativeFn("MalKeys"),
-  \ "vals":        NewNativeFnLambda({a -> ListNew(values(ObjValue(a[0])))}),
+  \ "vals":        NewNativeFnLambda({a -> ListNew(values(a[0].val))}),
   \ "pr-str":      NewNativeFnLambda({a -> StringNew(join(map(copy(a), {_, e -> PrStr(e, 1)}), " "))}),
   \ "str":         NewNativeFnLambda({a -> StringNew(join(map(copy(a), {_, e -> PrStr(e, 0)}), ""))}),
   \ "prn":         NewNativeFnLambda({a -> [PrintLn(join(map(copy(a), {_, e -> PrStr(e, 1)}), " ")), g:MalNil][1]}),
   \ "println":     NewNativeFnLambda({a -> [PrintLn(join(map(copy(a), {_, e -> PrStr(e, 0)}), " ")), g:MalNil][1]}),
-  \ "read-string": NewNativeFnLambda({a -> ReadStr(ObjValue(a[0]))}),
+  \ "read-string": NewNativeFnLambda({a -> ReadStr(a[0].val)}),
   \ "readline":    NewNativeFn("MalReadLine"),
-  \ "slurp":       NewNativeFnLambda({a -> StringNew(join(readfile(ObjValue(a[0]), "b"), "\n"))}),
+  \ "slurp":       NewNativeFnLambda({a -> StringNew(join(readfile(a[0].val, "b"), "\n"))}),
   \ "cons":        NewNativeFn("MalCons"),
   \ "concat":      NewNativeFn("MalConcat"),
   \ "first":       NewNativeFnLambda({a -> NilQ(a[0]) ? g:MalNil : ListFirst(a[0])}),
-  \ "nth":         NewNativeFnLambda({a -> ListNth(a[0], ObjValue(a[1]))}),
+  \ "nth":         NewNativeFnLambda({a -> ListNth(a[0], a[1].val)}),
   \ "rest":        NewNativeFnLambda({a -> NilQ(a[0]) ? ListNew([]) : ListRest(a[0])}),
   \ "apply":       NewNativeFn("MalApply"),
   \ "map":         NewNativeFn("MalMap"),
@@ -221,11 +221,11 @@ let CoreNs = {
   \ "conj":        NewNativeFn("MalConj"),
   \ "seq":         NewNativeFn("MalSeq"),
   \ "meta":        NewNativeFnLambda({a -> ObjMeta(a[0])}),
-  \ "with-meta":   NewNativeFnLambda({a -> ObjNewWithMeta(ObjType(a[0]), copy(ObjValue(a[0])), a[1])}),
+  \ "with-meta":   NewNativeFnLambda({a -> ObjNewWithMeta(ObjType(a[0]), copy(a[0].val), a[1])}),
   \ "atom":        NewNativeFnLambda({a -> AtomNew(a[0])}),
   \ "atom?":       NewNativeFnLambda({a -> BoolNew(AtomQ(a[0]))}),
-  \ "deref":       NewNativeFnLambda({a -> ObjValue(a[0])}),
+  \ "deref":       NewNativeFnLambda({a -> a[0].val}),
   \ "reset!":      NewNativeFnLambda({a -> ObjSetValue(a[0], a[1])}),
-  \ "swap!":       NewNativeFnLambda({a -> ObjSetValue(a[0], MalApply([a[1], ListNew([ObjValue(a[0])] + a[2:])]))}),
-  \ "vim*":        NewNativeFnLambda({a -> VimToMal(eval(ObjValue(a[0])))})
+  \ "swap!":       NewNativeFnLambda({a -> ObjSetValue(a[0], MalApply([a[1], ListNew([a[0].val] + a[2:])]))}),
+  \ "vim*":        NewNativeFnLambda({a -> VimToMal(eval(a[0].val))})
   \ }

--- a/vimscript/env.vim
+++ b/vimscript/env.vim
@@ -15,7 +15,6 @@ function NewEnvWithBinds(outer, binds, exprs)
   while i < ListCount(a:binds)
     let varname = ListNth(a:binds, i).val
     if varname == "&"
-      " TODO
       let restvarname = ListNth(a:binds, i + 1).val
       let restvarvalues = ListDrop(a:exprs, i)
       call env.set(restvarname, restvarvalues)

--- a/vimscript/env.vim
+++ b/vimscript/env.vim
@@ -13,10 +13,10 @@ function NewEnvWithBinds(outer, binds, exprs)
   let env = NewEnv(a:outer)
   let i = 0
   while i < ListCount(a:binds)
-    let varname = ObjValue(ListNth(a:binds, i))
+    let varname = ListNth(a:binds, i).val
     if varname == "&"
       " TODO
-      let restvarname = ObjValue(ListNth(a:binds, i + 1))
+      let restvarname = ListNth(a:binds, i + 1).val
       let restvarvalues = ListDrop(a:exprs, i)
       call env.set(restvarname, restvarvalues)
       break

--- a/vimscript/printer.vim
+++ b/vimscript/printer.vim
@@ -5,46 +5,46 @@ function PrStr(ast, readable)
   let r = a:readable
   if ListQ(obj)
     let ret = []
-    for e in ObjValue(obj)
+    for e in obj.val
       call add(ret, PrStr(e, r))
     endfor
     return "(" . join(ret, " ") . ")"
   elseif VectorQ(obj)
     let ret = []
-    for e in ObjValue(obj)
+    for e in obj.val
       call add(ret, PrStr(e, r))
     endfor
     return "[" . join(ret, " ") . "]"
   elseif HashQ(obj)
     let ret = []
-    for [k, v] in items(ObjValue(obj))
+    for [k, v] in items(obj.val)
       let keyobj = HashParseKey(k)
       call add(ret, PrStr(keyobj, r))
       call add(ret, PrStr(v, r))
     endfor
     return "{" . join(ret, " ") . "}"
   elseif MacroQ(obj)
-    let numargs = ListCount(ObjValue(obj).params)
+    let numargs = ListCount(obj.val.params)
     return "<Macro:" . numargs . "-arguments>"
   elseif FunctionQ(obj)
-    let numargs = ListCount(ObjValue(obj).params)
+    let numargs = ListCount(obj.val.params)
     return "<Function:" . numargs . "-arguments>"
   elseif NativeFunctionQ(obj)
-    let funcname = ObjValue(obj).name
+    let funcname = obj.val.name
     return "<NativeFunction:" . funcname . ">"
   elseif AtomQ(obj)
-    return "(atom " . PrStr(ObjValue(obj), 1) . ")"
+    return "(atom " . PrStr(obj.val, 1) . ")"
   elseif KeywordQ(obj)
-    return ':' . ObjValue(obj)
+    return ':' . obj.val
   elseif StringQ(obj)
     if r
-      let str = ObjValue(obj)
+      let str = obj.val
       let str = substitute(str, '\\', '\\\\', "g")
       let str = substitute(str, '"', '\\"', "g")
       let str = substitute(str, "\n", '\\n', "g")
       return '"' . str . '"'
     else
-      return ObjValue(obj)
+      return obj.val
     endif
   elseif NilQ(obj)
     return "nil"
@@ -53,8 +53,8 @@ function PrStr(ast, readable)
   elseif FalseQ(obj)
     return "false"
   elseif IntegerQ(obj) || FloatQ(obj)
-    return string(ObjValue(obj))
+    return string(obj.val)
   else
-    return ObjValue(obj)
+    return obj.val
   end
 endfunction

--- a/vimscript/readline.vim
+++ b/vimscript/readline.vim
@@ -11,8 +11,8 @@ endfunction
 
 " Returns [is_eof, line_string]
 function Readline(prompt)
-  " Use the vimreadline() function defined in vimreadline.c and compiled
-  " into libvimreadline.so
+  " Use the vimreadline() function defined in vimextras.c and compiled
+  " into libvimextras.so
   call s:buildlibvimreadline()
   let res = libcall("libvimextras.so", "vimreadline", a:prompt)
   if res[0] == "E"

--- a/vimscript/step2_eval.vim
+++ b/vimscript/step2_eval.vim
@@ -9,26 +9,26 @@ endfunction
 
 function EvalAst(ast, env)
   if SymbolQ(a:ast)
-    let varname = ObjValue(a:ast)
+    let varname = a:ast.val
     if !has_key(a:env, varname)
       throw "'" . varname . "' not found"
     end
     return a:env[varname]
   elseif ListQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return ListNew(ret)
   elseif VectorQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return VectorNew(ret)
   elseif HashQ(a:ast)
     let ret = {}
-    for [k,v] in items(ObjValue(a:ast))
+    for [k,v] in items(a:ast.val)
       let keyobj = HashParseKey(k)
       let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
@@ -52,8 +52,8 @@ function EVAL(ast, env)
   " apply list
   let el = EvalAst(a:ast, a:env)
 
-  let Fn = ObjValue(el)[0]
-  return Fn(ObjValue(el)[1:-1])
+  let Fn = el.val[0]
+  return Fn(el.val[1:-1])
 endfunction
 
 function PRINT(exp)

--- a/vimscript/step2_eval.vim
+++ b/vimscript/step2_eval.vim
@@ -15,17 +15,9 @@ function EvalAst(ast, env)
     end
     return a:env[varname]
   elseif ListQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return ListNew(ret)
+    return ListNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif VectorQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return VectorNew(ret)
+    return VectorNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)

--- a/vimscript/step2_eval.vim
+++ b/vimscript/step2_eval.vim
@@ -64,27 +64,11 @@ function REP(str, env)
   return PRINT(EVAL(READ(a:str), a:env))
 endfunction
 
-function MalAdd(args)
-  return IntegerNew(ObjValue(a:args[0]) + ObjValue(a:args[1]))
-endfunction
-
-function MalSub(args)
-  return IntegerNew(ObjValue(a:args[0]) - ObjValue(a:args[1]))
-endfunction
-
-function MalMul(args)
-  return IntegerNew(ObjValue(a:args[0]) * ObjValue(a:args[1]))
-endfunction
-
-function MalDiv(args)
-  return IntegerNew(ObjValue(a:args[0]) / ObjValue(a:args[1]))
-endfunction
-
 let repl_env = {}
-let repl_env["+"] = function("MalAdd")
-let repl_env["-"] = function("MalSub")
-let repl_env["*"] = function("MalMul")
-let repl_env["/"] = function("MalDiv")
+let repl_env["+"] = {a -> IntegerNew(a[0].val + a[1].val)}
+let repl_env["-"] = {a -> IntegerNew(a[0].val - a[1].val)}
+let repl_env["*"] = {a -> IntegerNew(a[0].val * a[1].val)}
+let repl_env["/"] = {a -> IntegerNew(a[0].val / a[1].val)}
 
 while 1
   let [eof, line] = Readline("user> ")

--- a/vimscript/step3_env.vim
+++ b/vimscript/step3_env.vim
@@ -80,27 +80,11 @@ function REP(str, env)
   return PRINT(EVAL(READ(a:str), a:env))
 endfunction
 
-function MalAdd(args)
-  return IntegerNew(ObjValue(a:args[0]) + ObjValue(a:args[1]))
-endfunction
-
-function MalSub(args)
-  return IntegerNew(ObjValue(a:args[0]) - ObjValue(a:args[1]))
-endfunction
-
-function MalMul(args)
-  return IntegerNew(ObjValue(a:args[0]) * ObjValue(a:args[1]))
-endfunction
-
-function MalDiv(args)
-  return IntegerNew(ObjValue(a:args[0]) / ObjValue(a:args[1]))
-endfunction
-
 let repl_env = NewEnv("")
-call repl_env.set("+", function("MalAdd"))
-call repl_env.set("-", function("MalSub"))
-call repl_env.set("*", function("MalMul"))
-call repl_env.set("/", function("MalDiv"))
+call repl_env.set("+", {a -> IntegerNew(a[0].val + a[1].val)})
+call repl_env.set("-", {a -> IntegerNew(a[0].val - a[1].val)})
+call repl_env.set("*", {a -> IntegerNew(a[0].val * a[1].val)})
+call repl_env.set("/", {a -> IntegerNew(a[0].val / a[1].val)})
 
 while 1
   let [eof, line] = Readline("user> ")

--- a/vimscript/step3_env.vim
+++ b/vimscript/step3_env.vim
@@ -10,23 +10,23 @@ endfunction
 
 function EvalAst(ast, env)
   if SymbolQ(a:ast)
-    let varname = ObjValue(a:ast)
+    let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return ListNew(ret)
   elseif VectorQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return VectorNew(ret)
   elseif HashQ(a:ast)
     let ret = {}
-    for [k,v] in items(ObjValue(a:ast))
+    for [k,v] in items(a:ast.val)
       let keyobj = HashParseKey(k)
       let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
@@ -47,27 +47,27 @@ function EVAL(ast, env)
     return a:ast
   endif
 
-  let first_symbol = ObjValue(ObjValue(a:ast)[0])
+  let first_symbol = a:ast.val[0].val
   if first_symbol == "def!"
-    let a1 = ObjValue(a:ast)[1]
-    let a2 = ObjValue(a:ast)[2]
-    return a:env.set(ObjValue(a1), EVAL(a2, a:env))
+    let a1 = a:ast.val[1]
+    let a2 = a:ast.val[2]
+    return a:env.set(a1.val, EVAL(a2, a:env))
   elseif first_symbol == "let*"
-    let a1 = ObjValue(a:ast)[1]
-    let a2 = ObjValue(a:ast)[2]
+    let a1 = a:ast.val[1]
+    let a2 = a:ast.val[2]
     let let_env = NewEnv(a:env)
-    let let_binds = ObjValue(a1)
+    let let_binds = a1.val
     let i = 0
     while i < len(let_binds)
-      call let_env.set(ObjValue(let_binds[i]), EVAL(let_binds[i+1], let_env))
+      call let_env.set(let_binds[i].val, EVAL(let_binds[i+1], let_env))
       let i = i + 2
     endwhile
     return EVAL(a2, let_env)
   else
     " apply list
     let el = EvalAst(a:ast, a:env)
-    let Fn = ObjValue(el)[0]
-    return Fn(ObjValue(el)[1:-1])
+    let Fn = el.val[0]
+    return Fn(el.val[1:-1])
   endif
 
 endfunction

--- a/vimscript/step3_env.vim
+++ b/vimscript/step3_env.vim
@@ -13,17 +13,9 @@ function EvalAst(ast, env)
     let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return ListNew(ret)
+    return ListNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif VectorQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return VectorNew(ret)
+    return VectorNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)

--- a/vimscript/step4_if_fn_do.vim
+++ b/vimscript/step4_if_fn_do.vim
@@ -14,17 +14,9 @@ function EvalAst(ast, env)
     let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return ListNew(ret)
+    return ListNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif VectorQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return VectorNew(ret)
+    return VectorNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)

--- a/vimscript/step4_if_fn_do.vim
+++ b/vimscript/step4_if_fn_do.vim
@@ -11,23 +11,23 @@ endfunction
 
 function EvalAst(ast, env)
   if SymbolQ(a:ast)
-    let varname = ObjValue(a:ast)
+    let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return ListNew(ret)
   elseif VectorQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return VectorNew(ret)
   elseif HashQ(a:ast)
     let ret = {}
-    for [k,v] in items(ObjValue(a:ast))
+    for [k,v] in items(a:ast.val)
       let keyobj = HashParseKey(k)
       let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
@@ -49,37 +49,37 @@ function EVAL(ast, env)
   endif
 
   let first = ListFirst(a:ast)
-  let first_symbol = SymbolQ(first) ? ObjValue(first) : ""
+  let first_symbol = SymbolQ(first) ? first.val : ""
   if first_symbol == "def!"
-    let a1 = ObjValue(a:ast)[1]
-    let a2 = ObjValue(a:ast)[2]
-    let ret = a:env.set(ObjValue(a1), EVAL(a2, a:env))
+    let a1 = a:ast.val[1]
+    let a2 = a:ast.val[2]
+    let ret = a:env.set(a1.val, EVAL(a2, a:env))
     return ret
   elseif first_symbol == "let*"
-    let a1 = ObjValue(a:ast)[1]
-    let a2 = ObjValue(a:ast)[2]
+    let a1 = a:ast.val[1]
+    let a2 = a:ast.val[2]
     let let_env = NewEnv(a:env)
-    let let_binds = ObjValue(a1)
+    let let_binds = a1.val
     let i = 0
     while i < len(let_binds)
-      call let_env.set(ObjValue(let_binds[i]), EVAL(let_binds[i+1], let_env))
+      call let_env.set(let_binds[i].val, EVAL(let_binds[i+1], let_env))
       let i = i + 2
     endwhile
     return EVAL(a2, let_env)
   elseif first_symbol == "if"
-    let condvalue = EVAL(ObjValue(a:ast)[1], a:env)
+    let condvalue = EVAL(a:ast.val[1], a:env)
     if FalseQ(condvalue) || NilQ(condvalue)
-      if len(ObjValue(a:ast)) < 4
+      if len(a:ast.val) < 4
         return g:MalNil
       else
-        return EVAL(ObjValue(a:ast)[3], a:env)
+        return EVAL(a:ast.val[3], a:env)
       endif
     else
-      return EVAL(ObjValue(a:ast)[2], a:env)
+      return EVAL(a:ast.val[2], a:env)
     endif
   elseif first_symbol == "do"
     let el = EvalAst(ListRest(a:ast), a:env)
-    return ObjValue(el)[-1]
+    return el.val[-1]
   elseif first_symbol == "fn*"
     let fn = NewFn(ListNth(a:ast, 2), a:env, ListNth(a:ast, 1))
     return fn

--- a/vimscript/step5_tco.vim
+++ b/vimscript/step5_tco.vim
@@ -14,17 +14,9 @@ function EvalAst(ast, env)
     let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return ListNew(ret)
+    return ListNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif VectorQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return VectorNew(ret)
+    return VectorNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)

--- a/vimscript/step5_tco.vim
+++ b/vimscript/step5_tco.vim
@@ -11,23 +11,23 @@ endfunction
 
 function EvalAst(ast, env)
   if SymbolQ(a:ast)
-    let varname = ObjValue(a:ast)
+    let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return ListNew(ret)
   elseif VectorQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return VectorNew(ret)
   elseif HashQ(a:ast)
     let ret = {}
-    for [k,v] in items(ObjValue(a:ast))
+    for [k,v] in items(a:ast.val)
       let keyobj = HashParseKey(k)
       let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
@@ -53,38 +53,38 @@ function EVAL(ast, env)
     endif
 
     let first = ListFirst(ast)
-    let first_symbol = SymbolQ(first) ? ObjValue(first) : ""
+    let first_symbol = SymbolQ(first) ? first.val : ""
     if first_symbol == "def!"
-      let a1 = ObjValue(ast)[1]
-      let a2 = ObjValue(ast)[2]
-      let ret = env.set(ObjValue(a1), EVAL(a2, env))
+      let a1 = ast.val[1]
+      let a2 = ast.val[2]
+      let ret = env.set(a1.val, EVAL(a2, env))
       return ret
     elseif first_symbol == "let*"
-      let a1 = ObjValue(ast)[1]
-      let a2 = ObjValue(ast)[2]
+      let a1 = ast.val[1]
+      let a2 = ast.val[2]
       let env = NewEnv(env)
-      let let_binds = ObjValue(a1)
+      let let_binds = a1.val
       let i = 0
       while i < len(let_binds)
-        call env.set(ObjValue(let_binds[i]), EVAL(let_binds[i+1], env))
+        call env.set(let_binds[i].val, EVAL(let_binds[i+1], env))
         let i = i + 2
       endwhile
       let ast = a2
       " TCO
     elseif first_symbol == "if"
-      let condvalue = EVAL(ObjValue(ast)[1], env)
+      let condvalue = EVAL(ast.val[1], env)
       if FalseQ(condvalue) || NilQ(condvalue)
-        if len(ObjValue(ast)) < 4
+        if len(ast.val) < 4
           return g:MalNil
         else
-          let ast = ObjValue(ast)[3]
+          let ast = ast.val[3]
         endif
       else
-        let ast = ObjValue(ast)[2]
+        let ast = ast.val[2]
       endif
       " TCO
     elseif first_symbol == "do"
-      let astlist = ObjValue(ast)
+      let astlist = ast.val
       call EvalAst(ListNew(astlist[1:-2]), env)
       let ast = astlist[-1]
       " TCO
@@ -99,7 +99,7 @@ function EVAL(ast, env)
       if NativeFunctionQ(funcobj)
         return NativeFuncInvoke(funcobj, args)
       elseif FunctionQ(funcobj)
-        let fn = ObjValue(funcobj)
+        let fn = funcobj.val
         let ast = fn.ast
         let env = NewEnvWithBinds(fn.env, fn.params, args)
         " TCO

--- a/vimscript/step6_file.vim
+++ b/vimscript/step6_file.vim
@@ -14,17 +14,9 @@ function EvalAst(ast, env)
     let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return ListNew(ret)
+    return ListNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif VectorQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return VectorNew(ret)
+    return VectorNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)

--- a/vimscript/step6_file.vim
+++ b/vimscript/step6_file.vim
@@ -11,23 +11,23 @@ endfunction
 
 function EvalAst(ast, env)
   if SymbolQ(a:ast)
-    let varname = ObjValue(a:ast)
+    let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return ListNew(ret)
   elseif VectorQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return VectorNew(ret)
   elseif HashQ(a:ast)
     let ret = {}
-    for [k,v] in items(ObjValue(a:ast))
+    for [k,v] in items(a:ast.val)
       let keyobj = HashParseKey(k)
       let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
@@ -53,38 +53,38 @@ function EVAL(ast, env)
     endif
 
     let first = ListFirst(ast)
-    let first_symbol = SymbolQ(first) ? ObjValue(first) : ""
+    let first_symbol = SymbolQ(first) ? first.val : ""
     if first_symbol == "def!"
-      let a1 = ObjValue(ast)[1]
-      let a2 = ObjValue(ast)[2]
-      let ret = env.set(ObjValue(a1), EVAL(a2, env))
+      let a1 = ast.val[1]
+      let a2 = ast.val[2]
+      let ret = env.set(a1.val, EVAL(a2, env))
       return ret
     elseif first_symbol == "let*"
-      let a1 = ObjValue(ast)[1]
-      let a2 = ObjValue(ast)[2]
+      let a1 = ast.val[1]
+      let a2 = ast.val[2]
       let env = NewEnv(env)
-      let let_binds = ObjValue(a1)
+      let let_binds = a1.val
       let i = 0
       while i < len(let_binds)
-        call env.set(ObjValue(let_binds[i]), EVAL(let_binds[i+1], env))
+        call env.set(let_binds[i].val, EVAL(let_binds[i+1], env))
         let i = i + 2
       endwhile
       let ast = a2
       " TCO
     elseif first_symbol == "if"
-      let condvalue = EVAL(ObjValue(ast)[1], env)
+      let condvalue = EVAL(ast.val[1], env)
       if FalseQ(condvalue) || NilQ(condvalue)
-        if len(ObjValue(ast)) < 4
+        if len(ast.val) < 4
           return g:MalNil
         else
-          let ast = ObjValue(ast)[3]
+          let ast = ast.val[3]
         endif
       else
-        let ast = ObjValue(ast)[2]
+        let ast = ast.val[2]
       endif
       " TCO
     elseif first_symbol == "do"
-      let astlist = ObjValue(ast)
+      let astlist = ast.val
       call EvalAst(ListNew(astlist[1:-2]), env)
       let ast = astlist[-1]
       " TCO
@@ -103,7 +103,7 @@ function EVAL(ast, env)
       if NativeFunctionQ(funcobj)
         return NativeFuncInvoke(funcobj, args)
       elseif FunctionQ(funcobj)
-        let fn = ObjValue(funcobj)
+        let fn = funcobj.val
         let ast = fn.ast
         let env = NewEnvWithBinds(fn.env, fn.params, args)
         " TCO

--- a/vimscript/step6_file.vim
+++ b/vimscript/step6_file.vim
@@ -127,12 +127,7 @@ function REP(str, env)
 endfunction
 
 function GetArgvList()
-  let args = argv()
-  let list = []
-  for arg in args[1:]
-    call add(list, StringNew(arg))
-  endfor
-  return ListNew(list)
+  return ListNew(map(copy(argv()[1:]), {_, arg -> StringNew(arg)}))
 endfunction
 
 set maxfuncdepth=10000

--- a/vimscript/step7_quote.vim
+++ b/vimscript/step7_quote.vim
@@ -150,12 +150,7 @@ function REP(str, env)
 endfunction
 
 function GetArgvList()
-  let args = argv()
-  let list = []
-  for arg in args[1:]
-    call add(list, StringNew(arg))
-  endfor
-  return ListNew(list)
+  return ListNew(map(copy(argv()[1:]), {_, arg -> StringNew(arg)}))
 endfunction
 
 set maxfuncdepth=10000

--- a/vimscript/step7_quote.vim
+++ b/vimscript/step7_quote.vim
@@ -32,17 +32,9 @@ function EvalAst(ast, env)
     let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return ListNew(ret)
+    return ListNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif VectorQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return VectorNew(ret)
+    return VectorNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)

--- a/vimscript/step8_macros.vim
+++ b/vimscript/step8_macros.vim
@@ -186,12 +186,7 @@ function REP(str, env)
 endfunction
 
 function GetArgvList()
-  let args = argv()
-  let list = []
-  for arg in args[1:]
-    call add(list, StringNew(arg))
-  endfor
-  return ListNew(list)
+  return ListNew(map(copy(argv()[1:]), {_, arg -> StringNew(arg)}))
 endfunction
 
 set maxfuncdepth=10000

--- a/vimscript/step8_macros.vim
+++ b/vimscript/step8_macros.vim
@@ -57,17 +57,9 @@ function EvalAst(ast, env)
     let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return ListNew(ret)
+    return ListNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif VectorQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return VectorNew(ret)
+    return VectorNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)

--- a/vimscript/step8_macros.vim
+++ b/vimscript/step8_macros.vim
@@ -18,9 +18,9 @@ function Quasiquote(ast)
     return ListNew([SymbolNew("quote"), a:ast])
   endif
   let a0 = ListFirst(a:ast)
-  if SymbolQ(a0) && ObjValue(a0) == "unquote"
+  if SymbolQ(a0) && a0.val == "unquote"
     return ListNth(a:ast, 1)
-  elseif PairQ(a0) && SymbolQ(ListFirst(a0)) && ObjValue(ListFirst(a0)) == "splice-unquote"
+  elseif PairQ(a0) && SymbolQ(ListFirst(a0)) && ListFirst(a0).val == "splice-unquote"
     return ListNew([SymbolNew("concat"), ListNth(a0, 1), Quasiquote(ListRest(a:ast))])
   else
     return ListNew([SymbolNew("cons"), Quasiquote(a0), Quasiquote(ListRest(a:ast))])
@@ -35,7 +35,7 @@ function IsMacroCall(ast, env)
   if !SymbolQ(a0)
     return 0
   endif
-  let macroname = ObjValue(a0)
+  let macroname = a0.val
   if empty(a:env.find(macroname))
     return 0
   endif
@@ -45,7 +45,7 @@ endfunction
 function MacroExpand(ast, env)
   let ast = a:ast
   while IsMacroCall(ast, a:env)
-    let macroobj = a:env.get(ObjValue(ListFirst(ast)))
+    let macroobj = a:env.get(ListFirst(ast).val)
     let macroargs = ListRest(ast)
     let ast = FuncInvoke(macroobj, macroargs)
   endwhile
@@ -54,23 +54,23 @@ endfunction
 
 function EvalAst(ast, env)
   if SymbolQ(a:ast)
-    let varname = ObjValue(a:ast)
+    let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return ListNew(ret)
   elseif VectorQ(a:ast)
     let ret = []
-    for e in ObjValue(a:ast)
+    for e in a:ast.val
       call add(ret, EVAL(e, a:env))
     endfor
     return VectorNew(ret)
   elseif HashQ(a:ast)
     let ret = {}
-    for [k,v] in items(ObjValue(a:ast))
+    for [k,v] in items(a:ast.val)
       let keyobj = HashParseKey(k)
       let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
@@ -101,19 +101,19 @@ function EVAL(ast, env)
     endif
 
     let first = ListFirst(ast)
-    let first_symbol = SymbolQ(first) ? ObjValue(first) : ""
+    let first_symbol = SymbolQ(first) ? first.val : ""
     if first_symbol == "def!"
-      let a1 = ObjValue(ast)[1]
-      let a2 = ObjValue(ast)[2]
-      return env.set(ObjValue(a1), EVAL(a2, env))
+      let a1 = ast.val[1]
+      let a2 = ast.val[2]
+      return env.set(a1.val, EVAL(a2, env))
     elseif first_symbol == "let*"
-      let a1 = ObjValue(ast)[1]
-      let a2 = ObjValue(ast)[2]
+      let a1 = ast.val[1]
+      let a2 = ast.val[2]
       let env = NewEnv(env)
-      let let_binds = ObjValue(a1)
+      let let_binds = a1.val
       let i = 0
       while i < len(let_binds)
-        call env.set(ObjValue(let_binds[i]), EVAL(let_binds[i+1], env))
+        call env.set(let_binds[i].val, EVAL(let_binds[i+1], env))
         let i = i + 2
       endwhile
       let ast = a2
@@ -127,23 +127,23 @@ function EVAL(ast, env)
       let a1 = ListNth(ast, 1)
       let a2 = ListNth(ast, 2)
       let macro = MarkAsMacro(EVAL(a2, env))
-      return env.set(ObjValue(a1), macro)
+      return env.set(a1.val, macro)
     elseif first_symbol == "macroexpand"
       return MacroExpand(ListNth(ast, 1), env)
     elseif first_symbol == "if"
-      let condvalue = EVAL(ObjValue(ast)[1], env)
+      let condvalue = EVAL(ast.val[1], env)
       if FalseQ(condvalue) || NilQ(condvalue)
-        if len(ObjValue(ast)) < 4
+        if len(ast.val) < 4
           return g:MalNil
         else
-          let ast = ObjValue(ast)[3]
+          let ast = ast.val[3]
         endif
       else
-        let ast = ObjValue(ast)[2]
+        let ast = ast.val[2]
       endif
       " TCO
     elseif first_symbol == "do"
-      let astlist = ObjValue(ast)
+      let astlist = ast.val
       call EvalAst(ListNew(astlist[1:-2]), env)
       let ast = astlist[-1]
       " TCO
@@ -162,7 +162,7 @@ function EVAL(ast, env)
       if NativeFunctionQ(funcobj)
         return NativeFuncInvoke(funcobj, args)
       elseif FunctionQ(funcobj)
-        let fn = ObjValue(funcobj)
+        let fn = funcobj.val
         let ast = fn.ast
         let env = NewEnvWithBinds(fn.env, fn.params, args)
         " TCO

--- a/vimscript/step9_try.vim
+++ b/vimscript/step9_try.vim
@@ -59,17 +59,9 @@ function EvalAst(ast, env)
     let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return ListNew(ret)
+    return ListNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif VectorQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return VectorNew(ret)
+    return VectorNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)

--- a/vimscript/step9_try.vim
+++ b/vimscript/step9_try.vim
@@ -218,12 +218,7 @@ function REP(str, env)
 endfunction
 
 function GetArgvList()
-  let args = argv()
-  let list = []
-  for arg in args[1:]
-    call add(list, StringNew(arg))
-  endfor
-  return ListNew(list)
+  return ListNew(map(copy(argv()[1:]), {_, arg -> StringNew(arg)}))
 endfunction
 
 set maxfuncdepth=10000

--- a/vimscript/stepA_mal.vim
+++ b/vimscript/stepA_mal.vim
@@ -59,17 +59,9 @@ function EvalAst(ast, env)
     let varname = a:ast.val
     return a:env.get(varname)
   elseif ListQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return ListNew(ret)
+    return ListNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif VectorQ(a:ast)
-    let ret = []
-    for e in a:ast.val
-      call add(ret, EVAL(e, a:env))
-    endfor
-    return VectorNew(ret)
+    return VectorNew(map(copy(a:ast.val), {_, e -> EVAL(e, a:env)}))
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)

--- a/vimscript/stepA_mal.vim
+++ b/vimscript/stepA_mal.vim
@@ -218,12 +218,7 @@ function REP(str, env)
 endfunction
 
 function GetArgvList()
-  let args = argv()
-  let list = []
-  for arg in args[1:]
-    call add(list, StringNew(arg))
-  endfor
-  return ListNew(list)
+  return ListNew(map(copy(argv()[1:]), {_, arg -> StringNew(arg)}))
 endfunction
 
 set maxfuncdepth=10000

--- a/vimscript/tests/stepA_mal.mal
+++ b/vimscript/tests/stepA_mal.mal
@@ -33,9 +33,9 @@
 ;; Test access to Vim predefined variables
 ;;
 
-(vim* "v:progname")
-;=>"vim"
+;;; (vim* "v:progname")
+;;; ;=>"vim"
 
-;; v:version is 704 for Vim 7.4
-(> (vim* "v:version") 700)
+;; v:version is 800 for Vim 8.0
+(>= (vim* "v:version") 800)
 ;=>true

--- a/vimscript/types.vim
+++ b/vimscript/types.vim
@@ -12,10 +12,6 @@ function ObjType(obj)
   return a:obj["type"]
 endfunction
 
-function ObjValue(obj)
-  return a:obj["val"]
-endfunction
-
 function ObjHasMeta(obj)
   return ObjQ(a:obj) && has_key(a:obj, "meta")
 endfunction
@@ -91,11 +87,11 @@ function HashQ(obj)
 endfunction
 
 function FunctionQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "function" && !ObjValue(a:obj).is_macro
+  return ObjQ(a:obj) && ObjType(a:obj) == "function" && !a:obj.val.is_macro
 endfunction
 
 function MacroQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "function" && ObjValue(a:obj).is_macro
+  return ObjQ(a:obj) && ObjType(a:obj) == "function" && a:obj.val.is_macro
 endfunction
 
 function NativeFunctionQ(obj)
@@ -158,7 +154,7 @@ function HashMakeKey(obj)
   if !StringQ(a:obj) && !KeywordQ(a:obj)
     throw "expected hash-map key string, got: " . ObjType(a:obj));
   endif
-  return ObjType(a:obj) . "#" . ObjValue(a:obj)
+  return ObjType(a:obj) . "#" . a:obj.val
 endfunction
 
 function HashParseKey(str)
@@ -186,12 +182,12 @@ function HashBuild(elements)
 endfunction
 
 function HashEqualQ(x, y)
-  if len(ObjValue(a:x)) != len(ObjValue(a:y))
+  if len(a:x.val) != len(a:y.val)
     return 0
   endif
-  for k in keys(ObjValue(a:x))
-    let vx = ObjValue(a:x)[k]
-    let vy = ObjValue(a:y)[k]
+  for k in keys(a:x.val)
+    let vx = a:x.val[k]
+    let vy = a:y.val[k]
     if empty(vy) || !EqualQ(vx, vy)
       return 0
     endif
@@ -200,13 +196,13 @@ function HashEqualQ(x, y)
 endfunction
 
 function SequentialEqualQ(x, y)
-  if len(ObjValue(a:x)) != len(ObjValue(a:y))
+  if len(a:x.val) != len(a:y.val)
     return 0
   endif
   let i = 0
-  while i < len(ObjValue(a:x))
-    let ex = ObjValue(a:x)[i]
-    let ey = ObjValue(a:y)[i]
+  while i < len(a:x.val)
+    let ex = a:x.val[i]
+    let ey = a:y.val[i]
     if !EqualQ(ex, ey)
       return 0
     endif
@@ -223,31 +219,31 @@ function EqualQ(x, y)
   elseif ObjType(a:x) != ObjType(a:y)
     return 0
   else
-    return ObjValue(a:x) == ObjValue(a:y)
+    return a:x.val == a:y.val
   endif
 endfunction
 
 function EmptyQ(list)
-  return empty(ObjValue(a:list))
+  return empty(a:list.val)
 endfunction
 
 function ListCount(list)
-  return len(ObjValue(a:list))
+  return len(a:list.val)
 endfunction
 
 function ListNth(list, index)
-  if a:index >= len(ObjValue(a:list))
+  if a:index >= len(a:list.val)
     throw "nth: index out of range"
   endif
-  return ObjValue(a:list)[a:index]
+  return a:list.val[a:index]
 endfunction
 
 function ListFirst(list)
-  return get(ObjValue(a:list), 0, g:MalNil)
+  return get(a:list.val, 0, g:MalNil)
 endfunction
 
 function ListDrop(list, drop_elements)
-  return ListNew(ObjValue(a:list)[a:drop_elements :])
+  return ListNew(a:list.val[a:drop_elements :])
 endfunction
 
 function ListRest(list)
@@ -255,18 +251,18 @@ function ListRest(list)
 endfunction
 
 function FuncInvoke(funcobj, args)
-  let fn = ObjValue(a:funcobj)
+  let fn = a:funcobj.val
   let funcenv = NewEnvWithBinds(fn.env, fn.params, a:args)
   return EVAL(fn.ast, funcenv)
 endfunction
 
 function NativeFuncInvoke(funcobj, argslist)
-  let fn = ObjValue(a:funcobj)
-  return fn.Func(ObjValue(a:argslist))
+  let fn = a:funcobj.val
+  return fn.Func(a:argslist.val)
 endfunction
 
 function MarkAsMacro(funcobj)
-  let fn = ObjValue(a:funcobj)
+  let fn = a:funcobj.val
   let fn.is_macro = 1
   return a:funcobj
 endfunction

--- a/vimscript/types.vim
+++ b/vimscript/types.vim
@@ -8,10 +8,6 @@ function ObjNew(obj_type, obj_val)
   return {"type": a:obj_type, "val": a:obj_val}
 endfunction
 
-function ObjType(obj)
-  return a:obj["type"]
-endfunction
-
 function ObjHasMeta(obj)
   return ObjQ(a:obj) && has_key(a:obj, "meta")
 endfunction
@@ -35,47 +31,47 @@ function ObjQ(obj)
 endfunction
 
 function SymbolQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "symbol"
+  return ObjQ(a:obj) && a:obj.type == "symbol"
 endfunction
 
 function StringQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "string"
+  return ObjQ(a:obj) && a:obj.type == "string"
 endfunction
 
 function KeywordQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "keyword"
+  return ObjQ(a:obj) && a:obj.type == "keyword"
 endfunction
 
 function AtomQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "atom"
+  return ObjQ(a:obj) && a:obj.type == "atom"
 endfunction
 
 function NilQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "nil"
+  return ObjQ(a:obj) && a:obj.type == "nil"
 endfunction
 
 function TrueQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "true"
+  return ObjQ(a:obj) && a:obj.type == "true"
 endfunction
 
 function FalseQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "false"
+  return ObjQ(a:obj) && a:obj.type == "false"
 endfunction
 
 function IntegerQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "integer"
+  return ObjQ(a:obj) && a:obj.type == "integer"
 endfunction
 
 function FloatQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "float"
+  return ObjQ(a:obj) && a:obj.type == "float"
 endfunction
 
 function ListQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "list"
+  return ObjQ(a:obj) && a:obj.type == "list"
 endfunction
 
 function VectorQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "vector"
+  return ObjQ(a:obj) && a:obj.type == "vector"
 endfunction
 
 function SequentialQ(obj)
@@ -83,19 +79,19 @@ function SequentialQ(obj)
 endfunction
 
 function HashQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "hash"
+  return ObjQ(a:obj) && a:obj.type == "hash"
 endfunction
 
 function FunctionQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "function" && !a:obj.val.is_macro
+  return ObjQ(a:obj) && a:obj.type == "function" && !a:obj.val.is_macro
 endfunction
 
 function MacroQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "function" && a:obj.val.is_macro
+  return ObjQ(a:obj) && a:obj.type == "function" && a:obj.val.is_macro
 endfunction
 
 function NativeFunctionQ(obj)
-  return ObjQ(a:obj) && ObjType(a:obj) == "nativefunction"
+  return ObjQ(a:obj) && a:obj.type == "nativefunction"
 endfunction
 
 function NilNew()
@@ -152,9 +148,9 @@ endfunction
 
 function HashMakeKey(obj)
   if !StringQ(a:obj) && !KeywordQ(a:obj)
-    throw "expected hash-map key string, got: " . ObjType(a:obj));
+    throw "expected hash-map key string, got: " . a:obj.type);
   endif
-  return ObjType(a:obj) . "#" . a:obj.val
+  return a:obj.type . "#" . a:obj.val
 endfunction
 
 function HashParseKey(str)
@@ -216,7 +212,7 @@ function EqualQ(x, y)
     return SequentialEqualQ(a:x, a:y)
   elseif HashQ(a:x) && HashQ(a:y)
     return HashEqualQ(a:x, a:y)
-  elseif ObjType(a:x) != ObjType(a:y)
+  elseif a:x.type != a:y.type
     return 0
   else
     return a:x.val == a:y.val

--- a/vimscript/types.vim
+++ b/vimscript/types.vim
@@ -9,7 +9,7 @@ function ObjNew(obj_type, obj_val)
 endfunction
 
 function ObjHasMeta(obj)
-  return ObjQ(a:obj) && has_key(a:obj, "meta")
+  return has_key(a:obj, "meta")
 endfunction
 
 function ObjMeta(obj)
@@ -26,72 +26,68 @@ function ObjSetMeta(obj, newmeta)
   return a:newmeta
 endfunction
 
-function ObjQ(obj)
-  return type(a:obj) == type({})
-endfunction
-
 function SymbolQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "symbol"
+  return a:obj.type == "symbol"
 endfunction
 
 function StringQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "string"
+  return a:obj.type == "string"
 endfunction
 
 function KeywordQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "keyword"
+  return a:obj.type == "keyword"
 endfunction
 
 function AtomQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "atom"
+  return a:obj.type == "atom"
 endfunction
 
 function NilQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "nil"
+  return a:obj.type == "nil"
 endfunction
 
 function TrueQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "true"
+  return a:obj.type == "true"
 endfunction
 
 function FalseQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "false"
+  return a:obj.type == "false"
 endfunction
 
 function IntegerQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "integer"
+  return a:obj.type == "integer"
 endfunction
 
 function FloatQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "float"
+  return a:obj.type == "float"
 endfunction
 
 function ListQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "list"
+  return a:obj.type == "list"
 endfunction
 
 function VectorQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "vector"
+  return a:obj.type == "vector"
 endfunction
 
 function SequentialQ(obj)
-  return ObjQ(a:obj) && ListQ(a:obj) || VectorQ(a:obj)
+  return ListQ(a:obj) || VectorQ(a:obj)
 endfunction
 
 function HashQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "hash"
+  return a:obj.type == "hash"
 endfunction
 
 function FunctionQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "function" && !a:obj.val.is_macro
+  return a:obj.type == "function" && !a:obj.val.is_macro
 endfunction
 
 function MacroQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "function" && a:obj.val.is_macro
+  return a:obj.type == "function" && a:obj.val.is_macro
 endfunction
 
 function NativeFunctionQ(obj)
-  return ObjQ(a:obj) && a:obj.type == "nativefunction"
+  return a:obj.type == "nativefunction"
 endfunction
 
 function NilNew()

--- a/vimscript/types.vim
+++ b/vimscript/types.vim
@@ -281,6 +281,11 @@ function NewNativeFn(funcname)
   return ObjNewWithMeta("nativefunction", fn, g:MalNil)
 endfunction
 
+function NewNativeFnLambda(lambdaexpr)
+  let fn = {"Func": a:lambdaexpr, "name": "inline"}
+  return ObjNewWithMeta("nativefunction", fn, g:MalNil)
+endfunction
+
 let g:MalNil = NilNew()
 let g:MalTrue = TrueNew()
 let g:MalFalse = FalseNew()

--- a/vimscript/vimextras.c
+++ b/vimscript/vimextras.c
@@ -27,10 +27,10 @@ char* vimreadline(char* prompt) {
     return buf;
 }
 
-#define UNIXTIME_2000_01_01 946684800
+#define UNIXTIME_BASE 1451606400 /* = Unix time of 2016-01-01 */
 
 /*
- * Returns the number of milliseconds since 2000-01-01 00:00:00 UTC.
+ * Returns the number of milliseconds since 2016-01-01 00:00:00 UTC.
  *
  * This date is chosen (instead of the standard 1970 epoch) so the number of
  * milliseconds will not exceed a 32-bit integer, which is the limit for Vim
@@ -40,5 +40,5 @@ int vimtimems(int dummy) {
     struct timeval tv;
     (void) dummy; /* unused */
     gettimeofday(&tv, NULL);
-    return (tv.tv_sec - UNIXTIME_2000_01_01) * 1000 + (tv.tv_usec / 1000);
+    return (tv.tv_sec - UNIXTIME_BASE) * 1000 + (tv.tv_usec / 1000);
 }


### PR DESCRIPTION
Changes:

* Dockerfile now installs Vim 8.0 (from source)
* Use lambdas for most functions in `core.vim` (this removed a lot of boilerplate code!)
* Use map+lambdas instead of `for` loops in several places
* Get rid of useless functions like ObjValue and ObjType to somewhat improve performance
* Fix bug in `time-ms` returning negative numbers

Not sure if there's any other improvement (Vim 8.0 has jobs, channels and JSON support - but not sure how these can help mal).