### PR TITLE
Update Elixir syntax & version to work with v1.5.x

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:vivid
+FROM ubuntu:xenial
 MAINTAINER Joel Martin <github@martintribe.org>
 
 ##########################################################
@@ -22,8 +22,9 @@ WORKDIR /mal
 ##########################################################
 
 # Elixir
-RUN curl -O https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
-    && dpkg -i erlang-solutions_1.0_all.deb
-RUN apt-get -y update
-RUN apt-get -y install elixir
-
+RUN apt-get install -y wget
+RUN wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
+RUN dpkg -i erlang-solutions_1.0_all.deb
+RUN apt-get update -y
+RUN apt-get install -y esl-erlang
+RUN apt-get install -y elixir

--- a/elixir/lib/mal/core.ex
+++ b/elixir/lib/mal/core.ex
@@ -75,7 +75,7 @@ defmodule Mal.Core do
   def readline(prompt) do
     IO.write(:stdio, prompt)
     IO.read(:stdio, :line)
-      |> String.strip(?\n)
+      |> String.trim("\n")
   end
 
   defp convert_vector({type, ast, meta}) when type == :map do
@@ -223,9 +223,9 @@ defmodule Mal.Core do
   end
 
   defp seq([nil]), do: nil
-  defp seq([{:list, [], meta}]), do: nil
+  defp seq([{:list, [], _meta}]), do: nil
   defp seq([{:list, ast, meta}]), do: {:list, ast, meta}
-  defp seq([{:vector, [], meta}]), do: nil
+  defp seq([{:vector, [], _meta}]), do: nil
   defp seq([{:vector, ast, meta}]), do: {:list, ast, meta}
   defp seq([""]), do: nil
   defp seq([s]), do: {:list, String.split(s, "", trim: true), nil}

--- a/elixir/lib/mix/tasks/step0_repl.ex
+++ b/elixir/lib/mix/tasks/step0_repl.ex
@@ -1,12 +1,12 @@
 defmodule Mix.Tasks.Step0Repl do
-  def run(_), do: loop
+  def run(_), do: loop()
 
   defp loop do
     Mal.Core.readline("user> ")
       |> read_eval_print
       |> IO.puts
 
-    loop
+    loop()
   end
 
   defp read(input) do

--- a/elixir/lib/mix/tasks/step1_read_print.ex
+++ b/elixir/lib/mix/tasks/step1_read_print.ex
@@ -1,12 +1,12 @@
 defmodule Mix.Tasks.Step1ReadPrint do
-  def run(_), do: loop
+  def run(_), do: loop()
 
   defp loop do
     Mal.Core.readline("user> ")
       |> read_eval_print
       |> IO.puts
 
-    loop
+    loop()
   end
 
   defp read(input) do

--- a/elixir/lib/mix/tasks/step2_eval.ex
+++ b/elixir/lib/mix/tasks/step2_eval.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Step2Eval do
     "/" => &div/2
   }
 
-  def run(_), do: loop
+  def run(_), do: loop()
 
   defp loop do
     IO.write(:stdio, "user> ")
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Step2Eval do
       |> read_eval_print
       |> IO.puts
 
-    loop
+    loop()
   end
 
   defp eval_ast({:list, ast, meta}, env) when is_list(ast) do
@@ -46,7 +46,7 @@ defmodule Mix.Tasks.Step2Eval do
     Mal.Reader.read_str(input)
   end
 
-  defp eval({:list, [], _} = empty_ast, env), do: empty_ast
+  defp eval({:list, [], _} = empty_ast, _env), do: empty_ast
   defp eval({:list, ast, meta}, env), do: eval_list(ast, env, meta)
   defp eval(ast, env), do: eval_ast(ast, env)
 

--- a/elixir/lib/mix/tasks/step3_env.ex
+++ b/elixir/lib/mix/tasks/step3_env.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Step3Env do
     Mal.Reader.read_str(input)
   end
 
