### PR TITLE
tests: step4: Add optional list and vector equality tests

### DIFF
--- a/tests/step4_if_fn_do.mal
+++ b/tests/step4_if_fn_do.mal
@@ -431,6 +431,8 @@ nil
 ;=>false
 (= :abc ":abc")
 ;=>false
+(= (list :abc) (list :abc))
+;=>true
 
 ;; Testing vector truthiness
 (if [] 7 8)
@@ -464,6 +466,8 @@ nil
 (= [] (list))
 ;=>true
 (= [7 8] [7 8])
+;=>true
+(= [:abc] [:abc])
 ;=>true
 (= (list 1 2) [1 2])
 ;=>true


### PR DESCRIPTION
These extra optional step4 tests would have caught the io implementation equality bug solved in #425 (specifically solved in commit 8e4de1ed14edf0c980643852d0663afa214e1202 ).

Note that this might reveal other implementations issues, but we won't see it clearly as Travis failures because these are part of the optional tests of step4 (should be hard failures from step9 onwards, IMO).
