### PR TITLE
New tests for steps 7 and 9

### DIFF
--- a/tests/step7_quote.mal
+++ b/tests/step7_quote.mal
@@ -25,6 +25,8 @@ a
 ;=>(1 2 3 4 5 6)
 (concat (concat))
 ;=>()
+(concat (list) (list))
+;=>()
 
 (def! a (list 1 2))
 (def! b (list 3 4))

--- a/tests/step7_quote.mal
+++ b/tests/step7_quote.mal
@@ -72,7 +72,8 @@ b
 ;=>(1 b 3)
 (quasiquote (1 (unquote b) 3))
 ;=>(1 (1 "b" "d") 3)
-
+(quasiquote ((unquote 1) (unquote 2)))
+;=>(1 2)
 
 ;; Testing splice-unquote
 (def! c (quote (1 "b" "d")))

--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -139,6 +139,9 @@
 (map (fn* (a) (* 2 a)) [1 2 3])
 ;=>(2 4 6)
 
+(map (fn* [& args] (list? args)) [1 2])
+;=>(true true)
+
 ;; Testing vector functions
 
 (vector? [10 11])


### PR DESCRIPTION
Split from PR #310, to avoid accidentally breaking other implementations.
(after reading comment in PR #240) 

These catch three errors in the NASM implementation which only appeared in self-hosting.