### PR TITLE
Io fixes

### DIFF
--- a/io/MalTypes.io
+++ b/io/MalTypes.io
@@ -30,6 +30,14 @@ MalKeyword := Object clone do (
 
 MalSequential := Object clone do(
     isSequential := method(true)
+    equalSequence := method(other,
+        if((other ?isSequential) not, return false)
+        if(self size != other size, return false)
+        unequalElement := self detect(i, valA,
+            (valA == (other at(i))) not
+        )
+        if(unequalElement, false, true)
+    )
 )
 
 MalList := List clone appendProto(MalSequential) appendProto(MalMeta) do (
@@ -39,6 +47,7 @@ MalList := List clone appendProto(MalSequential) appendProto(MalMeta) do (
     )
     rest := method(MalList with(resend))
     slice := method(MalList with(resend))
+    == := method(other, equalSequence(other))
 )
 
 MalVector := List clone appendProto(MalSequential) appendProto(MalMeta) do (
@@ -48,6 +57,7 @@ MalVector := List clone appendProto(MalSequential) appendProto(MalMeta) do (
     )
     rest := method(MalList with(resend))
     slice := method(MalList with(resend))
+    == := method(other, equalSequence(other))
 )
 
 MalMap := Map clone appendProto(MalMeta) do (

--- a/io/MalTypes.io
+++ b/io/MalTypes.io
@@ -16,14 +16,14 @@ MalMeta := Object clone do(
 
 MalSymbol := Object clone appendProto(MalMeta) do (
     val ::= nil
-    with := method(str, self clone setVal(str))
+    with := method(str, self clone setVal(if(str ?val, str val, str)))
     malPrint := method(readable, val)
     == := method(other, (self type == other type) and (val == other val))
 )
 
 MalKeyword := Object clone do (
     val ::= nil
-    with := method(str, self clone setVal(str))
+    with := method(str, self clone setVal(if(str ?val, str val, str)))
     malPrint := method(readable, ":" .. val)
     == := method(other, (self type == other type) and (val == other val))
 )

--- a/io/MalTypes.io
+++ b/io/MalTypes.io
@@ -119,7 +119,7 @@ MalFunc := Object clone appendProto(MalMeta) do (
     call := method(args, blk call(args))
 )
 
-MalAtom := Object clone do (
+MalAtom := Object clone appendProto(MalMeta) do (
     val ::= nil
     with := method(str, self clone setVal(str))
     malPrint := method(readable, "(atom " .. (val malPrint(true)) .. ")")

--- a/io/step8_macros.io
+++ b/io/step8_macros.io
@@ -88,7 +88,7 @@ EVAL := method(ast, env,
                     ast = quasiquote(ast at(1))
                     continue, // TCO
                 "defmacro!",
-                    return(env set(ast at(1), EVAL(ast at(2), env) setIsMacro(true))),
+                    return(env set(ast at(1), EVAL(ast at(2), env) clone setIsMacro(true))),
                 "macroexpand",
                     return(macroexpand(ast at(1), env))
             )

--- a/io/step9_try.io
+++ b/io/step9_try.io
@@ -88,7 +88,7 @@ EVAL := method(ast, env,
                     ast = quasiquote(ast at(1))
                     continue, // TCO
                 "defmacro!",
-                    return(env set(ast at(1), EVAL(ast at(2), env) setIsMacro(true))),
+                    return(env set(ast at(1), EVAL(ast at(2), env) clone setIsMacro(true))),
                 "macroexpand",
                     return(macroexpand(ast at(1), env)),
                 "try*",

--- a/io/stepA_mal.io
+++ b/io/stepA_mal.io
@@ -88,7 +88,7 @@ EVAL := method(ast, env,
                     ast = quasiquote(ast at(1))
                     continue, // TCO
                 "defmacro!",
-                    return(env set(ast at(1), EVAL(ast at(2), env) setIsMacro(true))),
+                    return(env set(ast at(1), EVAL(ast at(2), env) clone setIsMacro(true))),
                 "macroexpand",
                     return(macroexpand(ast at(1), env)),
                 "try*",


### PR DESCRIPTION
Few fixes for the Io implementation (in 4 commits for easier review):

* Fix list and vector equality (this is the issue that broke the self-hosting in #418 ); I'll add the new step4 optional tests in a separate PR.
* keyword and symbol accept a keyword/symbol argument (soft fail in step9)
* Don't mutate existing function when defining a macro (soft fail in stepA)
* Atoms can have meta (soft fail in stepA)
