### PR TITLE
step 1: Test reading some simple nested collections.

### DIFF
--- a/tests/step1_read_print.mal
+++ b/tests/step1_read_print.mal
@@ -50,6 +50,8 @@ abc-def
 ;=>(** 1 2)
 (* -3 6)
 ;=>(* -3 6)
+(()())
+;=>(() ())
 
 ;; Test commas as whitespace
 (1 2, 3,,,,),,
@@ -139,6 +141,8 @@ false
 ;=>[+ 1 [+ 2 3]]
   [ +   1   [+   2 3   ]   ]  
 ;=>[+ 1 [+ 2 3]]
+([])
+;=>([])
 
 ;; Testing read of hash maps
 {}
@@ -155,6 +159,8 @@ false
 ;=>{"a" {"b" {"cde" 3}}}
 {  :a  {:b   {  :cde     3   }  }}
 ;=>{:a {:b {:cde 3}}}
+({})
+;=>({})
 
 ;; Testing read of comments
  ;; whole line comment (not an exception)


### PR DESCRIPTION
These tests are intended to catch the cases where the routine for reading a list, vector, or hashmap fails to consume the trailing token (`)`, `]`, or `}` as the case may be) from the input.  None of the existing step 1 tests detected this, and I only found it by playing around in the REPL.