### PR TITLE
Test that (not nil) returns true

### DIFF
--- a/tests/step4_if_fn_do.mal
+++ b/tests/step4_if_fn_do.mal
@@ -243,6 +243,8 @@ a
 ;; Testing language defined not function
 (not false)
 ;=>true
+(not nil)
+;=>true
 (not true)
 ;=>false
 (not "a")


### PR DESCRIPTION
In step 4, by mistake I implemented the `not` function in my host language rather than in mal itself as the guide instructs. And I did it poorly. `(not nil)` was returning `false`, and I managed to make it all the way past stepA, not finding the error until the self-hosting tests.

This little test in step 4 should help others I hope!