### PR TITLE
Mark step 4 tests that use strings as deferrable.

### DIFF
--- a/tests/step4_if_fn_do.mal
+++ b/tests/step4_if_fn_do.mal
@@ -18,10 +18,10 @@
 ;=>0
 (count nil)
 ;=>0
-(if (> (count (list 1 2 3)) 3) "yes" "no")
-;=>"no"
-(if (>= (count (list 1 2 3)) 3) "yes" "no")
-;=>"yes"
+(if (> (count (list 1 2 3)) 3) 89 78)
+;=>78
+(if (>= (count (list 1 2 3)) 3) 89 78)
+;=>89
 
 
 ;; Testing if form
@@ -38,8 +38,6 @@
 (if nil 7 8)
 ;=>8
 (if 0 7 8)
-;=>7
-(if "" 7 8)
 ;=>7
 (if (list) 7 8)
 ;=>7
@@ -110,18 +108,6 @@
 ;=>true
 (= 1 0)
 ;=>false
-(= "" "")
-;=>true
-(= "abc" "abc")
-;=>true
-(= "abc" "")
-;=>false
-(= "" "abc")
-;=>false
-(= "abc" "def")
-;=>false
-(= "abc" "ABC")
-;=>false
 (= true true)
 ;=>true
 (= false false)
@@ -140,10 +126,6 @@
 (= 0 (list))
 ;=>false
 (= (list) 0)
-;=>false
-(= (list) "")
-;=>false
-(= "" (list))
 ;=>false
 
 
@@ -174,15 +156,15 @@
 ;=>15
 
 ;; Testing do form
-(do (prn "prn output1"))
-;/"prn output1"
+(do (prn 101))
+;/101
 ;=>nil
-(do (prn "prn output2") 7)
-;/"prn output2"
+(do (prn 102) 7)
+;/102
 ;=>7
-(do (prn "prn output1") (prn "prn output2") (+ 1 2))
-;/"prn output1"
-;/"prn output2"
+(do (prn 101) (prn 102) (+ 1 2))
+;/101
+;/102
 ;=>3
 
 (do (def! a 6) 7 (+ a 8))
@@ -221,6 +203,30 @@ a
 ;>>> deferrable=True
 ;;
 ;; -------- Deferrable Functionality --------
+
+;; Testing if on strings
+
+(if "" 7 8)
+;=>7
+
+;; Testing string equality
+
+(= "" "")
+;=>true
+(= "abc" "abc")
+;=>true
+(= "abc" "")
+;=>false
+(= "" "abc")
+;=>false
+(= "abc" "def")
+;=>false
+(= "abc" "ABC")
+;=>false
+(= (list) "")
+;=>false
+(= "" (list))
+;=>false
 
 ;; Testing variable length arguments
 


### PR DESCRIPTION
Hello again. This is another discovery stemming from my extreme laziness. I haven't implemented strings yet, but a bunch of non-deferrable tests at step 4 use strings. I propose fixing this by two means: where the test is of string functionality, I've marked it as deferrable. Where the strings are just constants to be returned or printed by the code, I've replaced them with integers.