### PR TITLE
Trivial simplifications in core.mal.

### DIFF
--- a/core.mal
+++ b/core.mal
@@ -6,30 +6,28 @@
 
 (def! reduce
   (fn* (f init xs)
-    (if (> (count xs) 0)
-      (reduce f (f init (first xs)) (rest xs))
-      init)))
+    (if (empty? xs)
+      init
+      (reduce f (f init (first xs)) (rest xs)))))
 
 (def! identity (fn* (x) x))
 
 (def! every?
   (fn* (pred xs)
-    (if (> (count xs) 0)
+    (if (empty? xs)
+      true
       (if (pred (first xs))
         (every? pred (rest xs))
-        false)
-      true)))
-
-(def! not (fn* (x) (if x false true)))
+        false))))
 
 (def! some
   (fn* (pred xs)
-    (if (> (count xs) 0)
+    (if (empty? xs)
+      nil
       (let* (res (pred (first xs)))
-        (if (pred (first xs))
+        (if res
           res
-          (some pred (rest xs))))
-      nil)))
+          (some pred (rest xs)))))))
 
 (defmacro! and
   (fn* (& xs)
@@ -40,25 +38,6 @@
         (let* (condvar (gensym))
           `(let* (~condvar ~(first xs))
             (if ~condvar (and ~@(rest xs)) ~condvar)))))))
-
-(defmacro! or
-  (fn* (& xs)
-    (if (empty? xs)
-      nil
-      (if (= 1 (count xs))
-        (first xs)
-        (let* (condvar (gensym))
-          `(let* (~condvar ~(first xs))
-             (if ~condvar ~condvar (or ~@(rest xs)))))))))
-
-(defmacro! cond
-  (fn* (& clauses)
-    (if (> (count clauses) 0)
-      (list 'if (first clauses)
-            (if (> (count clauses) 1)
-                (nth clauses 1)
-                (throw "cond requires an even number of forms"))
-            (cons 'cond (rest (rest clauses)))))))
 
 (defmacro! ->
   (fn* (x & xs)
@@ -84,4 +63,6 @@
             (list form x))
           `(->> (->> ~x ~form) ~@more))))))
 
+; This `nil` is intentional so that the result of doing `load-file` is
+; `nil` instead of whatever happens to be at the end of `core.mal`.
 nil


### PR DESCRIPTION
Replace many (= (count xs) 0) with (empty? x).

Stop definining 'not', 'or' and 'cond' in core.mal, they are defined
in the process steps.

In 'some', avoid computing the same result twice.

Remove the final nil evaluation.