-  defp eval_bindings([], _env), do: _env
+  defp eval_bindings([], env), do: env
   defp eval_bindings([{:symbol, key}, binding | tail], env) do
     evaluated = eval(binding, env)
     Mal.Env.set(env, key, evaluated)
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Step3Env do
   end
   defp eval_bindings(_bindings, _env), do: throw({:error, "Unbalanced let* bindings"})
 
-  defp eval({:list, [], _} = empty_ast, env), do: empty_ast
+  defp eval({:list, [], _} = empty_ast, _env), do: empty_ast
   defp eval({:list, ast, meta}, env), do: eval_list(ast, env, meta)
   defp eval(ast, env), do: eval_ast(ast, env)
 

--- a/elixir/lib/mix/tasks/step4_if_fn_do.ex
+++ b/elixir/lib/mix/tasks/step4_if_fn_do.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Step4IfFnDo do
     Mal.Reader.read_str(input)
   end
 
-  defp eval_bindings([], _env), do: _env
+  defp eval_bindings([], env), do: env
   defp eval_bindings([{:symbol, key}, binding | tail], env) do
     evaluated = eval(binding, env)
     Mal.Env.set(env, key, evaluated)
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Step4IfFnDo do
   end
   defp eval_bindings(_bindings, _env), do: throw({:error, "Unbalanced let* bindings"})
 
-  defp eval({:list, [], _} = empty_ast, env), do: empty_ast
+  defp eval({:list, [], _} = empty_ast, _env), do: empty_ast
   defp eval({:list, ast, meta}, env), do: eval_list(ast, env, meta)
   defp eval(ast, env), do: eval_ast(ast, env)
 

--- a/elixir/lib/mix/tasks/step5_tco.ex
+++ b/elixir/lib/mix/tasks/step5_tco.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Step5Tco do
     Mal.Reader.read_str(input)
   end
 
-  defp eval_bindings([], _env), do: _env
+  defp eval_bindings([], env), do: env
   defp eval_bindings([{:symbol, key}, binding | tail], env) do
     evaluated = eval(binding, env)
     Mal.Env.set(env, key, evaluated)
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Step5Tco do
   end
   defp eval_bindings(_bindings, _env), do: throw({:error, "Unbalanced let* bindings"})
 
-  defp eval({:list, [], _} = empty_ast, env), do: empty_ast
+  defp eval({:list, [], _} = empty_ast, _env), do: empty_ast
   defp eval({:list, ast, meta}, env), do: eval_list(ast, env, meta)
   defp eval(ast, env), do: eval_ast(ast, env)
 

--- a/elixir/lib/mix/tasks/step6_file.ex
+++ b/elixir/lib/mix/tasks/step6_file.ex
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.Step6File do
     Mal.Reader.read_str(input)
   end
 
-  defp eval_bindings([], _env), do: _env
+  defp eval_bindings([], env), do: env
   defp eval_bindings([{:symbol, key}, binding | tail], env) do
     evaluated = eval(binding, env)
     Mal.Env.set(env, key, evaluated)
@@ -90,7 +90,7 @@ defmodule Mix.Tasks.Step6File do
   end
   defp eval_bindings(_bindings, _env), do: throw({:error, "Unbalanced let* bindings"})
 
-  defp eval({:list, [], _} = empty_ast, env), do: empty_ast
+  defp eval({:list, [], _} = empty_ast, _env), do: empty_ast
   defp eval({:list, ast, meta}, env), do: eval_list(ast, env, meta)
   defp eval(ast, env), do: eval_ast(ast, env)
 

--- a/elixir/lib/mix/tasks/step7_quote.ex
+++ b/elixir/lib/mix/tasks/step7_quote.ex
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.Step7Quote do
     Mal.Reader.read_str(input)
   end
 
-  defp eval_bindings([], _env), do: _env
+  defp eval_bindings([], env), do: env
   defp eval_bindings([{:symbol, key}, binding | tail], env) do
     evaluated = eval(binding, env)
     Mal.Env.set(env, key, evaluated)
