### PR TITLE
Mark some stepA core functions as not optional.

### DIFF
--- a/process/guide.md
+++ b/process/guide.md
@@ -1547,6 +1547,28 @@ diff -urp ../process/step9_try.txt ../process/stepA_mal.txt
   to print a startup header:
   "(println (str \"Mal [\" \*host-language\* \"]\"))".
 
+* Add the following new core functions:
+  * `time-ms`: takes no arguments and returns the number of
+    milliseconds since epoch (00:00:00 UTC January 1, 1970), or, if
+    not possible, since another point in time (`time-ms` is usually
+    used relatively to measure time durations).  After `time-ms` is
+    implemented, you can run the performance micro-benchmarks by
+    running `make perf^quux`.
+  * `conj`: takes a collection and one or more elements as arguments
+    and returns a new collection which includes the original
+    collection and the new elements.  If the collection is a list, a
+    new list is returned with the elements inserted at the start of
+    the given list in opposite order; if the collection is a vector, a
+    new vector is returned with the elements added to the end of the
+    given vector.
+  * `number?`: returns true if the parameter is a number.
+  * `string?`: returns true if the parameter is a string.
+  * `seq`: takes a list, vector, string, or nil. If an empty list,
+    empty vector, or empty string ("") is passed in then nil is
+    returned. Otherwise, a list is returned unchanged, a vector is
+    converted into a list, and a string is converted to a list that
+    containing the original string split into single character
+    strings.
 
 Now go to the top level, run the step A tests:
 ```
@@ -1631,30 +1653,9 @@ For extra information read [Peter Seibel's thorough discussion about
 * Add metadata support to other composite data types (lists, vectors
   and hash-maps), and to native functions.
 * Add the following new core functions:
-  * `time-ms`: takes no arguments and returns the number of
-    milliseconds since epoch (00:00:00 UTC January 1, 1970), or, if
-    not possible, since another point in time (`time-ms` is usually
-    used relatively to measure time durations).  After `time-ms` is
-    implemented, you can run the performance micro-benchmarks by
-    running `make perf^quux`.
-  * `conj`: takes a collection and one or more elements as arguments
-    and returns a new collection which includes the original
-    collection and the new elements.  If the collection is a list, a
-    new list is returned with the elements inserted at the start of
-    the given list in opposite order; if the collection is a vector, a
-    new vector is returned with the elements added to the end of the
-    given vector.
-  * `string?`: returns true if the parameter is a string.
-  * `number?`: returns true if the parameter is a number.
   * `fn?`: returns true if the parameter is a function (internal or
     user-defined).
   * `macro?`: returns true if the parameter is a macro.
-  * `seq`: takes a list, vector, string, or nil. If an empty list,
-    empty vector, or empty string ("") is passed in then nil is
-    returned. Otherwise, a list is returned unchanged, a vector is
-    converted into a list, and a string is converted to a list that
-    containing the original string split into single character
-    strings.
 * For interop with the target language, add this core function:
   * `quux-eval`: takes a string, evaluates it in the target language,
     and returns the result converted to the relevant Mal type. You

--- a/tests/stepA_mal.mal
+++ b/tests/stepA_mal.mal
@@ -82,29 +82,6 @@
 ;=>{"meta" 1}
 
 ;;
-;; Testing hash-map evaluation and atoms (i.e. an env)
-(def! e (atom {"+" +}))
-(swap! e assoc "-" -)
-( (get @e "+") 7 8)
-;=>15
-( (get @e "-") 11 8)
-;=>3
-(swap! e assoc "foo" (list))
-(get @e "foo")
-;=>()
-(swap! e assoc "bar" '(1 2 3))
-(get @e "bar")
-;=>(1 2 3)
-
-;; ------------------------------------------------------------------
-
-;>>> soft=True
-;>>> optional=True
-;;
-;; ------- Optional Functionality --------------
-;; ------- (Not needed for self-hosting) -------
-
-;;
 ;; Testing string? function
 (string? "")
 ;=>true
@@ -132,33 +109,6 @@
 ;=>false
 (number? "123")
 ;=>false
-
-(def! add1 (fn* (x) (+ x 1)))
-
-;; Testing fn? function
-(fn? +)
-;=>true
-(fn? add1)
-;=>true
-(fn? cond)
-;=>false
-(fn? "+")
-;=>false
-(fn? :+)
-;=>false
-
-;; Testing macro? function
-(macro? cond)
-;=>true
-(macro? +)
-;=>false
-(macro? add1)
-;=>false
-(macro? "+")
-;=>false
-(macro? :+)
-;=>false
-
 
 ;;
 ;; Testing conj function
@@ -203,6 +153,66 @@
 ;=>nil
 (seq nil)
 ;=>nil
+
+;;
+;; Testing hash-map evaluation and atoms (i.e. an env)
+(def! e (atom {"+" +}))
+(swap! e assoc "-" -)
+( (get @e "+") 7 8)
+;=>15
+( (get @e "-") 11 8)
+;=>3
+(swap! e assoc "foo" (list))
+(get @e "foo")
+;=>()
+(swap! e assoc "bar" '(1 2 3))
+(get @e "bar")
+;=>(1 2 3)
+
+;;
+;; Testing time-ms function
+(def! start-time (time-ms))
+(= start-time 0)
+;=>false
+(let* [sumdown (fn* (N) (if (> N 0) (+ N (sumdown (- N 1))) 0))] (sumdown 10)) ; Waste some time
+;=>55
+(> (time-ms) start-time)
+;=>true
+
+;; ------------------------------------------------------------------
+
+;>>> soft=True
+;>>> optional=True
+;;
+;; ------- Optional Functionality --------------
+;; ------- (Not needed for self-hosting) -------
+
+(def! add1 (fn* (x) (+ x 1)))
+
+;; Testing fn? function
+(fn? +)
+;=>true
+(fn? add1)
+;=>true
+(fn? cond)
+;=>false
+(fn? "+")
+;=>false
+(fn? :+)
+;=>false
+
+;; Testing macro? function
+(macro? cond)
+;=>true
+(macro? +)
+;=>false
+(macro? add1)
+;=>false
+(macro? "+")
+;=>false
+(macro? :+)
+;=>false
+
 
 ;;
 ;; Testing metadata on collections
@@ -264,13 +274,3 @@
 ;=>false
 (let* [or_FIXME 23] (or false (+ or_FIXME 100)))
 ;=>123
-
-;;
-;; Testing time-ms function
-(def! start-time (time-ms))
-(= start-time 0)
-;=>false
-(let* [sumdown (fn* (N) (if (> N 0) (+ N (sumdown (- N 1))) 0))] (sumdown 10)) ; Waste some time
-;=>55
-(> (time-ms) start-time)
-;=>true


### PR DESCRIPTION
I found that all of these were needed for self-hosting: without them,
even trying to run stepA_mal.mal gave me undefined-symbol errors.

This commit edits both guide.md and the stepA tests to move those core
functions out of the optional section.