### PR TITLE
Elm: Removed usage of Env from step1 and step2

### DIFF
--- a/elm/Eval.elm
+++ b/elm/Eval.elm
@@ -223,3 +223,16 @@ inGlobal body =
                 else
                     body
             )
+
+
+runSimple : Eval a -> Result MalExpr a
+runSimple e =
+    case run Env.global e of
+        ( _, EvalOk res ) ->
+            Ok res
+
+        ( _, EvalErr msg ) ->
+            Err msg
+
+        _ ->
+            Debug.crash "can't happen"

--- a/elm/Printer.elm
+++ b/elm/Printer.elm
@@ -7,6 +7,11 @@ import Utils exposing (encodeString, wrap)
 import Env
 
 
+printStr : Bool -> MalExpr -> String
+printStr =
+    printString Env.global
+
+
 printString : Env -> Bool -> MalExpr -> String
 printString env readably ast =
     case ast of
@@ -40,18 +45,6 @@ printString env readably ast =
         MalMap map ->
             printMap env readably map
 
-        MalFunction (UserFunc { frameId, meta }) ->
-            "#<function "
-                ++ (toString frameId)
-                ++ (case meta of
-                        Nothing ->
-                            ""
-
-                        Just meta ->
-                            " meta=" ++ printString env True meta
-                   )
-                ++ ">"
-
         MalFunction _ ->
             "#<function>"
 
@@ -62,8 +55,8 @@ printString env readably ast =
             in
                 "(atom " ++ (printString env True value) ++ ")"
 
-        MalApply { frameId, bound } ->
-            "#<apply " ++ (toString frameId) ++ " bound=" ++ (printBound env True bound) ++ ">"
+        MalApply _ ->
+            "#<apply>"
 
 
 printBound : Env -> Bool -> List ( String, MalExpr ) -> String

--- a/elm/step1_read_print.elm
+++ b/elm/step1_read_print.elm
@@ -5,8 +5,7 @@ import Json.Decode exposing (decodeValue)
 import Platform exposing (programWithFlags)
 import Types exposing (MalExpr(..))
 import Reader exposing (readString)
-import Printer exposing (printString)
-import Env
+import Printer exposing (printStr)
 
 
 main : Program Flags Model Msg
@@ -86,7 +85,7 @@ eval ast =
 
 print : MalExpr -> String
 print =
-    printString Env.global True
+    printStr True
 
 
 {-| Read-Eval-Print

--- a/elm/step2_eval.elm
+++ b/elm/step2_eval.elm
@@ -5,13 +5,12 @@ import Json.Decode exposing (decodeValue)
 import Platform exposing (programWithFlags)
 import Types exposing (..)
 import Reader exposing (readString)
-import Printer exposing (printString)
+import Printer exposing (printStr)
 import Utils exposing (maybeToList, zip)
 import Dict exposing (Dict)
 import Tuple exposing (mapFirst, second)
 import Array
 import Eval
-import Env
 
 
 main : Program Flags Model Msg
@@ -135,15 +134,12 @@ eval env ast =
                             ( Err "can't happen", newEnv )
 
                         (MalFunction (CoreFunc fn)) :: args ->
-                            case second <| Eval.run Env.global (fn args) of
-                                EvalOk res ->
+                            case Eval.runSimple (fn args) of
+                                Ok res ->
                                     ( Ok res, newEnv )
 
-                                EvalErr msg ->
+                                Err msg ->
                                     ( Err (print msg), newEnv )
-
-                                _ ->
-                                    Debug.crash "can't happen"
 
                         fn :: _ ->
                             ( Err ((print fn) ++ " is not a function"), newEnv )
@@ -232,7 +228,7 @@ tryMapList fn list =
 
 print : MalExpr -> String
 print =
-    printString Env.global True
+    printStr True
 
 
 {-| Read-Eval-Print. rep returns:

--- a/elm/step3_env.elm
+++ b/elm/step3_env.elm
@@ -135,15 +135,12 @@ eval env ast =
                             ( Err "can't happen", newEnv )
 
                         (MalFunction (CoreFunc fn)) :: args ->
-                            case second <| Eval.run Env.global (fn args) of
-                                EvalOk res ->
+                            case Eval.runSimple (fn args) of
+                                Ok res ->
                                     ( Ok res, newEnv )
 
-                                EvalErr msg ->
+                                Err msg ->
                                     ( Err (print msg), newEnv )
-
-                                _ ->
-                                    Debug.crash "can't happen"
 
                         fn :: _ ->
                             ( Err ((print fn) ++ " is not a function"), newEnv )


### PR DESCRIPTION
- Removed the (direct) import of Env in step1 and step2.
- Simplified use of Eval in the first 3 steps.
- Cleaned up some debugging code in Printer.