### PR TITLE
Fix init warning

### DIFF
--- a/gst/step0_repl.st
+++ b/gst/step0_repl.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/step1_read_print.st
+++ b/gst/step1_read_print.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/step2_eval.st
+++ b/gst/step2_eval.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/step3_env.st
+++ b/gst/step3_env.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/step4_if_fn_do.st
+++ b/gst/step4_if_fn_do.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/step5_tco.st
+++ b/gst/step5_tco.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/step6_file.st
+++ b/gst/step6_file.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/step7_quote.st
+++ b/gst/step7_quote.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/step8_macros.st
+++ b/gst/step8_macros.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/step9_try.st
+++ b/gst/step9_try.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]

--- a/gst/stepA_mal.st
+++ b/gst/stepA_mal.st
@@ -1,7 +1,7 @@
 String extend [
     String >> loadRelative [
         | scriptPath scriptDirectory |
-        scriptPath := ContextPart thisContext currentFileName.
+        scriptPath := thisContext currentFileName.
         scriptDirectory := FilePath stripFileNameFor: scriptPath.
         FileStream fileIn: (FilePath append: self to: scriptDirectory)
     ]


### PR DESCRIPTION
I mistakenly assumed that the way to retrieve the current context is by calling a documented static method.  Apparently `thisContext` is the missing sixth keyword in Smalltalk, so that's not needed.