### PR TITLE
Some fixes for unterminated strings

### DIFF
--- a/awk/reader.awk
+++ b/awk/reader.awk
@@ -18,7 +18,7 @@ function reader_read_atom(token)
 	case /^:/:
 		return ":" token
 	case /^"/:
-		if (token ~ /"$/) {
+		if (token ~ /^\"(\\[^\r\n]|[^\\"\r\n])*\"$/) {
 				return reader_read_string(token)
 		} else {
 				return "!\"Expected '\"', got EOF."

--- a/bash/reader.sh
+++ b/bash/reader.sh
@@ -13,7 +13,7 @@ READ_ATOM () {
     case "${token}" in
         [0-9]*)  _number "${token}" ;;
         -[0-9]*) _number "${token}" ;;
-        \"*)    if [ "${token: -1}" != "\"" ]; then
+        \"*)    if [[ ! "${token}" =~ ^\"(\\.|[^\\\"])*\"$ ]]; then
                     _error "expected '\"', got EOF"
                     return
                 fi

--- a/perl/reader.pm
+++ b/perl/reader.pm
@@ -31,13 +31,13 @@ sub read_atom {
     my $token = $rdr->next();
     given ($token) {
         when(/^-?[0-9]+$/) { return Integer->new($token) }
-        when(/^".*"$/) {
+        when(/^"(?:\\.|[^\\"])*"$/) {
             my %escaped_chars = ( "\\\\" => "\\", "\\\"" => "\"", "\\n" => "\n" );
             my $str = substr $token, 1, -1;
             $str =~ s/\\./$escaped_chars{$&}/ge;
             return String->new($str)
         }
-        when(/^".*/) {
+        when(/^"/) {
             die "expected '\"', got EOF";
         }
         when(/^:/) { return _keyword(substr($token,1)) }

--- a/python/reader.py
+++ b/python/reader.py
@@ -28,12 +28,12 @@ def _unescape(s):
 def read_atom(reader):
     int_re = re.compile(r"-?[0-9]+$")
     float_re = re.compile(r"-?[0-9][0-9.]*$")
+    string_re = re.compile(r'"(?:[\\].|[^\\"])*"')
     token = reader.next()
     if re.match(int_re, token):     return int(token)
     elif re.match(float_re, token): return int(token)
-    elif token[0] == '"':
-        if token[-1] == '"':        return _s2u(_unescape(token[1:-1]))
-        else:                       raise Exception("expected '\"', got EOF")
+    elif re.match(string_re, token):return _s2u(_unescape(token[1:-1]))
+    elif token[0] == '"':           raise Exception("expected '\"', got EOF")
     elif token[0] == ':':           return _keyword(token[1:])
     elif token == "nil":            return None
     elif token == "true":           return True

--- a/ruby/reader.rb
+++ b/ruby/reader.rb
@@ -31,8 +31,8 @@ def read_atom(rdr)
     return case token
         when /^-?[0-9]+$/ then       token.to_i # integer
         when /^-?[0-9][0-9.]*$/ then token.to_f # float
-        when /^".*"$/ then           parse_str(token) # string
-        when /^".*$/ then            raise "expected '\"', got EOF"
+        when /^"(?:\\.|[^\\"])*"$/ then parse_str(token) # string
+        when /^"/ then               raise "expected '\"', got EOF"
         when /^:/ then               "\u029e" + token[1..-1] # keyword
         when "nil" then              nil
         when "true" then             true

--- a/tcl/reader.tcl
+++ b/tcl/reader.tcl
@@ -83,8 +83,9 @@ proc read_atom {reader} {
         ^true$     { return $::mal_true }
         ^false$    { return $::mal_false }
         ^:         { return [keyword_new [parse_keyword $token]] }
-        ^\".*\"$   { return [string_new [parse_string $token]] }
-        ^\".*$     { error "expected '\"', got EOF" }
+        ^\"(\\\\.|[^\\\\\"])*\"$
+	           { return [string_new [parse_string $token]] }
+        ^\"        { error "expected '\"', got EOF" }
         default    { return [symbol_new $token] }
     }
 }


### PR DESCRIPTION
These are some initial fixes for the unterminated-string bugs tested for by #359.  The first three are simple regexp matchers using the string part of the `tokenize` regexp.