### PR TITLE
Fix nasm zero argument function call

### DIFF
--- a/nasm/step5_tco.asm
+++ b/nasm/step5_tco.asm
@@ -1236,7 +1236,7 @@ eval:
         mov [rax + Cons.typecdr], BYTE content_pointer
         
         mov [r13 + Cons.cdr], rax ; Append to list
-        mov r14, rax
+        mov r14, rax              ; R14 contains last cons in list
         
         push rax
         mov rsi, r15
@@ -1314,18 +1314,20 @@ eval:
         je .list_got_args
         
         ; No arguments
-        
         push rbx                ; Function object
-        
-        mov rsi, rax            ; List with function first
-        call release_object     ; Can be freed now
+        push rax                ; List with function first
 
         ; Create an empty list for the arguments
         call alloc_cons
         mov [rax], BYTE maltype_empty_list
+        mov rsi, rax            ; Argument list into RSI
+
+        pop rax                 ; list, function first
+        ;;  Put new empty list onto end of original list
+        mov [rax + Cons.typecdr], BYTE content_pointer
+        mov [rax + Cons.cdr], rsi
         
         pop rbx
-        mov rsi, rax
         jmp  .list_function_call
 .list_got_args:
         mov rsi, [rax + Cons.cdr] ; Rest of list

--- a/nasm/step6_file.asm
+++ b/nasm/step6_file.asm
@@ -1241,7 +1241,7 @@ eval:
         mov [rax + Cons.typecdr], BYTE content_pointer
         
         mov [r13 + Cons.cdr], rax ; Append to list
-        mov r14, rax
+        mov r14, rax              ; R14 contains last cons in list
         
         push rax
         mov rsi, r15
@@ -1319,18 +1319,20 @@ eval:
         je .list_got_args
         
         ; No arguments
-        
         push rbx                ; Function object
-        
-        mov rsi, rax            ; List with function first
-        call release_object     ; Can be freed now
+        push rax                ; List with function first
 
         ; Create an empty list for the arguments
         call alloc_cons
         mov [rax], BYTE maltype_empty_list
+        mov rsi, rax            ; Argument list into RSI
+
+        pop rax                 ; list, function first
+        ;;  Put new empty list onto end of original list
+        mov [rax + Cons.typecdr], BYTE content_pointer
+        mov [rax + Cons.cdr], rsi
         
         pop rbx
-        mov rsi, rax
         jmp  .list_function_call
 .list_got_args:
         mov rsi, [rax + Cons.cdr] ; Rest of list

--- a/nasm/step7_quote.asm
+++ b/nasm/step7_quote.asm
@@ -1254,7 +1254,7 @@ eval:
         mov [rax + Cons.typecdr], BYTE content_pointer
         
         mov [r13 + Cons.cdr], rax ; Append to list
-        mov r14, rax
+        mov r14, rax              ; R14 contains last cons in list
         
         push rax
         mov rsi, r15
@@ -1404,18 +1404,20 @@ eval:
         je .list_got_args
         
         ; No arguments
-        
         push rbx                ; Function object
-        
-        mov rsi, rax            ; List with function first
-        call release_object     ; Can be freed now
+        push rax                ; List with function first
 
         ; Create an empty list for the arguments
         call alloc_cons
         mov [rax], BYTE maltype_empty_list
+        mov rsi, rax            ; Argument list into RSI
+
+        pop rax                 ; list, function first
+        ;;  Put new empty list onto end of original list
+        mov [rax + Cons.typecdr], BYTE content_pointer
+        mov [rax + Cons.cdr], rsi
         
         pop rbx
-        mov rsi, rax
         jmp  .list_function_call
 .list_got_args:
         mov rsi, [rax + Cons.cdr] ; Rest of list

--- a/nasm/step8_macros.asm
+++ b/nasm/step8_macros.asm
@@ -1321,7 +1321,7 @@ eval:
         mov [rax + Cons.typecdr], BYTE content_pointer
         
         mov [r13 + Cons.cdr], rax ; Append to list
-        mov r14, rax
+        mov r14, rax              ; R14 contains last cons in list
         
         push rax
         mov rsi, r15
@@ -1502,18 +1502,20 @@ eval:
         je .list_got_args
         
         ; No arguments
-        
         push rbx                ; Function object
-        
-        mov rsi, rax            ; List with function first
-        call release_object     ; Can be freed now
+        push rax                ; List with function first
 
         ; Create an empty list for the arguments
         call alloc_cons
         mov [rax], BYTE maltype_empty_list
+        mov rsi, rax            ; Argument list into RSI
+
+        pop rax                 ; list, function first
+        ;;  Put new empty list onto end of original list
+        mov [rax + Cons.typecdr], BYTE content_pointer
+        mov [rax + Cons.cdr], rsi
         
         pop rbx
-        mov rsi, rax
         jmp  .list_function_call
 .list_got_args:
         mov rsi, [rax + Cons.cdr] ; Rest of list

--- a/nasm/step9_try.asm
+++ b/nasm/step9_try.asm
@@ -1349,7 +1349,7 @@ eval:
         mov [rax + Cons.typecdr], BYTE content_pointer
         
         mov [r13 + Cons.cdr], rax ; Append to list
-        mov r14, rax
+        mov r14, rax              ; R14 contains last cons in list
         
         push rax
         mov rsi, r15
@@ -1743,18 +1743,20 @@ eval:
         je .list_got_args
         
         ; No arguments
-        
         push rbx                ; Function object
-        
-        mov rsi, rax            ; List with function first
-        call release_object     ; Can be freed now
+        push rax                ; List with function first
 
         ; Create an empty list for the arguments
         call alloc_cons
         mov [rax], BYTE maltype_empty_list
+        mov rsi, rax            ; Argument list into RSI
+
+        pop rax                 ; list, function first
+        ;;  Put new empty list onto end of original list
+        mov [rax + Cons.typecdr], BYTE content_pointer
+        mov [rax + Cons.cdr], rsi
         
         pop rbx
-        mov rsi, rax
         jmp  .list_function_call
 .list_got_args:
         mov rsi, [rax + Cons.cdr] ; Rest of list

--- a/nasm/stepA_mal.asm
+++ b/nasm/stepA_mal.asm
@@ -1366,7 +1366,7 @@ eval:
         mov [rax + Cons.typecdr], BYTE content_pointer
         
         mov [r14 + Cons.cdr], rax ; Append to list
-        mov r14, rax
+        mov r14, rax              ; R14 contains last cons in list
         
         push rax
         mov rsi, r15
@@ -1760,18 +1760,20 @@ eval:
         je .list_got_args
         
         ; No arguments
-        
         push rbx                ; Function object
-        
-        mov rsi, rax            ; List with function first
-        call release_object     ; Can be freed now
+        push rax                ; List with function first
 
         ; Create an empty list for the arguments
         call alloc_cons
         mov [rax], BYTE maltype_empty_list
+        mov rsi, rax            ; Argument list into RSI
+
+        pop rax                 ; list, function first
+        ;;  Put new empty list onto end of original list
+        mov [rax + Cons.typecdr], BYTE content_pointer
+        mov [rax + Cons.cdr], rsi
         
         pop rbx
-        mov rsi, rax
         jmp  .list_function_call
 .list_got_args:
         mov rsi, [rax + Cons.cdr] ; Rest of list


### PR DESCRIPTION
Releasing function object prematurely led to segfaults after step 4 when evaluating:
```
((fn* () 4))
```
Now works on steps 5 to A.

Fixes issue #429 