### PR TITLE
step 7: Test `([~a]).

### DIFF
--- a/tests/step7_quote.mal
+++ b/tests/step7_quote.mal
@@ -174,6 +174,8 @@ b
 ;=>(1 a 3)
 ;;; TODO: fix this
 ;;;;=>[1 a 3]
+`([~a])
+;=>((8))
 
 ;; Testing splice-unquote with vectors
 (def! c '(1 "b" "d"))


### PR DESCRIPTION
I haven't been following #384 very carefully, but I think while @asarhaddon added a workaround in 2dfe777 for guile's problems with expressions like `` `([~a])``, there wasn't any talk of testing for or fixing the bug.  So here's a test for it.

I think the test is correct based on the guide's specification of `quasiquote`, and at least the perl and python implementations agree with me.

Implementations that would need to be fixed to deploy this test:
- [ ] common-lisp
- [ ] elisp
- [ ] guile
- [ ] scheme
(plpgsql failure is unrelated)