### PR TITLE
load-file: Require a newline before adding a paren

### DIFF
--- a/process/guide.md
+++ b/process/guide.md
@@ -990,7 +990,7 @@ diff -urp ../process/step5_tco.txt ../process/step6_file.txt
 
 * Define a `load-file` function using mal itself. In your main
   program call the `rep` function with this string:
-  "(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \")\")))))".
+  "(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\n)\")))))".
 
 Try out `load-file`:
   * `(load-file "../tests/incA.mal")` -> `9`


### PR DESCRIPTION
If the last line of a file isn't newline terminated, and ends with a comment, then the closing paren won't close the `(do`.