### PR TITLE
Another round of minor doc/test fixes

### DIFF
--- a/process/guide.md
+++ b/process/guide.md
@@ -1455,6 +1455,9 @@ self-hosting.
   * `vector?`: takes a single argument and returns true (mal true
     value) if the argument is a vector, otherwise returns false (mal
     false value).
+  * `sequential?`: takes a single arguments and returns true (mal true
+    value) if it is a list or a vector, otherwise returns false (mal
+    false value).
   * `hash-map`: takes a variable but even number of arguments and
     returns a new mal hash-map value with keys from the odd arguments
     and values from the even arguments respectively. This is basically
@@ -1482,9 +1485,6 @@ self-hosting.
     all the keys in the hash-map.
   * `vals`: takes a hash-map and returns a list (mal list value) of
     all the values in the hash-map.
-  * `sequential?`: takes a single arguments and returns true (mal true
-    value) if it is a list or a vector, otherwise returns false (mal
-    false value).
 
 
 <a name="stepA"></a>

--- a/tests/step7_quote.mal
+++ b/tests/step7_quote.mal
@@ -156,7 +156,7 @@ b
 ;;
 ;; -------- Optional Functionality --------
 
-;; Testing cons, concat, first, rest with vectors
+;; Testing cons and concat with vectors
 
 (cons [1] [2 3])
 ;=>([1] 2 3)

--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -15,7 +15,7 @@
 ;=>nil
 
 ;; Make sure error from core can be caught
-(try* (nth [] 1) (catch* exc (prn "exc is:" exc)))
+(try* (nth () 1) (catch* exc (prn "exc is:" exc)))
 ;/"exc is:".*(length|range|[Bb]ounds|beyond).*
 ;=>nil
 

--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -3,8 +3,6 @@
 
 (throw "err1")
 ;/.*([Ee][Rr][Rr][Oo][Rr]|[Ee]xception).*err1.*
-(throw {:msg "err2"})
-;/.*([Ee][Rr][Rr][Oo][Rr]|[Ee]xception).*msg.*err2.*
 
 ;;
 ;; Testing try*/catch*
@@ -91,6 +89,10 @@
 ;;
 ;; ------- Deferrable Functionality ----------
 ;; ------- (Needed for self-hosting) -------
+
+;; Testing throwing a hash-map
+(throw {:msg "err2"})
+;/.*([Ee][Rr][Rr][Oo][Rr]|[Ee]xception).*msg.*err2.*
 
 ;; Testing symbol and keyword functions
 (symbol? :abc)


### PR DESCRIPTION
Hello.  Here are two more fixes for tests that used deferrable features, a fix for an erroneous heading in a test, and a slight improvement to the ordering of the process guide.

PS: My BBC BASIC port has passed step 9, so now I'm busy implementing all the things I deferred.