### PR TITLE
ocaml: Fix result of (concat [1 2]), so it returns a list not a vector.

### DIFF
--- a/ocaml/core.ml
+++ b/ocaml/core.ml
@@ -123,7 +123,8 @@ let init env = begin
     (Types.fn (let rec concat =
                  function
                  | x :: y :: more -> concat ((Types.list ((seq x) @ (seq y))) :: more)
-                 | [x] -> x
+                 | [T.List _ as x] -> x
+                 | [x] -> Types.list (seq x)
                  | [] -> Types.list []
                in concat));
 


### PR DESCRIPTION
It turns out that OCaml is close enough to the ML I learned as an undergraduate that I can fix this bug exposed by #358 as well.