### PR TITLE
ada: fix the fix for unterminated strings

### DIFF
--- a/ada/reader.adb
+++ b/ada/reader.adb
@@ -70,8 +70,8 @@ package body Reader is
                Append (Res, S (I+1));
                I := I + 2;
             else
-               Append (Res, S (I .. I+1));
-               I := I + 2;
+               Append (Res, S (I));
+               I := I + 1;
             end if;
          else
             Append (Res, S (I));
@@ -138,20 +138,17 @@ package body Reader is
 
          when '"' => -- a string
 
-            -- Skip over "
-            J := J + 1;
-            while J <= Str_Len and then
-               (Element (Saved_Line, J) /= '"' or else
-                 Element (Saved_Line, J-1) = '\') loop
+            loop
+               if Str_Len <= J then
+                  raise String_Error;
+               end if;
                J := J + 1;
+               exit when Element (Saved_Line, J) = '"';
+               if Element (Saved_Line, J) = '\' then
+                  J := J + 1;
+               end if;
             end loop;
 
-            -- So we either ran out of string..
-            if J > Str_Len then
-               raise String_Error;
-            end if;
-
-            -- or we reached an unescaped "
             Res := (ID => Str_Tok, Start_Char => I, Stop_Char => J);
             Char_To_Read := J + 1;
 


### PR DESCRIPTION
Thanks bjh21. I have been distracted by a less important issue (should
"\a" be read as "\a" or "a"?).