### PR TITLE
step6: Test loading of a large (>255 byte) file earlier than before.

### DIFF
--- a/tests/step6_file.mal
+++ b/tests/step6_file.mal
@@ -86,9 +86,20 @@
 ;=>9
 
 ;>>> deferrable=True
+;;
+;; -------- Deferrable Functionality --------
+
+;; Testing reading of large files
+(load-file "../tests/computations.mal")
+;=>nil
+(sumdown 2)
+;=>3
+(fib 2)
+;=>1
+
 ;>>> optional=True
 ;;
-;; -------- Deferrable/Optional Functionality --------
+;; -------- Optional Functionality --------
 
 ;; Testing comments in a file
 (load-file "../tests/incB.mal")


### PR DESCRIPTION
I just introduced a bug in the BBC BASIC implementation meaning that `load-file` was broken on files over 255 bytes long, and it was only caught by the optional test of `time-ms` in step A.  This change brings forward the relevant part of that test so the failure can be detected earlier and more obviously, at the same time as the other tests of `load-file`.

I've marked the new test as deferrable because it's needed for self-hosting (most of `mal/*.mal` are over 255 bytes), but not otherwise critical.