### PR TITLE
Check that the eval built-in uses Repl instead of a local environment.

### DIFF
--- a/nim/step5_tco.nim
+++ b/nim/step5_tco.nim
@@ -2,7 +2,7 @@ import rdstdin, tables, sequtils, types, reader, printer, env, core
 
 proc read(str: string): MalType = str.read_str
 
-proc eval(ast: MalType, env: var Env): MalType
+proc eval(ast: MalType, env: Env): MalType
 
 proc eval_ast(ast: MalType, env: var Env): MalType =
   case ast.kind
@@ -19,8 +19,9 @@ proc eval_ast(ast: MalType, env: var Env): MalType =
   else:
     result = ast
 
-proc eval(ast: MalType, env: var Env): MalType =
+proc eval(ast: MalType, env: Env): MalType =
   var ast = ast
+  var env = env
 
   template defaultApply =
     let el = ast.eval_ast(env)
@@ -50,7 +51,7 @@ proc eval(ast: MalType, env: var Env): MalType =
         let
           a1 = ast.list[1]
           a2 = ast.list[2]
-        var let_env = env
+        var let_env = initEnv(env)
         case a1.kind
         of List, Vector:
           for i in countup(0, a1.list.high, 2):

--- a/nim/step6_file.nim
+++ b/nim/step6_file.nim
@@ -2,7 +2,7 @@ import rdstdin, tables, sequtils, os, types, reader, printer, env, core
 
 proc read(str: string): MalType = str.read_str
 
-proc eval(ast: MalType, env: var Env): MalType
+proc eval(ast: MalType, env: Env): MalType
 
 proc eval_ast(ast: MalType, env: var Env): MalType =
   case ast.kind
@@ -19,8 +19,9 @@ proc eval_ast(ast: MalType, env: var Env): MalType =
   else:
     result = ast
 
-proc eval(ast: MalType, env: var Env): MalType =
+proc eval(ast: MalType, env: Env): MalType =
   var ast = ast
+  var env = env
 
   template defaultApply =
     let el = ast.eval_ast(env)
@@ -50,7 +51,7 @@ proc eval(ast: MalType, env: var Env): MalType =
         let
           a1 = ast.list[1]
           a2 = ast.list[2]
-        var let_env = env
+        var let_env = initEnv(env)
         case a1.kind
         of List, Vector:
           for i in countup(0, a1.list.high, 2):

--- a/nim/step7_quote.nim
+++ b/nim/step7_quote.nim
@@ -16,7 +16,7 @@ proc quasiquote(ast: MalType): MalType =
   else:
     return list(symbol "cons", quasiquote(ast.list[0]), quasiquote(list(ast.list[1 .. ^1])))
 
-proc eval(ast: MalType, env: var Env): MalType
+proc eval(ast: MalType, env: Env): MalType
 
 proc eval_ast(ast: MalType, env: var Env): MalType =
   case ast.kind
@@ -33,8 +33,9 @@ proc eval_ast(ast: MalType, env: var Env): MalType =
   else:
     result = ast
 
-proc eval(ast: MalType, env: var Env): MalType =
+proc eval(ast: MalType, env: Env): MalType =
   var ast = ast
+  var env = env
 
   template defaultApply =
     let el = ast.eval_ast(env)
@@ -64,7 +65,7 @@ proc eval(ast: MalType, env: var Env): MalType =
         let
           a1 = ast.list[1]
           a2 = ast.list[2]
-        var let_env = env
+        var let_env = initEnv(env)
         case a1.kind
         of List, Vector:
           for i in countup(0, a1.list.high, 2):

--- a/nim/step8_macros.nim
+++ b/nim/step8_macros.nim
@@ -17,7 +17,7 @@ proc quasiquote(ast: MalType): MalType =
     return list(symbol "cons", quasiquote(ast.list[0]), quasiquote(list(ast.list[1 .. ^1])))
 
 proc is_macro_call(ast: MalType, env: Env): bool =
-  ast.kind == List and ast.list[0].kind == Symbol and
+  ast.kind == List and ast.list.len > 0 and ast.list[0].kind == Symbol and
     env.find(ast.list[0].str) != nil and env.get(ast.list[0].str).fun_is_macro
 
 proc macroexpand(ast: MalType, env: Env): MalType =
@@ -78,7 +78,7 @@ proc eval(ast: MalType, env: Env): MalType =
         let
           a1 = ast.list[1]
           a2 = ast.list[2]
-        var let_env = env
+        var let_env = initEnv(env)
         case a1.kind
         of List, Vector:
           for i in countup(0, a1.list.high, 2):

--- a/nim/step9_try.nim
+++ b/nim/step9_try.nim
@@ -79,7 +79,7 @@ proc eval(ast: MalType, env: Env): MalType =
         let
           a1 = ast.list[1]
           a2 = ast.list[2]
-        var let_env = env
+        var let_env = initEnv(env)
         case a1.kind
         of List, Vector:
           for i in countup(0, a1.list.high, 2):

--- a/nim/stepA_mal.nim
+++ b/nim/stepA_mal.nim
@@ -79,7 +79,7 @@ proc eval(ast: MalType, env: Env): MalType =
         let
           a1 = ast.list[1]
           a2 = ast.list[2]
-        var let_env = env
+        var let_env = initEnv(env)
         case a1.kind
         of List, Vector:
           for i in countup(0, a1.list.high, 2):

--- a/tests/step6_file.mal
+++ b/tests/step6_file.mal
@@ -125,3 +125,8 @@ mymap
 (g 3)
 ;=>81
 
+;; Checking that eval does not use local environments.
+(def! a 1)
+;=>1
+(let* (a 2) (eval (read-string "a")))
+;=>1

--- a/tests/step7_quote.mal
+++ b/tests/step7_quote.mal
@@ -181,3 +181,9 @@ b
 ;;; TODO: fix this
 ;;;;=>[1 1 "b" "d" 3]
 
+;; Checking that eval does not use local environments.
+;; Test step6, but requires a quote.
+(def! a 1)
+;=>1
+(let* (a 2) (eval 'a))
+;=>1

--- a/tests/step7_quote.mal
+++ b/tests/step7_quote.mal
@@ -181,9 +181,3 @@ b
 ;;; TODO: fix this
 ;;;;=>[1 1 "b" "d" 3]
 
-;; Checking that eval does not use local environments.
-;; Test step6, but requires a quote.
-(def! a 1)
-;=>1
-(let* (a 2) (eval 'a))
-;=>1


### PR DESCRIPTION
The description in process/guide.md states:
> The closure calls the your `EVAL` function using the `ast` as the first argument and the REPL environment (closed over from outside) as the second argument.
Reading this, I would expect
```
   (def! a 1)
   let* (a 1) (eval 'a))

```
to answer 1.
The only failing implementation is nim, and it seems to use a local environment instead of repl_env when evaluating the (locally evaluated) first argument.
The suggested test is after
`;>>> optional=True
and should be visible as an optional test.
I have no opinion about this, but process/guide.md should be updated if repl_env is not required.