### PR TITLE
io: Fix unneeded escaping of forward slash

### DIFF
--- a/io/MalTypes.io
+++ b/io/MalTypes.io
@@ -7,7 +7,9 @@ Number malPrint := method(readable, self asString)
 
 // Io strings are of type Sequence
 Sequence malPrint := method(readable,
-    if(readable, self asString asJson, self asString)
+    if(readable,
+       "\"" .. (self asString asMutable replaceSeq("\\", "\\\\") replaceSeq("\"", "\\\"") replaceSeq("\n", "\\n")) .. "\"",
+       self asString)
 )
 
 MalMeta := Object clone do(

--- a/tests/step1_read_print.mal
+++ b/tests/step1_read_print.mal
@@ -98,6 +98,8 @@ false
 ;=>","
 "-"
 ;=>"-"
+"/"
+;=>"/"
 ":"
 ;=>":"
 ";"
@@ -275,6 +277,3 @@ false
 ;; fantom fails this one
 "!"
 ;=>"!"
-;; io fails this one
-"/"
-;=>"/"


### PR DESCRIPTION
Instead of using Io's `asJson` method which escapes forward slashes, implement our own string escaping code so it fits the Mal requirements (escape only double-quotes, newline, and backslash).

The relevant step1 test was modified from soft to hard.