### PR TITLE
PHP: refactor web running mechanism.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ objpascal/regexpr/Source/RegExpr.ppu
 perl/mal.pl
 perl6/.precomp/
 php/mal.php
+php/mal-web.php
 ps/mal.ps
 python/mal.pyz
 r/mal.r

--- a/php/Makefile
+++ b/php/Makefile
@@ -17,8 +17,11 @@ mal: mal.php
 	cat $< >> $@
 	chmod +x $@
 
+mal-web.php: mal.php
+	cat $< | ( IFS="NON-MATCHING-IFS"; while read -r line; do if [ "$$line" = "// run mal file" ]; then echo "?>"; cat webrunner.php; echo "<?php"; fi; printf '%s\n' "$$line"; done < "$<" ) > $@
+
 clean:
-	rm -f mal.php mal
+	rm -f mal.php mal mal-web.php
 
 .PHONY: stats tests $(TESTS)
 

--- a/php/README.md
+++ b/php/README.md
@@ -1,16 +1,20 @@
 ### Running .mal scripts on PHP hosting ###
 
-Create a symlink to `mal.php` with the same name as your `.mal` script and your script will be executed as if it was PHP.
+Create a symlink to `mal-web.php` with the same name as your `.mal` script and your script will be executed as if it was PHP.
 
-Here's an example using local dev:
+Here's an example using local dev.
 
-	cd php
-	make mal.php
-	echo '(prn "Hello world!")' > myscript.mal
-	ln -s mal.php myscript.php
-	php -S 0.0.0.0:8000
+First build `mal-web.php`:
 
-Then browse to http://localhost:8000/myscript.php and you should see "Hello world!" in your browser as `myscript.mal` is run.
+	cd mal/php
+	make mal-web.php
+
+Now you can create a web runnable mal script:
+
+	echo '(println "Hello world!")' > myscript.mal
+	ln -s mal-web.php myscript.php
+
+Start a development server with `php -S 0.0.0.0:8000` and then browse to http://localhost:8000/myscript.php and you should see "Hello world!" in your browser as `myscript.mal` is run.
 
 You can do the same thing on live PHP web hosting by copying `mal.php` up and creating a symlink for each `.mal` file you want to be web-executable.
 

--- a/php/stepA_mal.php
+++ b/php/stepA_mal.php
@@ -225,13 +225,7 @@ rep("(def! *gensym-counter* (atom 0))");
 rep("(def! gensym (fn* [] (symbol (str \"G__\" (swap! *gensym-counter* (fn* [x] (+ 1 x)))))))");
 rep("(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) (let* (condvar (gensym)) `(let* (~condvar ~(first xs)) (if ~condvar ~condvar (or ~@(rest xs)))))))))");
 
-// if we're called in a webserver context, auto-resolve to mal file
-if (php_sapi_name() != "cli") {
-    $malfile = str_replace(".php", ".mal", $_SERVER['SCRIPT_FILENAME']);
-    rep('(load-file "' . $malfile . '")');
-    exit(0);
-}
-
+// run mal file
 if (count($argv) > 1) {
     rep('(load-file "' . $argv[1] . '")');
     exit(0);

--- a/php/webrunner.php
+++ b/php/webrunner.php
@@ -1,0 +1,8 @@
+<?php
+// if we're called in a webserver context, auto-resolve to mal file
+if (php_sapi_name() != "cli") {
+    $malfile = str_replace(".php", ".mal", $_SERVER['SCRIPT_FILENAME']);
+    rep('(load-file "' . $malfile . '")');
+    exit(0);
+}
+?>


### PR DESCRIPTION
Hi @kanaka,

This change is to make it easier to re-use `php/mal` in other projects. It pulls the web runner code out into `webrunner.php` and includes it at build time instead of including that code directly in `stepA_mal.php`.

I made this change to help with [frock](https://github.com/chr15m/frock), which is an experimental tool to build single-artifact PHP scripts from `mal` code. It relies heavily on and is itself written in `mal`. I also cleaned up the documentation a little.