### PR TITLE
bbc-basic: Increase Brandy heap size so we run out of memory less

### DIFF
--- a/bbc-basic/run
+++ b/bbc-basic/run
@@ -1,3 +1,3 @@
 #! /bin/bash
-exec "${BRANDY:-sbrandy}" \
+exec "${BRANDY:-sbrandy}" -size 1024k \
     -path ../bbc-basic -quit $(dirname $0)/${STEP:-stepA_mal}.bbc "${@}"

--- a/bbc-basic/types
+++ b/bbc-basic/types
@@ -57,7 +57,7 @@ DEF PROCtypes_init
   REM  8 bytes in Brandy on a 32-bit system, 16 bytes in Brandy on
   REM  a 64-bit system.
 
-  DIM Z%((HIMEM-LOMEM)/100,3), Z$((HIMEM-LOMEM)/100)
+  DIM Z%((HIMEM-LOMEM)/110,3), Z$((HIMEM-LOMEM)/110)
   DIM sS%((HIMEM-LOMEM)/64)
 
   Z%(1,0) = &04 : REM false


### PR DESCRIPTION
Self-hosting the performance tests turned out to defeat even my careful hand-tweaking of the balance between mal's heap and BASIC's string storage, so I've resorted to the crude approach of simply doubling Brandy's RAM allocation to a whole megabyte. That seems a bit extravagant, but it's Brandy's fault for having such a huge overhead for string arrays.