### PR TITLE
Unterminated string fixes: gnu-smalltalk, go, js, lua, objpascal, php, powershell, racket, rust, ts

### DIFF
--- a/gnu-smalltalk/reader.st
+++ b/gnu-smalltalk/reader.st
@@ -4,6 +4,7 @@ Object subclass: Reader [
     TokenRegex := '[\s,]*(~@|[\[\]{}()''`~^@]|"(?:\\.|[^\\"])*"|;.*|[^\s\[\]{}(''"`,;)]*)'.
     CommentRegex := ';.*'.
     NumberRegex := '-?[0-9]+(?:\.[0-9]+)?'.
+    StringRegex := '"(?:\\.|[^\\"])*"'.
 
     Reader class >> tokenizer: input [
         | tokens token hit pos done |
@@ -106,12 +107,11 @@ Object subclass: Reader [
         token = 'false' ifTrue: [ ^MALObject False ].
         token = 'nil' ifTrue: [ ^MALObject Nil ].
 
+        (token matchRegex: StringRegex) ifTrue: [
+            ^MALString new: token parse
+        ].
         (token first = $") ifTrue: [
-            (token last = $") ifTrue: [
-                ^MALString new: token parse
-            ] ifFalse: [
-                ^MALUnterminatedSequence new signal: '"'
-            ]
+            ^MALUnterminatedSequence new signal: '"'
         ].
 
         (token matchRegex: NumberRegex) ifTrue: [

--- a/go/src/reader/reader.go
+++ b/go/src/reader/reader.go
@@ -65,10 +65,8 @@ func read_atom(rdr Reader) (MalType, error) {
 			return nil, errors.New("number parse error")
 		}
 		return i, nil
-	} else if (*token)[0] == '"' {
-		if (*token)[len(*token)-1] != '"' {
-			return nil, errors.New("expected '\"', got EOF")
-		}
+	} else if match, _ :=
+		  regexp.MatchString(`^"(?:\\.|[^\\"])*"$`, *token); match {
 		str := (*token)[1 : len(*token)-1]
 		return strings.Replace(
 			strings.Replace(
@@ -77,6 +75,8 @@ func read_atom(rdr Reader) (MalType, error) {
 			  `\"`, `"`, -1),
 			 `\n`, "\n", -1),
 			"\u029e", "\\", -1), nil
+	} else if (*token)[0] == '"' {
+		return nil, errors.New("expected '\"', got EOF")
 	} else if (*token)[0] == ':' {
 		return NewKeyword((*token)[1:len(*token)])
 	} else if *token == "nil" {

--- a/js/reader.js
+++ b/js/reader.js
@@ -31,12 +31,11 @@ function read_atom (reader) {
         return parseInt(token,10)        // integer
     } else if (token.match(/^-?[0-9][0-9.]*$/)) {
         return parseFloat(token,10);     // float
-    } else if (token[0] === "\"") {
-        if (token.slice(-1) !== "\"") {
-            throw new Error("expected '\"', got EOF");
-        }
+    } else if (token.match(/^"(?:\\.|[^\\"])*"$/)) {
         return token.slice(1,token.length-1) 
             .replace(/\\(.)/g, function (_, c) { return c === "n" ? "\n" : c})
+    } else if (token[0] === "\"") {
+            throw new Error("expected '\"', got EOF");
     } else if (token[0] === ":") {
         return types._keyword(token.slice(1));
     } else if (token === "nil") {

--- a/lua/reader.lua
+++ b/lua/reader.lua
@@ -40,19 +40,19 @@ end
 function M.read_atom(rdr)
     local int_re = rex.new("^-?[0-9]+$")
     local float_re = rex.new("^-?[0-9][0-9.]*$")
+    local string_re = rex.new("^\"(?:\\\\.|[^\\\\\"])*\"$")
     local token = rdr:next()
     if int_re:exec(token) then       return tonumber(token)
     elseif float_re:exec(token) then return tonumber(token)
-    elseif string.sub(token,1,1) == '"' then
-        if string.sub(token,-1) ~= '"' then
-            throw("expected '\"', got EOF")
-        end
+    elseif string_re:exec(token) then
         local sval = string.sub(token,2,string.len(token)-1)
         sval = string.gsub(sval, '\\\\', '\177')
         sval = string.gsub(sval, '\\"', '"')
         sval = string.gsub(sval, '\\n', '\n')
         sval = string.gsub(sval, '\177', '\\')
         return sval
+    elseif string.sub(token,1,1) == '"' then
+        throw("expected '\"', got EOF")
     elseif string.sub(token,1,1) == ':' then
         return "\177" .. string.sub(token,2)
     elseif token == "nil" then       return Nil

--- a/objpascal/reader.pas
+++ b/objpascal/reader.pas
@@ -91,7 +91,7 @@ var
     Str    : string;
 begin
     RE := TRegExpr.Create;
-    RE.Expression := '(^-?[0-9]+$)|(^-?[0-9][0-9.]*$)|(^nil$)|(^true$)|(^false$)|^(\".*\")$|^(\".*)$|:(.*)|(^[^\"]*$)';
+    RE.Expression := '(^-?[0-9]+$)|(^-?[0-9][0-9.]*$)|(^nil$)|(^true$)|(^false$)|^("([\\].|[^\\"])*)"$|^(\".*)$|:(.*)|(^[^\"]*$)';
     Token := Reader.Next();
     //WriteLn('token: ' + Token);
     if RE.Exec(Token) then
@@ -116,11 +116,11 @@ begin
             Str := StringReplace(Str, #127, '\',  [rfReplaceAll]);
             read_atom := TMalString.Create(Str)
         end
-        else if RE.Match[7] <> '' then
-            raise Exception.Create('expected ''"'', got EOF')
         else if RE.Match[8] <> '' then
-            read_atom := TMalString.Create(#127 + RE.Match[8])
+            raise Exception.Create('expected ''"'', got EOF')
         else if RE.Match[9] <> '' then
+            read_atom := TMalString.Create(#127 + RE.Match[9])
+        else if RE.Match[10] <> '' then
             read_atom := TMalSymbol.Create(Token);
     end
     else

--- a/php/reader.php
+++ b/php/reader.php
@@ -36,16 +36,15 @@ function read_atom($reader) {
     $token = $reader->next();
     if (preg_match("/^-?[0-9]+$/", $token)) {
         return intval($token, 10);
-    } elseif ($token[0] === "\"") {
-        if (substr($token, -1) !== "\"") {
-            throw new Exception("expected '\"', got EOF");
-        }
+    } elseif (preg_match("/^\"(?:\\\\.|[^\\\\\"])*\"$/", $token)) {
         $str = substr($token, 1, -1);
         $str = str_replace('\\\\', chr(0x7f), $str);
         $str = str_replace('\\"', '"', $str);
         $str = str_replace('\\n', "\n", $str);
         $str = str_replace(chr(0x7f), "\\", $str);
         return $str;
+    } elseif ($token[0] === "\"") {
+        throw new Exception("expected '\"', got EOF");
     } elseif ($token[0] === ":") {
         return _keyword(substr($token,1));
     } elseif ($token === "nil") {

--- a/powershell/reader.psm1
+++ b/powershell/reader.psm1
@@ -31,7 +31,7 @@ function read_atom([Reader] $rdr) {
     $token = $rdr.next()
     if ($token -match "^-?[0-9]+$") {
         return [convert]::ToInt32($token, 10)
-    } elseif ($token -match "^`".*`"") {
+    } elseif ($token -match "^`"(?:\\.|[^\\`"])*`"$") {
         $s = $token.Substring(1,$token.Length-2)
         $s = $s -replace "\\\\", "$([char]0x29e)"
         $s = $s -replace "\\`"", "`""

--- a/racket/reader.rkt
+++ b/racket/reader.rkt
@@ -31,7 +31,7 @@
            (string->number token)]
           [(regexp-match #px"^-?[0-9][0-9.]*$" token)
            (string->number token)]
-          [(regexp-match #px"^\".*\"$" token)
+          [(regexp-match #px"^\"(?:\\\\.|[^\\\\\"])*\"$" token)
            (with-input-from-string token read)]
           [(regexp-match #px"^\".*$" token)
            (raise "expected '\"', got EOF")]

--- a/rust/reader.rs
+++ b/rust/reader.rs
@@ -48,6 +48,7 @@ fn unescape_str(s: &str) -> String {
 fn read_atom(rdr: &mut Reader) -> MalRet {
   lazy_static! {
     static ref INT_RE: Regex = Regex::new(r"^-?[0-9]+$").unwrap();
+    static ref STR_RE: Regex = Regex::new(r#""(?:\\.|[^\\"])*""#).unwrap();
   }
   let token = rdr.next()?;
   match &token[..] {
@@ -57,12 +58,10 @@ fn read_atom(rdr: &mut Reader) -> MalRet {
     _       => {
       if INT_RE.is_match(&token) {
         Ok(Int(token.parse().unwrap()))
+      } else if STR_RE.is_match(&token) {
+        Ok(Str(unescape_str(&token[1..token.len()-1])))
       } else if token.starts_with("\"") {
-        if token.ends_with("\"") {
-          Ok(Str(unescape_str(&token[1..token.len()-1])))
-        } else {
-          error("expected '\"', got EOF")
-        }
+        error("expected '\"', got EOF")
       } else if token.starts_with(":") {
         Ok(Str(format!("\u{29e}{}", &token[1..])))
       } else {

--- a/ts/reader.ts
+++ b/ts/reader.ts
@@ -122,13 +122,13 @@ function readAtom(reader: Reader): MalType {
         const v = parseFloat(token);
         return new MalNumber(v);
     }
-    if (token[0] === '"') {
-        if (token.slice(-1) !== '"') {
-            throw new Error("expected '\"', got EOF");
-        }
+    if (token.match(/^"(?:\\.|[^\\"])*"$/)) {
         const v = token.slice(1, token.length - 1)
             .replace(/\\(.)/g, (_, c: string) => c == 'n' ? '\n' : c)
         return new MalString(v);
+    }
+    if (token[0] === '"') {
+        throw new Error("expected '\"', got EOF");
     }
     if (token[0] === ":") {
         return MalKeyword.get(token.substr(1));


### PR DESCRIPTION
Another batch of fixes for #359. These are split into two commits reflecting two different kinds of change that I made. The first batch add a new regexp test to detect a valid string, while the second modify an existing regexp to make it only match valid strings.