### PR TITLE
Updated PHP native interop interface.

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -32,11 +32,11 @@ Eval PHP code:
 
 Native function call:
 
-	(! date "Y-m-d" 0)
-	1970-01-01
+	(php/date "Y-m-d" 0)
+	"1970-01-01"
 
 Accessing PHP "superglobal" variables:
 
-	(get ($ "_SERVER") "PHP_SELF")
-	./mal
+	(get php/_SERVER "PHP_SELF")
+	"./mal"
 

--- a/php/interop.php
+++ b/php/interop.php
@@ -45,4 +45,20 @@ function _to_mal($obj) {
     }
 }
 
+function _to_native($name, $env) {
+  if (is_callable($name)) {
+    return _function(function() use ($name) {
+      $args = array_map("_to_php", func_get_args());
+      $res = call_user_func_array($name, $args);
+      return _to_mal($res);
+    });
+  } else if (in_array($name, ["_SERVER", "_GET", "_POST", "_FILES", "_REQUEST", "_SESSION", "_ENV", "_COOKIE"])) {
+      $val = $GLOBALS[$name];
+  } else if (defined($name)) {
+      $val = constant($name);
+  } else {
+      $val = ${$name};
+  }
+  return _to_mal($val);
+}
 ?>

--- a/php/reader.php
+++ b/php/reader.php
@@ -27,7 +27,7 @@ function _real_token($s) {
 }
 
 function tokenize($str) {
-    $pat = "/[\s,]*(~@|[\[\]{}()'`~^@]|\"(?:\\\\.|[^\\\\\"])*\"|;.*|[^\s\[\]{}('\"`,;)]*)/";
+    $pat = "/[\s,]*(php\/|~@|[\[\]{}()'`~^@]|\"(?:\\\\.|[^\\\\\"])*\"|;.*|[^\s\[\]{}('\"`,;)]*)/";
     preg_match_all($pat, $str, $matches);
     return array_values(array_filter($matches[1], '_real_token'));
 }
@@ -100,6 +100,10 @@ function read_form($reader) {
 
     case '@':  $reader->next();
                return _list(_symbol('deref'),
+                               read_form($reader));
+
+    case 'php/': $reader->next();
+               return _list(_symbol('to-native'),
                                read_form($reader));
 
     case ')': throw new Exception("unexpected ')'");

--- a/php/stepA_mal.php
+++ b/php/stepA_mal.php
@@ -72,7 +72,6 @@ function eval_ast($ast, $env) {
 }
 
 function MAL_EVAL($ast, $env) {
-    $_SUPERGLOBALS = ["_SERVER", "_GET", "_POST", "_FILES", "_REQUEST", "_SESSION", "_ENV", "_COOKIE"];
     while (true) {
 
     #echo "MAL_EVAL: " . _pr_str($ast) . "\n";
@@ -152,27 +151,8 @@ function MAL_EVAL($ast, $env) {
     case "fn*":
         return _function('MAL_EVAL', 'native',
                          $ast[2], $env, $ast[1]);
-    case "$":
-        $var = MAL_EVAL($ast[1], $env);
-        if (_symbol_Q($var)) {
-          $varname = $var->value;
-        } elseif (gettype($var) === "string") {
-          $varname = $var;
-        } else {
-          throw new Exception("$ arg unknown type: " . gettype($var));
-        }
-        if (in_array($varname, $_SUPERGLOBALS)) {
-            $val = $GLOBALS[$varname];
-        } else {
-            $val = ${$varname};
-        }
-        return _to_mal($val);
-    case "!":
-        $fn = $ast[1]->value;
-        $el = eval_ast($ast->slice(2), $env);
-        $args = _to_php($el);
-        $res = call_user_func_array($fn, $args);
-        return _to_mal($res);
+    case "to-native":
+        return _to_native($ast[1]->value, $env);
     default:
         $el = eval_ast($ast, $env);
         $f = $el[0];

--- a/php/tests/stepA_mal.mal
+++ b/php/tests/stepA_mal.mal
@@ -26,15 +26,20 @@
 
 ;; testing native function calling
 
-(! date "Y-m-d" 0)
+(php/date "Y-m-d" 0)
 ;=>"1970-01-01"
 
 ;; testing native function with mal callback
 
-(! array_map (fn* [t] (if (> t 3) t)) [1 2 3 4 5 6])
+(php/array_map (fn* [t] (if (> t 3) t)) [1 2 3 4 5 6])
 ;=>(nil nil nil 4 5 6)
 
 ;; testing superglobal variable access
 
-(get ($ "_SERVER") "PHP_SELF")
+(get php/_SERVER "PHP_SELF")
 ;=>"../php/stepA_mal.php"
+
+;; testing PHP constants access
+
+php/FILE_APPEND
+;=>8


### PR DESCRIPTION
Hi @kanaka,

This is a change to the way the PHP interop presents to the end user and to clean up the interface. Interop is now exposed via the `php/` prefix for reaching into the PHP "namespace" and is the same for referencing functions and variables.

Previously to make native function call you'd do: `(! str_replace "l" "x" "hello")` whereas this patch changes it to work like this: `(php/str_replace "l" "x" "hello")`.

Likewise for referencing PHP global vars you previously used `($ "_SERVER")` whereas with this patch you instead use `php/_SERVER`.

These changes make the interop more Clojure-like which has e.g. the `js/...` namespace for referencing JavaScript objects. An added benefit is that editors now know you mean `php/str_replace` as a function call and will highlight it appropriately.

I made this change to help with [frock](https://github.com/chr15m/frock), which is an experimental tool to build single-artifact PHP scripts from `mal` code. I'm interested in your feedback on that tool.