### PR TITLE
step A: Test that metadata doesn't break empty collections.

### DIFF
--- a/tests/stepA_mal.mal
+++ b/tests/stepA_mal.mal
@@ -222,10 +222,19 @@
 (meta (with-meta [1 2 3] "abc"))
 ;=>"abc"
 
+(with-meta [] "abc")
+;=>[]
+
 (meta (with-meta (list 1 2 3) {"a" 1}))
 ;=>{"a" 1}
 
 (list? (with-meta (list 1 2 3) {"a" 1}))
+;=>true
+
+(with-meta (list) {"a" 1})
+;=>()
+
+(empty? (with-meta (list) {"a" 1}))
 ;=>true
 
 (meta (with-meta {"abc" 123} {"a" 1}))
@@ -233,6 +242,9 @@
 
 (map? (with-meta {"abc" 123} {"a" 1}))
 ;=>true
+
+(with-meta {} {"a" 1})
+;=>{}
 
 ;;; Not actually supported by Clojure
 ;;;(meta (with-meta (atom 7) {"a" 1}))


### PR DESCRIPTION
In the BBC BASIC implementation, the empty list, vector, and hash-map are distinguished values and detected by their address.  Adding metadata to them makes a copy, and then they don't work properly any more.

Let's see if anyone else made that mistake...