### PR TITLE
Cpp ada.2 conformance

### DIFF
--- a/ada.2/core.adb
+++ b/ada.2/core.adb
@@ -79,7 +79,6 @@ package body Core is
    function Keyword       (Args : in Types.T_Array) return Types.T;
    function Less_Equal    is new Generic_Comparison ("<=");
    function Less_Than     is new Generic_Comparison ("<");
-   function Mal_Do        (Args : in Types.T_Array) return Types.T;
    function Meta          (Args : in Types.T_Array) return Types.T;
    function Pr_Str        (Args : in Types.T_Array) return Types.T;
    function Println       (Args : in Types.T_Array) return Types.T;
@@ -162,12 +161,6 @@ package body Core is
       return (Kind_Keyword, Args (Args'First).Str);
    end Keyword;
 
-   function Mal_Do (Args : in Types.T_Array) return Types.T is
-   begin
-      Err.Check (0 < Args'Length, "expected at least 1 parameter");
-      return Args (Args'Last);
-   end Mal_Do;
-
    function Meta (Args : in Types.T_Array) return Types.T is
    begin
       Err.Check (Args'Length = 1, "expected 1 parameter");
@@ -214,7 +207,6 @@ package body Core is
       P ("deref",       Types.Atoms.Deref'Access);
       P ("dissoc",      Types.Maps.Dissoc'Access);
       P ("/",           Division'Access);
-      P ("do",          Mal_Do'Access);
       P ("=",           Equals'Access);
       P ("first",       Types.Sequences.First'Access);
       P ("get",         Types.Maps.Get'Access);

--- a/ada.2/step4_if_fn_do.adb
+++ b/ada.2/step4_if_fn_do.adb
@@ -118,7 +118,16 @@ procedure Step4_If_Fn_Do is
                Env.all.Set (Key, Val); --  Check key kind.
                return Val;
             end;
-         --  do is a built-in function, shortening this test cascade.
+         elsif First.Str.all = "do" then
+            Err.Check (1 < Ast.Sequence.all.Length, "do expects arguments");
+            declare
+               Result : Types.T;
+            begin
+               for I in 2 .. Ast.Sequence.all.Length loop
+                  Result := Eval (Ast.Sequence.all.Data (I), Env);
+               end loop;
+               return Result;
+            end;
          elsif First.Str.all = "fn*" then
             Err.Check (Ast.Sequence.all.Length = 3, "expected 2 parameters");
             declare

--- a/ada.2/step5_tco.adb
+++ b/ada.2/step5_tco.adb
@@ -133,7 +133,16 @@ procedure Step5_Tco is
                Env.all.Set (Key, Val); --  Check key kind.
                return Val;
             end;
-         --  do is a built-in function, shortening this test cascade.
+         elsif First.Str.all = "do" then
+            Err.Check (1 < Ast.Sequence.all.Length, "do expects arguments");
+            declare
+               Result : Types.T;
+            begin
+               for I in 2 .. Ast.Sequence.all.Length loop
+                  Result := Eval (Ast.Sequence.all.Data (I), Env);
+               end loop;
+               return Result;
+            end;
          elsif First.Str.all = "fn*" then
             Err.Check (Ast.Sequence.all.Length = 3, "expected 2 parameters");
             declare

--- a/ada.2/step6_file.adb
+++ b/ada.2/step6_file.adb
@@ -137,7 +137,16 @@ procedure Step6_File is
                Env.all.Set (Key, Val); --  Check key kind.
                return Val;
             end;
-         --  do is a built-in function, shortening this test cascade.
+         elsif First.Str.all = "do" then
+            Err.Check (1 < Ast.Sequence.all.Length, "do expects arguments");
+            declare
+               Result : Types.T;
+            begin
+               for I in 2 .. Ast.Sequence.all.Length loop
+                  Result := Eval (Ast.Sequence.all.Data (I), Env);
+               end loop;
+               return Result;
+            end;
          elsif First.Str.all = "fn*" then
             Err.Check (Ast.Sequence.all.Length = 3, "expected 2 parameters");
             declare

--- a/ada.2/step7_quote.adb
+++ b/ada.2/step7_quote.adb
@@ -149,7 +149,16 @@ procedure Step7_Quote is
                Env.all.Set (Key, Val); --  Check key kind.
                return Val;
             end;
-         --  do is a built-in function, shortening this test cascade.
+         elsif First.Str.all = "do" then
+            Err.Check (1 < Ast.Sequence.all.Length, "do expects arguments");
+            declare
+               Result : Types.T;
+            begin
+               for I in 2 .. Ast.Sequence.all.Length loop
+                  Result := Eval (Ast.Sequence.all.Data (I), Env);
+               end loop;
+               return Result;
+            end;
          elsif First.Str.all = "fn*" then
             Err.Check (Ast.Sequence.all.Length = 3, "expected 2 parameters");
             declare

--- a/ada.2/step8_macros.adb
+++ b/ada.2/step8_macros.adb
@@ -163,7 +163,16 @@ procedure Step8_Macros is
                Env.all.Set (Key, Val);  --  Check key kind.
                return Val;
             end;
-         --  do is a built-in function, shortening this test cascade.
+         elsif First.Str.all = "do" then
+            Err.Check (1 < Ast.Sequence.all.Length, "do expects arguments");
+            declare
+               Result : Types.T;
+            begin
+               for I in 2 .. Ast.Sequence.all.Length loop
+                  Result := Eval (Ast.Sequence.all.Data (I), Env);
+               end loop;
+               return Result;
+            end;
          elsif First.Str.all = "fn*" then
             Err.Check (Ast.Sequence.all.Length = 3, "expected 2 parameters");
             declare

--- a/ada.2/step9_try.adb
+++ b/ada.2/step9_try.adb
@@ -163,7 +163,16 @@ procedure Step9_Try is
                Env.all.Set (Key, Val);  --  Check key kind.
                return Val;
             end;
-         --  do is a built-in function, shortening this test cascade.
+         elsif First.Str.all = "do" then
+            Err.Check (1 < Ast.Sequence.all.Length, "do expects arguments");
+            declare
+               Result : Types.T;
+            begin
+               for I in 2 .. Ast.Sequence.all.Length loop
+                  Result := Eval (Ast.Sequence.all.Data (I), Env);
+               end loop;
+               return Result;
+            end;
          elsif First.Str.all = "fn*" then
             Err.Check (Ast.Sequence.all.Length = 3, "expected 2 parameters");
             declare

--- a/ada.2/stepa_mal.adb
+++ b/ada.2/stepa_mal.adb
@@ -164,7 +164,16 @@ procedure StepA_Mal is
                Env.all.Set (Key, Val);  --  Check key kind.
                return Val;
             end;
-         --  do is a built-in function, shortening this test cascade.
+         elsif First.Str.all = "do" then
+            Err.Check (1 < Ast.Sequence.all.Length, "do expects arguments");
+            declare
+               Result : Types.T;
+            begin
+               for I in 2 .. Ast.Sequence.all.Length loop
+                  Result := Eval (Ast.Sequence.all.Data (I), Env);
+               end loop;
+               return Result;
+            end;
          elsif First.Str.all = "fn*" then
             Err.Check (Ast.Sequence.all.Length = 3, "expected 2 parameters");
             declare

--- a/cpp/Core.cpp
+++ b/cpp/Core.cpp
@@ -325,6 +325,22 @@ BUILTIN("macro?")
     return mal::boolean((lambda != NULL) && lambda->isMacro());
 }
 
+BUILTIN("map")
+{
+    CHECK_ARGS_IS(2);
+    malValuePtr op = *argsBegin++; // this gets checked in APPLY
+    ARG(malSequence, source);
+
+    const int length = source->count();
+    malValueVec* items = new malValueVec(length);
+    auto it = source->begin();
+    for (int i = 0; i < length; i++) {
+      items->at(i) = APPLY(op, it+i, it+i+1);
+    }
+
+    return  mal::list(items);
+}
+
 BUILTIN("meta")
 {
     CHECK_ARGS_IS(1);

--- a/cpp/step8_macros.cpp
+++ b/cpp/step8_macros.cpp
@@ -10,12 +10,12 @@
 malValuePtr READ(const String& input);
 String PRINT(malValuePtr ast);
 static void installFunctions(malEnvPtr env);
+//  Installs functions and macros implemented in MAL.
 
 static void makeArgv(malEnvPtr env, int argc, char* argv[]);
 static String safeRep(const String& input, malEnvPtr env);
 static malValuePtr quasiquote(malValuePtr obj);
 static malValuePtr macroExpand(malValuePtr obj, malEnvPtr env);
-static void installMacros(malEnvPtr env);
 
 static ReadLine s_readLine("~/.mal-history");
 
@@ -27,7 +27,6 @@ int main(int argc, char* argv[])
     String input;
     installCore(replEnv);
     installFunctions(replEnv);
-    installMacros(replEnv);
     makeArgv(replEnv, argc - 2, argv + 2);
     if (argc > 1) {
         String filename = escape(argv[1]);
@@ -279,19 +278,9 @@ static malValuePtr macroExpand(malValuePtr obj, malEnvPtr env)
     return obj;
 }
 
-static const char* macroTable[] = {
+static const char* malFunctionTable[] = {
     "(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))",
     "(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) `(let* (or_FIXME ~(first xs)) (if or_FIXME or_FIXME (or ~@(rest xs))))))))",
-};
-
-static void installMacros(malEnvPtr env)
-{
-    for (auto &macro : macroTable) {
-        rep(macro, env);
-    }
-}
-
-static const char* malFunctionTable[] = {
     "(def! not (fn* (cond) (if cond false true)))",
     "(def! load-file (fn* (filename) \
         (eval (read-string (str \"(do \" (slurp filename) \")\")))))",

--- a/cpp/step9_try.cpp
+++ b/cpp/step9_try.cpp
@@ -10,12 +10,12 @@
 malValuePtr READ(const String& input);
 String PRINT(malValuePtr ast);
 static void installFunctions(malEnvPtr env);
+//  Installs functions and macros implemented in MAL.
 
 static void makeArgv(malEnvPtr env, int argc, char* argv[]);
 static String safeRep(const String& input, malEnvPtr env);
 static malValuePtr quasiquote(malValuePtr obj);
 static malValuePtr macroExpand(malValuePtr obj, malEnvPtr env);
-static void installMacros(malEnvPtr env);
 
 static ReadLine s_readLine("~/.mal-history");
 
@@ -27,7 +27,6 @@ int main(int argc, char* argv[])
     String input;
     installCore(replEnv);
     installFunctions(replEnv);
-    installMacros(replEnv);
     makeArgv(replEnv, argc - 2, argv + 2);
     if (argc > 1) {
         String filename = escape(argv[1]);
@@ -328,24 +327,12 @@ static malValuePtr macroExpand(malValuePtr obj, malEnvPtr env)
     return obj;
 }
 
-static const char* macroTable[] = {
+static const char* malFunctionTable[] = {
     "(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))",
     "(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) `(let* (or_FIXME ~(first xs)) (if or_FIXME or_FIXME (or ~@(rest xs))))))))",
-};
-
-static void installMacros(malEnvPtr env)
-{
-    for (auto &macro : macroTable) {
-        rep(macro, env);
-    }
-}
-
-static const char* malFunctionTable[] = {
     "(def! not (fn* (cond) (if cond false true)))",
     "(def! load-file (fn* (filename) \
         (eval (read-string (str \"(do \" (slurp filename) \")\")))))",
-    "(def! map (fn* (f xs) (if (empty? xs) xs \
-        (cons (f (first xs)) (map f (rest xs))))))",
 };
 
 static void installFunctions(malEnvPtr env) {

--- a/cpp/stepA_mal.cpp
+++ b/cpp/stepA_mal.cpp
@@ -10,12 +10,12 @@
 malValuePtr READ(const String& input);
 String PRINT(malValuePtr ast);
 static void installFunctions(malEnvPtr env);
+//  Installs functions, macros and constants implemented in MAL.
 
 static void makeArgv(malEnvPtr env, int argc, char* argv[]);
 static String safeRep(const String& input, malEnvPtr env);
 static malValuePtr quasiquote(malValuePtr obj);
 static malValuePtr macroExpand(malValuePtr obj, malEnvPtr env);
-static void installMacros(malEnvPtr env);
 
 static ReadLine s_readLine("~/.mal-history");
 
@@ -27,7 +27,6 @@ int main(int argc, char* argv[])
     String input;
     installCore(replEnv);
     installFunctions(replEnv);
-    installMacros(replEnv);
     makeArgv(replEnv, argc - 2, argv + 2);
     if (argc > 1) {
         String filename = escape(argv[1]);
@@ -329,24 +328,12 @@ static malValuePtr macroExpand(malValuePtr obj, malEnvPtr env)
     return obj;
 }
 
-static const char* macroTable[] = {
+static const char* malFunctionTable[] = {
     "(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))",
     "(defmacro! or (fn* (& xs) (if (empty? xs) nil (if (= 1 (count xs)) (first xs) (let* (condvar (gensym)) `(let* (~condvar ~(first xs)) (if ~condvar ~condvar (or ~@(rest xs)))))))))",
-};
-
-static void installMacros(malEnvPtr env)
-{
-    for (auto &macro : macroTable) {
-        rep(macro, env);
-    }
-}
-
-static const char* malFunctionTable[] = {
     "(def! not (fn* (cond) (if cond false true)))",
     "(def! load-file (fn* (filename) \
         (eval (read-string (str \"(do \" (slurp filename) \")\")))))",
-    "(def! map (fn* (f xs) (if (empty? xs) xs \
-        (cons (f (first xs)) (map f (rest xs))))))",
     "(def! *gensym-counter* (atom 0))",
     "(def! gensym (fn* [] (symbol (str \"G__\" (swap! *gensym-counter* (fn* [x] (+ 1 x)))))))",
     "(def! *host-language* \"C++\")",


### PR DESCRIPTION
This PR follows the discussion at #360.

In Ada.2, convert `do` from built-in function to special form.
In C++, convert `map` from native definition to built-in function.
Also in C++, merge native functions and macros, the distinction was artificial. 