### PR TITLE
test macroexpand without assuming that quasiquote is a special form

### DIFF
--- a/tests/step8_macros.mal
+++ b/tests/step8_macros.mal
@@ -12,7 +12,7 @@
 ;=>7
 (unless true 7 8)
 ;=>8
-(defmacro! unless2 (fn* (pred a b) `(if (not ~pred) ~a ~b)))
+(defmacro! unless2 (fn* (pred a b) (list 'if (list 'not pred) a b)))
 (unless2 false 7 8)
 ;=>7
 (unless2 true 7 8)


### PR DESCRIPTION
This allows to test rewriting quasiquote as a macro, and should
change nothing else in theory.