### PR TITLE
vala: avoid half-constructed vectors being garbage-collected.

### DIFF
--- a/vala/step2_eval.vala
+++ b/vala/step2_eval.vala
@@ -101,11 +101,12 @@ class Mal.Main : GLib.Object {
             return result;
         }
         if (ast is Mal.Vector) {
-            var results = new GLib.List<Mal.Val>();
-            for (var iter = (ast as Mal.Vector).iter();
-                 iter.nonempty(); iter.step())
-                results.append(EVAL(iter.deref(), env));
-            return new Mal.Vector.from_list(results);
+            var vec = ast as Mal.Vector;
+            var result = new Mal.Vector.with_size(vec.length);
+            var root = new GC.Root(result); (void)root;
+            for (var i = 0; i < vec.length; i++)
+                result[i] = EVAL(vec[i], env);
+            return result;
         }
         if (ast is Mal.Hashmap) {
             var result = new Mal.Hashmap();

--- a/vala/step3_env.vala
+++ b/vala/step3_env.vala
@@ -83,11 +83,12 @@ class Mal.Main : GLib.Object {
             return result;
         }
         if (ast is Mal.Vector) {
-            var results = new GLib.List<Mal.Val>();
-            for (var iter = (ast as Mal.Vector).iter();
-                 iter.nonempty(); iter.step())
-                results.append(EVAL(iter.deref(), env));
-            return new Mal.Vector.from_list(results);
+            var vec = ast as Mal.Vector;
+            var result = new Mal.Vector.with_size(vec.length);
+            var root = new GC.Root(result); (void)root;
+            for (var i = 0; i < vec.length; i++)
+                result[i] = EVAL(vec[i], env);
+            return result;
         }
         if (ast is Mal.Hashmap) {
             var result = new Mal.Hashmap();

--- a/vala/step4_if_fn_do.vala
+++ b/vala/step4_if_fn_do.vala
@@ -38,11 +38,12 @@ class Mal.Main: GLib.Object {
             return result;
         }
         if (ast is Mal.Vector) {
-            var results = new GLib.List<Mal.Val>();
-            for (var iter = (ast as Mal.Vector).iter();
-                 iter.nonempty(); iter.step())
-                results.append(EVAL(iter.deref(), env));
-            return new Mal.Vector.from_list(results);
+            var vec = ast as Mal.Vector;
+            var result = new Mal.Vector.with_size(vec.length);
+            var root = new GC.Root(result); (void)root;
+            for (var i = 0; i < vec.length; i++)
+                result[i] = EVAL(vec[i], env);
+            return result;
         }
         if (ast is Mal.Hashmap) {
             var result = new Mal.Hashmap();

--- a/vala/step5_tco.vala
+++ b/vala/step5_tco.vala
@@ -38,11 +38,12 @@ class Mal.Main : GLib.Object {
             return result;
         }
         if (ast is Mal.Vector) {
-            var results = new GLib.List<Mal.Val>();
-            for (var iter = (ast as Mal.Vector).iter();
-                 iter.nonempty(); iter.step())
-                results.append(EVAL(iter.deref(), env));
-            return new Mal.Vector.from_list(results);
+            var vec = ast as Mal.Vector;
+            var result = new Mal.Vector.with_size(vec.length);
+            var root = new GC.Root(result); (void)root;
+            for (var i = 0; i < vec.length; i++)
+                result[i] = EVAL(vec[i], env);
+            return result;
         }
         if (ast is Mal.Hashmap) {
             var result = new Mal.Hashmap();

--- a/vala/step6_file.vala
+++ b/vala/step6_file.vala
@@ -52,11 +52,12 @@ class Mal.Main : GLib.Object {
             return result;
         }
         if (ast is Mal.Vector) {
-            var results = new GLib.List<Mal.Val>();
-            for (var iter = (ast as Mal.Vector).iter();
-                 iter.nonempty(); iter.step())
-                results.append(EVAL(iter.deref(), env));
-            return new Mal.Vector.from_list(results);
+            var vec = ast as Mal.Vector;
+            var result = new Mal.Vector.with_size(vec.length);
+            var root = new GC.Root(result); (void)root;
+            for (var i = 0; i < vec.length; i++)
+                result[i] = EVAL(vec[i], env);
+            return result;
         }
         if (ast is Mal.Hashmap) {
             var result = new Mal.Hashmap();

--- a/vala/step7_quote.vala
+++ b/vala/step7_quote.vala
@@ -52,11 +52,12 @@ class Mal.Main : GLib.Object {
             return result;
         }
         if (ast is Mal.Vector) {
-            var results = new GLib.List<Mal.Val>();
-            for (var iter = (ast as Mal.Vector).iter();
-                 iter.nonempty(); iter.step())
-                results.append(EVAL(iter.deref(), env));
-            return new Mal.Vector.from_list(results);
+            var vec = ast as Mal.Vector;
+            var result = new Mal.Vector.with_size(vec.length);
+            var root = new GC.Root(result); (void)root;
+            for (var i = 0; i < vec.length; i++)
+                result[i] = EVAL(vec[i], env);
+            return result;
         }
         if (ast is Mal.Hashmap) {
             var result = new Mal.Hashmap();

--- a/vala/step8_macros.vala
+++ b/vala/step8_macros.vala
@@ -52,11 +52,12 @@ class Mal.Main : GLib.Object {
             return result;
         }
         if (ast is Mal.Vector) {
-            var results = new GLib.List<Mal.Val>();
-            for (var iter = (ast as Mal.Vector).iter();
-                 iter.nonempty(); iter.step())
-                results.append(EVAL(iter.deref(), env));
-            return new Mal.Vector.from_list(results);
+            var vec = ast as Mal.Vector;
+            var result = new Mal.Vector.with_size(vec.length);
+            var root = new GC.Root(result); (void)root;
+            for (var i = 0; i < vec.length; i++)
+                result[i] = EVAL(vec[i], env);
+            return result;
         }
         if (ast is Mal.Hashmap) {
             var result = new Mal.Hashmap();

--- a/vala/step9_try.vala
+++ b/vala/step9_try.vala
@@ -53,11 +53,12 @@ class Mal.Main : GLib.Object {
             return result;
         }
         if (ast is Mal.Vector) {
-            var results = new GLib.List<Mal.Val>();
-            for (var iter = (ast as Mal.Vector).iter();
-                 iter.nonempty(); iter.step())
-                results.append(EVAL(iter.deref(), env));
-            return new Mal.Vector.from_list(results);
+            var vec = ast as Mal.Vector;
+            var result = new Mal.Vector.with_size(vec.length);
+            var root = new GC.Root(result); (void)root;
+            for (var i = 0; i < vec.length; i++)
+                result[i] = EVAL(vec[i], env);
+            return result;
         }
         if (ast is Mal.Hashmap) {
             var result = new Mal.Hashmap();

--- a/vala/stepA_mal.vala
+++ b/vala/stepA_mal.vala
@@ -53,11 +53,12 @@ class Mal.Main : GLib.Object {
             return result;
         }
         if (ast is Mal.Vector) {
-            var results = new GLib.List<Mal.Val>();
-            for (var iter = (ast as Mal.Vector).iter();
-                 iter.nonempty(); iter.step())
-                results.append(EVAL(iter.deref(), env));
-            return new Mal.Vector.from_list(results);
+            var vec = ast as Mal.Vector;
+            var result = new Mal.Vector.with_size(vec.length);
+            var root = new GC.Root(result); (void)root;
+            for (var i = 0; i < vec.length; i++)
+                result[i] = EVAL(vec[i], env);
+            return result;
         }
         if (ast is Mal.Hashmap) {
             var result = new Mal.Hashmap();


### PR DESCRIPTION
The clause in eval_ast() which evaluates each element of an input
vector into an output vector was holding the intermediate results in
an ordinary GLib.List, and putting them all into a vector at the end
of the evaluation. But that meant that nothing was preventing all
those values from being garbage-collected half way through.

Now we make an output Mal.Vector at the start of the process, and
point a GC.Root at it to ensure it stays around until we've finished
putting items in it.

This fixes the vala part of #418, I think.