### PR TITLE
step 4: Test that (= (list nil) (list)) returns false.

### DIFF
--- a/tests/step4_if_fn_do.mal
+++ b/tests/step4_if_fn_do.mal
@@ -127,6 +127,8 @@
 ;=>false
 (= (list) 0)
 ;=>false
+(= (list nil) (list))
+;=>false
 
 
 ;; Testing builtin and user defined functions


### PR DESCRIPTION
Certain naïve implementations of `=` (like the one I just wrote) will get this wrong, and no existing test at step 4 will catch it.