### PR TITLE
NASM: Fix bug in str when appending empty arrays

### DIFF
--- a/nasm/types.asm
+++ b/nasm/types.asm
@@ -745,6 +745,10 @@ string_append_string:
         ; Source end address
         mov r11d, DWORD [rbx + Array.length] ; Length of the array
         add r11, r10
+
+        ;  Check if the next array is empty
+        cmp r10, r11
+        je .finished
         
 .source_ok:
 


### PR DESCRIPTION
The `slurp` function can produce strings which end with an empty Array, if the input file is a multiple of the Array size. When appending such a string, `string_append_string` would keep reading past the end of the string, and continue until it ran out of memory. This fix adds a check for empty Array.

Partly fixes issue #418