### PR TITLE
Update README with hint on test permission failing

### DIFF
--- a/process/guide.md
+++ b/process/guide.md
@@ -109,7 +109,9 @@ quux_STEP_TO_PROG = mylang/$($(1)).qx
 
 * Add a "run" script to you implementation directory that listens to
   the "STEP" environment variable for the implementation step to run
-  and defaults to "stepA_mal".  The following are examples of "run"
+  and defaults to "stepA_mal". Make sure the run script has the
+  executable file permission set (or else the test runner might fail with a
+  permission denied error message). The following are examples of "run"
   scripts for a compiled language and an interpreted language (where
   the interpreter is named "quux"):
 


### PR DESCRIPTION
Ran into some problems with the <language>/run file
not having the executable flag set.

Setting +x on the run file helps this.

The error-message the python runner throws is:
Traceback (most recent call last):
  File "../runtest.py", line 227, in <module>
    r = Runner(args.mal_cmd, no_pty=args.no_pty)
  File "../runtest.py", line 105, in __init__
    env=env)
  File "/usr/lib/python3.6/subprocess.py", line 707, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1326, in _execute_child
    raise child_exception_type(errno_num, err_msg)
PermissionError: [Errno 13] Permission denied
make: *** [Makefile:310: test^mymal^step0] Error 1