### PR TITLE
Fix typo in Common Lisp section of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ cd chuck
 
 The implementation has been tested with SBCL, CCL, CMUCL, GNU CLISP, ECL and
 Allegro CL on Ubuntu 16.04 and Ubuntu 12.04, see
-the [README][common-lisp/README.org] for more details. Provided you have the
+the [README](common-lisp/README.org) for more details. Provided you have the
 dependencies mentioned installed, do the following to run the implementation
 
 ```


### PR DESCRIPTION
The link to the Common Lisp readme in the project readme was not formatted correctly. This is a small PR that just fixes that.