@@ -114,7 +114,7 @@ defmodule Mix.Tasks.Step7Quote do
   end
   defp quasiquote(ast, _env), do: list([{:symbol, "quote"}, ast])
 
-  defp eval({:list, [], _} = empty_ast, env), do: empty_ast
+  defp eval({:list, [], _} = empty_ast, _env), do: empty_ast
   defp eval({:list, ast, meta}, env), do: eval_list(ast, env, meta)
   defp eval(ast, env), do: eval_ast(ast, env)
 

--- a/elixir/lib/mix/tasks/step8_macros.ex
+++ b/elixir/lib/mix/tasks/step8_macros.ex
@@ -105,7 +105,7 @@ defmodule Mix.Tasks.Step8Macros do
     Mal.Reader.read_str(input)
   end
 
-  defp eval_bindings([], _env), do: _env
+  defp eval_bindings([], env), do: env
   defp eval_bindings([{:symbol, key}, binding | tail], env) do
     evaluated = eval(binding, env)
     Mal.Env.set(env, key, evaluated)
@@ -159,7 +159,7 @@ defmodule Mix.Tasks.Step8Macros do
     end
   end
 
-  defp eval({:list, [], _} = empty_ast, env), do: empty_ast
+  defp eval({:list, [], _} = empty_ast, _env), do: empty_ast
   defp eval({:list, _list, _meta} = ast, env) do
     case macroexpand(ast, env) do
       {:list, list, meta} -> eval_list(list, env, meta)

--- a/elixir/lib/mix/tasks/step9_try.ex
+++ b/elixir/lib/mix/tasks/step9_try.ex
@@ -105,7 +105,7 @@ defmodule Mix.Tasks.Step9Try do
     Mal.Reader.read_str(input)
   end
 
-  defp eval_bindings([], _env), do: _env
+  defp eval_bindings([], env), do: env
   defp eval_bindings([{:symbol, key}, binding | tail], env) do
     evaluated = eval(binding, env)
     Mal.Env.set(env, key, evaluated)
@@ -159,7 +159,7 @@ defmodule Mix.Tasks.Step9Try do
     end
   end
 
-  defp eval({:list, [], _} = empty_ast, env), do: empty_ast
+  defp eval({:list, [], _} = empty_ast, _env), do: empty_ast
   defp eval({:list, _list, _meta} = ast, env) do
     case macroexpand(ast, env) do
       {:list, list, meta} -> eval_list(list, env, meta)

--- a/elixir/lib/mix/tasks/stepA_mal.ex
+++ b/elixir/lib/mix/tasks/stepA_mal.ex
@@ -124,7 +124,7 @@ defmodule Mix.Tasks.StepAMal do
     Mal.Reader.read_str(input)
   end
 
-  defp eval_bindings([], _env), do: _env
+  defp eval_bindings([], env), do: env
   defp eval_bindings([{:symbol, key}, binding | tail], env) do
     evaluated = eval(binding, env)
     Mal.Env.set(env, key, evaluated)
@@ -178,7 +178,7 @@ defmodule Mix.Tasks.StepAMal do
     end
   end
 
-  defp eval({:list, [], _} = empty_ast, env), do: empty_ast
+  defp eval({:list, [], _} = empty_ast, _env), do: empty_ast
   defp eval({:list, _list, _meta} = ast, env) do
     case macroexpand(ast, env) do
       {:list, list, meta} -> eval_list(list, env, meta)

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -4,12 +4,12 @@ defmodule Mal.Mixfile do
   def project do
     [app: :mal,
      version: "0.0.1",
-     elixir: "~> 1.0",
+     elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      default_task: "stepA_mal",
-     escript: escript]
+     escript: escript()]
   end
 
   def escript do


### PR DESCRIPTION
The v1.0 syntax was deprecated, and threw a lot of deprecation warnings.  I fixed the warnings, and bumped the Elixir version to v1.5.  I shouldn't have introduced any bugs, but there aren't any tests, so hard to know for sure.