### PR TITLE
Update guide with note on reader macro with-meta

### DIFF
--- a/process/guide.md
+++ b/process/guide.md
@@ -1527,6 +1527,11 @@ diff -urp ../process/step9_try.txt ../process/stepA_mal.txt
     returned that has its `meta` attribute set to the second argument.
     Note that it is important that the environment and macro attribute
     of mal function are retained when it is copied.
+  * Add a reader-macro that expands the token "^" to
+    return a new list that contains the symbol "with-meta" and the
+    result of reading the next next form (2nd argument) (`read_form`) and the
+    next form (1st argument) in that order
+    (metadata comes first with the ^ macro and the function second).
 
 * Add a new "\*host-language\*" (symbol) entry to your REPL
   environment. The value of this entry should be a mal string


### PR DESCRIPTION
Guide was missing the deferrable step of having
a reader macro for ^ (which is included in the
tests for step A) which caused some confusion
as to what it was.

It's included in the tests/step1_read_print.mal
but not mentioned in the docs.