### PR TITLE
Apply hack to Emacs 25 instead of Emacs 25.1

### DIFF
--- a/elisp/reader.el
+++ b/elisp/reader.el
@@ -1,6 +1,6 @@
 ;; HACK: `text-quoting-style' prettifies quotes in error messages on
-;; Emacs 25.1, but no longer does from 25.2 upwards...
-(when (and (= emacs-major-version 25) (= emacs-minor-version 1))
+;; Emacs 25, but no longer does from 26 upwards...
+(when (= emacs-major-version 25)
   (setq text-quoting-style 'grave))
 
 (defvar tokens nil)


### PR DESCRIPTION
Unlike what I've read on `emacs-devel`, the problem is *not* gone in Emacs 25.2.  Maybe it will if Emacs 25.3 happens, but I'm no longer betting on that.