### PR TITLE
guide.md: Don't use vectors in step 4 when they're still deferrable.

### DIFF
--- a/process/guide.md
+++ b/process/guide.md
@@ -765,10 +765,10 @@ the apply section of `EVAL`.
 
 Try out the basic functionality you have implemented:
 
-  * `(fn* [a] a)` -> `#<function>`
-  * `( (fn* [a] a) 7)` -> `7`
-  * `( (fn* [a] (+ a 1)) 10)` -> `11`
-  * `( (fn* [a b] (+ a b)) 2 3)` -> `5`
+  * `(fn* (a) a)` -> `#<function>`
+  * `( (fn* (a) a) 7)` -> `7`
+  * `( (fn* (a) (+ a 1)) 10)` -> `11`
+  * `( (fn* (a b) (+ a b)) 2 3)` -> `5`
 
 * Add a new file `core.qx` and define an associative data structure
   `ns` (namespace) that maps symbols to functions. Move the numeric


### PR DESCRIPTION
Thank you for mal.  I've been enjoying working my way through the process. I've reached step 4, but not yet implemented vectors. The manual tests of `fn*` in step 4, though, use vectors to specify the function parameters. This may be idiomatic mal, but it doesn't work if you've deferred implementing vectors. Thus, I think it would be better to use lists here, like the automated tests do.