### PR TITLE
Fix for PHP 7 compatibility 

### DIFF
--- a/php/core.php
+++ b/php/core.php
@@ -6,7 +6,7 @@ require_once 'reader.php';
 require_once 'printer.php';
 
 // Error/Exception functions
-function mal_throw($obj) { throw new Error($obj); }
+function mal_throw($obj) { throw new _Error($obj); }
 
 
 // String functions

--- a/php/step9_try.php
+++ b/php/step9_try.php
@@ -119,7 +119,7 @@ function MAL_EVAL($ast, $env) {
         if ($a2[0]->value === "catch*") {
             try {
                 return MAL_EVAL($a1, $env);
-            } catch (Error $e) {
+            } catch (_Error $e) {
                 $catch_env = new Env($env, array($a2[1]),
                                             array($e->obj));
                 return MAL_EVAL($a2[2], $catch_env);

--- a/php/stepA_mal.php
+++ b/php/stepA_mal.php
@@ -124,7 +124,7 @@ function MAL_EVAL($ast, $env) {
         if ($a2[0]->value === "catch*") {
             try {
                 return MAL_EVAL($a1, $env);
-            } catch (Error $e) {
+            } catch (_Error $e) {
                 $catch_env = new Env($env, array($a2[1]),
                                             array($e->obj));
                 return MAL_EVAL($a2[2], $catch_env);

--- a/php/types.php
+++ b/php/types.php
@@ -2,7 +2,7 @@
 
 
 // Errors/Exceptions
-class Error extends Exception {
+class _Error extends Exception {
     public $obj = null;
     public function __construct($obj) {
         parent::__construct("Mal Error", 0, null);


### PR DESCRIPTION
This PR renames the Error class to _Error, so that it doesn't interfere with PHP 7's own internal Error class. Mal is otherwise running just fine with PHP 7.0.