### PR TITLE
bash: Fix `string?` result on keyword arguments

### DIFF
--- a/bash/core.sh
+++ b/bash/core.sh
@@ -74,7 +74,7 @@ time_ms () {
 
 # String functions
 
-string? () { _string? "${1}" && r="${__true}" || r="${__false}"; }
+string? () { _string? "${1}" && ( ! _keyword? "${1}" ) && r="${__true}" || r="${__false}"; }
 
 pr_str () {
     local res=""


### PR DESCRIPTION
Fixed wrong `string?` value on keyword arguments in bash implementation
(2 soft test fails).

Before the fix:

```
TEST: (string? :abc) -> ['',false] -> SOFT FAIL (line 115):
    Expected : '(string? :abc)\r\nfalse'
    Got      : '(string? :abc)\r\ntrue'
TEST: (string? (keyword "abc")) -> ['',false] -> SOFT FAIL (line 117):
    Expected : '(string? (keyword "abc"))\r\nfalse'
    Got      : '(string? (keyword "abc"))\r\ntrue'
```

With the fix:

```
TEST: (string? :abc) -> ['',false] -> SUCCESS
TEST: (string? (keyword "abc")) -> ['',false] -> SUCCESS
```