### PR TITLE
Elisp fixes

### DIFF
--- a/elisp/core.el
+++ b/elisp/core.el
@@ -223,8 +223,7 @@
 
     (meta . ,(mal-fn (lambda (mal-object) (or (mal-meta mal-object) mal-nil))))
     (with-meta . ,(mal-fn (lambda (mal-object meta)
-                            ;; TODO: doesn't work on hashtables
-                            (let ((mal-object* (copy-tree mal-object t)))
+                            (let ((mal-object* (copy-sequence mal-object)))
                               (setf (aref mal-object* 2) meta)
                               mal-object*))))
 

--- a/elisp/types.el
+++ b/elisp/types.el
@@ -18,7 +18,7 @@
        (defun ,constructor (&optional value meta)
          (vector ',name value meta))
        (defun ,predicate (arg)
-         (and (arrayp arg) (eq (aref arg 0) ',name))))))
+         (and (vectorp arg) (eq (aref arg 0) ',name))))))
 
 (mal-object nil)
 (mal-object true)


### PR DESCRIPTION
I've remembered there was still one TODO left.  Speaking of which, is it OK to do a shallow copy for `with-meta` or could that be problematic for the atom type?  If I understand correctly this is about ensuring that the meta flag is independent for objects, even if their other properties are structurally shared.