### PR TITLE
perl: New metadata and TCO and other changes

### DIFF
--- a/perl/core.pm
+++ b/perl/core.pm
@@ -152,8 +152,7 @@ sub with_meta {
 # Atom functions
 sub swap_BANG {
     my ($atm,$f,@args) = @_;
-    unshift @args, $$atm;
-    return $$atm = &$f(@args);
+    return $$atm = &$f($$atm, @args);
 }
 
 

--- a/perl/core.pm
+++ b/perl/core.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
+use Hash::Util qw(fieldhash);
 use List::Util qw(pairmap);
 use Time::HiRes qw(time);
 
@@ -140,11 +141,12 @@ sub seq {
     }
 }
 
+fieldhash my %meta;
+
 # Metadata functions
 sub with_meta {
-    no overloading '%{}';
     my $new_obj = _clone($_[0]);
-    $new_obj->{meta} = $_[1];
+    $meta{$new_obj} = $_[1];
     return $new_obj;
 }
 
@@ -226,7 +228,7 @@ sub pl_STAR {
     'seq'         => \&seq,
 
     'with-meta'   => \&with_meta,
-    'meta'        => sub { $_[0]->meta },
+    'meta'        => sub { $meta{$_[0]} // $nil },
     'atom'        => sub { Mal::Atom->new($_[0]) },
     'atom?'       => sub { _atom_Q($_[0]) ? $true : $false },
     'deref'       => sub { ${$_[0]} },

--- a/perl/core.pm
+++ b/perl/core.pm
@@ -9,7 +9,7 @@ use Time::HiRes qw(time);
 
 use readline;
 use types qw(_equal_Q $nil $true $false
-             _string_Q _keyword);
+             _string_Q);
 use reader qw(read_str);
 use printer qw(_pr_str);
 use interop qw(pl_to_mal);
@@ -178,7 +178,7 @@ sub pl_STAR {
     'symbol'      => sub { Mal::Symbol->new(${$_[0]}) },
     'symbol?'     => sub { $_[0]->isa('Mal::Symbol') ? $true : $false },
     'string?'     => sub { _string_Q($_[0]) ? $true : $false },
-    'keyword'     => sub { _keyword(${$_[0]}) },
+    'keyword'     => sub { Mal::Keyword->new(${$_[0]}) },
     'keyword?'    => sub { $_[0]->isa('Mal::Keyword') ? $true : $false },
     'fn?'         => sub { $_[0]->isa('Mal::Function') ? $true : $false },
     'macro?'      => sub { $_[0]->isa('Mal::Macro') ? $true : $false },

--- a/perl/core.pm
+++ b/perl/core.pm
@@ -9,8 +9,7 @@ use Time::HiRes qw(time);
 
 use readline;
 use types qw(_equal_Q $nil $true $false
-             _string_Q _keyword _keyword_Q
-             _hash_map);
+             _string_Q _keyword _keyword_Q);
 use reader qw(read_str);
 use printer qw(_pr_str);
 use interop qw(pl_to_mal);
@@ -205,7 +204,7 @@ sub pl_STAR {
     'list?'       => sub { $_[0]->isa('Mal::List') ? $true : $false },
     'vector'      => sub { Mal::Vector->new(\@_) },
     'vector?'     => sub { $_[0]->isa('Mal::Vector') ? $true : $false },
-    'hash-map'    => \&_hash_map,
+    'hash-map'    => sub { Mal::HashMap->new(\@_) },
     'map?'        => sub { $_[0]->isa('Mal::HashMap') ? $true : $false },
     'assoc'       => \&assoc,
     'dissoc'      => \&dissoc,

--- a/perl/core.pm
+++ b/perl/core.pm
@@ -101,8 +101,8 @@ sub first {
 
 sub apply {
     my $f = shift;
-    my $more_args = pop;
-    return &$f(@_, @$more_args);
+    push @_, @{pop @_};
+    goto &$f;
 }
 
 sub mal_map {

--- a/perl/core.pm
+++ b/perl/core.pm
@@ -181,8 +181,8 @@ sub pl_STAR {
     'string?'     => sub { _string_Q($_[0]) ? $true : $false },
     'keyword'     => sub { _keyword(${$_[0]}) },
     'keyword?'    => sub { _keyword_Q($_[0]) ? $true : $false },
-    'fn?'         => sub { (_sub_Q($_[0]) || (_function_Q($_[0]) && !$_[0]->{ismacro})) ? $true : $false },
-    'macro?'      => sub { (_function_Q($_[0]) && $_[0]->{ismacro}) ? $true : $false },
+    'fn?'         => sub { $_[0]->isa('Mal::Function') ? $true : $false },
+    'macro?'      => sub { $_[0]->isa('Mal::Macro') ? $true : $false },
 
     'pr-str'      => \&pr_str,
     'str'         => \&str,
@@ -239,7 +239,7 @@ sub pl_STAR {
 );
 
 foreach my $f (values %core::ns) {
-    bless $f, 'Mal::CoreFunction';
+    $f = Mal::Function->new($f);
 }
 
 1;

--- a/perl/core.pm
+++ b/perl/core.pm
@@ -8,8 +8,7 @@ use List::Util qw(pairmap);
 use Time::HiRes qw(time);
 
 use readline;
-use types qw(_equal_Q $nil $true $false
-             _string_Q);
+use types qw(_equal_Q $nil $true $false);
 use reader qw(read_str);
 use printer qw(_pr_str);
 use interop qw(pl_to_mal);
@@ -131,7 +130,7 @@ sub seq {
     } elsif ($arg->isa('Mal::Vector')) {
         return $nil unless @$arg;
         return Mal::List->new([@$arg]);
-    } elsif (_string_Q($arg)) {
+    } elsif ($arg->isa('Mal::String') && !$arg->isa('Mal::Keyword')) {
         return $nil if length($$arg) == 0;
         my @chars = map { Mal::String->new($_) } split(//, $$arg);
         return Mal::List->new(\@chars);
@@ -177,7 +176,7 @@ sub pl_STAR {
     'number?'     => sub { $_[0]->isa('Mal::Integer') ? $true : $false },
     'symbol'      => sub { Mal::Symbol->new(${$_[0]}) },
     'symbol?'     => sub { $_[0]->isa('Mal::Symbol') ? $true : $false },
-    'string?'     => sub { _string_Q($_[0]) ? $true : $false },
+    'string?'     => sub { $_[0]->isa('Mal::String') && !$_[0]->isa('Mal::Keyword') ? $true : $false },
     'keyword'     => sub { Mal::Keyword->new(${$_[0]}) },
     'keyword?'    => sub { $_[0]->isa('Mal::Keyword') ? $true : $false },
     'fn?'         => sub { $_[0]->isa('Mal::Function') ? $true : $false },

--- a/perl/core.pm
+++ b/perl/core.pm
@@ -9,7 +9,7 @@ use Time::HiRes qw(time);
 
 use readline;
 use types qw(_equal_Q $nil $true $false
-             _string_Q _keyword _keyword_Q);
+             _string_Q _keyword);
 use reader qw(read_str);
 use printer qw(_pr_str);
 use interop qw(pl_to_mal);
@@ -179,7 +179,7 @@ sub pl_STAR {
     'symbol?'     => sub { $_[0]->isa('Mal::Symbol') ? $true : $false },
     'string?'     => sub { _string_Q($_[0]) ? $true : $false },
     'keyword'     => sub { _keyword(${$_[0]}) },
-    'keyword?'    => sub { _keyword_Q($_[0]) ? $true : $false },
+    'keyword?'    => sub { $_[0]->isa('Mal::Keyword') ? $true : $false },
     'fn?'         => sub { $_[0]->isa('Mal::Function') ? $true : $false },
     'macro?'      => sub { $_[0]->isa('Mal::Macro') ? $true : $false },
 

--- a/perl/core.pm
+++ b/perl/core.pm
@@ -8,7 +8,7 @@ use List::Util qw(pairmap);
 use Time::HiRes qw(time);
 
 use readline;
-use types qw(_sequential_Q _equal_Q _clone $nil $true $false
+use types qw(_sequential_Q _equal_Q $nil $true $false
              _number_Q _symbol _symbol_Q _string_Q _keyword _keyword_Q _list_Q _vector_Q _sub_Q _function_Q
              _hash_map _hash_map_Q _atom_Q);
 use reader qw(read_str);
@@ -113,7 +113,7 @@ sub mal_map {
 
 sub conj {
     my $seq = shift;
-    my $new_seq = _clone($seq);
+    my $new_seq = $seq->clone;
     if (_list_Q($new_seq)) {
         unshift @$new_seq, reverse @_;
     } else {
@@ -145,7 +145,7 @@ fieldhash my %meta;
 
 # Metadata functions
 sub with_meta {
-    my $new_obj = _clone($_[0]);
+    my $new_obj = $_[0]->clone;
     $meta{$new_obj} = $_[1];
     return $new_obj;
 }

--- a/perl/interop.pm
+++ b/perl/interop.pm
@@ -1,8 +1,6 @@
 package interop;
 use strict;
 use warnings;
-no if $] >= 5.018, warnings => "experimental::smartmatch";
-use feature qw(switch);
 
 use Exporter 'import';
 our @EXPORT_OK = qw( pl_to_mal );
@@ -12,19 +10,17 @@ use types qw($nil);
 
 sub pl_to_mal {
     my($obj) = @_;
-    given (ref $obj) {
-        when(/^ARRAY/) {
+    for (ref $obj) {
+        if (/^ARRAY/) {
             my @arr = map {pl_to_mal($_)} @$obj;
             return Mal::List->new(\@arr);
-        }
-        when(/^HASH/) {
+        } elsif (/^HASH/) {
             my $hsh = {};
             foreach my $key (keys %$obj) {
                 $hsh->{$key} = pl_to_mal($obj->{$key});
             }
             return Mal::HashMap->new($hsh)
-        }
-        default {
+        } else {
 	    if (!defined($obj)) {
 		return $nil;
             } elsif (looks_like_number($obj)) {

--- a/perl/printer.pm
+++ b/perl/printer.pm
@@ -37,13 +37,12 @@ sub _pr_str {
 	} else {
 	    return $$obj;
 	}
-    } elsif ($obj->isa('Mal::Function') || $obj->isa('Mal::FunctionRef')) {
-	return '<fn* ' . _pr_str($obj->{params}) .
-	    ' ' . _pr_str($obj->{ast}) . '>';
     } elsif ($obj->isa('Mal::Atom')) {
 	return '(atom ' . _pr_str($$obj) . ")";
-    } elsif ($obj->isa('Mal::CoreFunction')) {
-        return '<builtin_fn* ' . $obj . '>';
+    } elsif ($obj->isa('Mal::Function')) {
+        return '<fn* ' . $obj . '>';
+    } elsif ($obj->isa('Mal::Macro')) {
+        return '<macro* ' . $obj . '>';
     } else {
         return $$obj;
     }

--- a/perl/printer.pm
+++ b/perl/printer.pm
@@ -33,16 +33,16 @@ sub _pr_str {
 	    $str =~ s/\\/\\\\/g;
 	    $str =~ s/"/\\"/g;
 	    $str =~ s/\n/\\n/g;
-	    return '"' . $str . '"';
+	    return qq'"$str"';
 	} else {
 	    return $$obj;
 	}
     } elsif ($obj->isa('Mal::Atom')) {
 	return '(atom ' . _pr_str($$obj) . ")";
     } elsif ($obj->isa('Mal::Function')) {
-        return '<fn* ' . $obj . '>';
+        return "<fn* $obj>";
     } elsif ($obj->isa('Mal::Macro')) {
-        return '<macro* ' . $obj . '>';
+        return "<macro* $obj>";
     } else {
         return $$obj;
     }

--- a/perl/printer.pm
+++ b/perl/printer.pm
@@ -12,7 +12,7 @@ use List::Util qw(pairmap);
 
 sub _pr_str {
     my($obj, $print_readably) = @_;
-    my($_r) = (defined $print_readably) ? $print_readably : 1;
+    my($_r) = $print_readably // 1;
     if ($obj->isa('Mal::List')) {
 	return '(' . join(' ', map { _pr_str($_, $_r) } @$obj) . ')';
     } elsif ($obj->isa('Mal::Vector')) {

--- a/perl/printer.pm
+++ b/perl/printer.pm
@@ -27,7 +27,7 @@ sub _pr_str {
 	return '{' . join(' ', @elems) . '}';
     } elsif ($obj->isa('Mal::String')) {
 	if ($$obj =~ /^\x{029e}/) {
-	    return ':' . substr($$obj,1);
+	    return ":$'";
 	} elsif ($_r) {
 	    my $str = $$obj;
 	    $str =~ s/\\/\\\\/g;

--- a/perl/printer.pm
+++ b/perl/printer.pm
@@ -8,23 +8,18 @@ our @EXPORT_OK = qw( _pr_str );
 use types qw($nil $true $false);
 
 use Data::Dumper;
+use List::Util qw(pairmap);
 
 sub _pr_str {
     my($obj, $print_readably) = @_;
     my($_r) = (defined $print_readably) ? $print_readably : 1;
     if ($obj->isa('Mal::List')) {
-	return '(' . join(' ', map {_pr_str($_, $_r)} @{$obj}) . ')';
+	return '(' . join(' ', map { _pr_str($_, $_r) } @$obj) . ')';
     } elsif ($obj->isa('Mal::Vector')) {
-	return '[' . join(' ', map {_pr_str($_, $_r)} @{$obj}) . ']';
+	return '[' . join(' ', map { _pr_str($_, $_r) } @$obj) . ']';
     } elsif ($obj->isa('Mal::HashMap')) {
-	my @elems = ();
-
-	foreach my $key (keys %$obj) {
-	    push(@elems, _pr_str(Mal::String->new($key), $_r));
-	    push(@elems, _pr_str($obj->{$key}, $_r));
-	}
-
-	return '{' . join(' ', @elems) . '}';
+	return '{' . join(' ', pairmap { _pr_str(Mal::String->new($a), $_r) =>
+				         _pr_str($b, $_r) } %$obj) . '}';
     } elsif ($obj->isa('Mal::String')) {
 	if ($$obj =~ /^\x{029e}/) {
 	    return ":$'";

--- a/perl/reader.pm
+++ b/perl/reader.pm
@@ -33,8 +33,7 @@ sub read_atom {
     given ($token) {
         when(/^-?[0-9]+$/) { return Mal::Integer->new($token) }
         when(/^"((?:\\.|[^\\"])*)"$/) {
-            my %escaped_chars = ( "\\\\" => "\\", "\\\"" => "\"", "\\n" => "\n" );
-            return Mal::String->new($1 =~ s/\\./$escaped_chars{$&}/ger);
+            return Mal::String->new($1 =~ s/\\(.)/$1 =~ tr|n|\n|r/ger);
         }
         when(/^"/) {
             die "expected '\"', got EOF";

--- a/perl/reader.pm
+++ b/perl/reader.pm
@@ -7,7 +7,7 @@ use feature qw(switch);
 use Exporter 'import';
 our @EXPORT_OK = qw( read_str );
 
-use types qw($nil $true $false _keyword _hash_map);
+use types qw($nil $true $false _keyword);
 
 use Data::Dumper;
 
@@ -68,13 +68,7 @@ sub read_list {
         push(@lst, read_form($rdr));
     }
     $rdr->next();
-    if ($class eq 'Mal::List') {
-        return Mal::List->new(\@lst);
-    } elsif ($class eq 'Mal::Vector') {
-        return Mal::Vector->new(\@lst);
-    } else {
-        return _hash_map(@lst);
-    }
+    return $class->new(\@lst);
 }
 
 sub read_form {

--- a/perl/reader.pm
+++ b/perl/reader.pm
@@ -32,16 +32,14 @@ sub read_atom {
     my $token = $rdr->next();
     given ($token) {
         when(/^-?[0-9]+$/) { return Mal::Integer->new($token) }
-        when(/^"(?:\\.|[^\\"])*"$/) {
+        when(/^"((?:\\.|[^\\"])*)"$/) {
             my %escaped_chars = ( "\\\\" => "\\", "\\\"" => "\"", "\\n" => "\n" );
-            my $str = substr $token, 1, -1;
-            $str =~ s/\\./$escaped_chars{$&}/ge;
-            return Mal::String->new($str)
+            return Mal::String->new($1 =~ s/\\./$escaped_chars{$&}/ger);
         }
         when(/^"/) {
             die "expected '\"', got EOF";
         }
-        when(/^:/) { return Mal::Keyword->new(substr($token,1)) }
+        when(/^:/) { return Mal::Keyword->new($') }
         when('nil') { return $nil }
         when('true') { return $true }
         when('false') { return $false }

--- a/perl/reader.pm
+++ b/perl/reader.pm
@@ -7,7 +7,7 @@ use feature qw(switch);
 use Exporter 'import';
 our @EXPORT_OK = qw( read_str );
 
-use types qw($nil $true $false _keyword);
+use types qw($nil $true $false);
 
 use Data::Dumper;
 
@@ -41,7 +41,7 @@ sub read_atom {
         when(/^"/) {
             die "expected '\"', got EOF";
         }
-        when(/^:/) { return _keyword(substr($token,1)) }
+        when(/^:/) { return Mal::Keyword->new(substr($token,1)) }
         when('nil') { return $nil }
         when('true') { return $true }
         when('false') { return $false }

--- a/perl/step2_eval.pl
+++ b/perl/step2_eval.pl
@@ -8,7 +8,7 @@ use List::Util qw(pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw(_list_Q);
+use types;
 use reader;
 use printer;
 
@@ -35,7 +35,7 @@ sub eval_ast {
 sub EVAL {
     my($ast, $env) = @_;
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
         return eval_ast($ast, $env);
     }
 

--- a/perl/step3_env.pl
+++ b/perl/step3_env.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw(_list_Q);
+use types;
 use reader;
 use printer;
 use env;
@@ -38,7 +38,7 @@ sub eval_ast {
 sub EVAL {
     my($ast, $env) = @_;
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
         return eval_ast($ast, $env);
     }
 

--- a/perl/step4_if_fn_do.pl
+++ b/perl/step4_if_fn_do.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _list_Q);
+use types qw($nil $true $false);
 use reader;
 use printer;
 use env;
@@ -39,7 +39,7 @@ sub eval_ast {
 sub EVAL {
     my($ast, $env) = @_;
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
         return eval_ast($ast, $env);
     }
 

--- a/perl/step4_if_fn_do.pl
+++ b/perl/step4_if_fn_do.pl
@@ -74,8 +74,7 @@ sub EVAL {
         when ('fn*') {
             return Mal::Function->new(sub {
                 #print "running fn*\n";
-                my $args = \@_;
-                return EVAL($a2, Mal::Env->new($env, $a1, $args));
+                return EVAL($a2, Mal::Env->new($env, $a1, \@_));
             });
         }
         default {

--- a/perl/step4_if_fn_do.pl
+++ b/perl/step4_if_fn_do.pl
@@ -72,11 +72,11 @@ sub EVAL {
             }
         }
         when ('fn*') {
-            return bless sub {
+            return Mal::Function->new(sub {
                 #print "running fn*\n";
                 my $args = \@_;
                 return EVAL($a2, Mal::Env->new($env, $a1, $args));
-            }, 'Mal::CoreFunction';
+            });
         }
         default {
             my @el = @{eval_ast($ast, $env)};

--- a/perl/step5_tco.pl
+++ b/perl/step5_tco.pl
@@ -76,12 +76,12 @@ sub EVAL {
 	    goto &EVAL;
         }
         when ('fn*') {
-            return bless sub {
+            return Mal::Function->new(sub {
                 #print "running fn*\n";
                 my $args = \@_;
 		@_ = ($a2, Mal::Env->new($env, $a1, $args));
                 goto &EVAL;
-            }, 'Mal::CoreFunction';
+            });
         }
         default {
             @_ = @{eval_ast($ast, $env)};

--- a/perl/step5_tco.pl
+++ b/perl/step5_tco.pl
@@ -69,7 +69,7 @@ sub EVAL {
         when ('if') {
             my $cond = EVAL($a1, $env);
             if ($cond eq $nil || $cond eq $false) {
-                @_ = ($a3 ? $a3 : $nil, $env);
+                @_ = ($a3 // $nil, $env);
             } else {
                 @_ = ($a2, $env);
             }

--- a/perl/step5_tco.pl
+++ b/perl/step5_tco.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _list_Q);
+use types qw($nil $true $false);
 use reader;
 use printer;
 use env;
@@ -40,7 +40,7 @@ sub EVAL {
     my($ast, $env) = @_;
 
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
         goto &eval_ast;
     }
 

--- a/perl/step5_tco.pl
+++ b/perl/step5_tco.pl
@@ -78,8 +78,7 @@ sub EVAL {
         when ('fn*') {
             return Mal::Function->new(sub {
                 #print "running fn*\n";
-                my $args = \@_;
-		@_ = ($a2, Mal::Env->new($env, $a1, $args));
+		@_ = ($a2, Mal::Env->new($env, $a1, \@_));
                 goto &EVAL;
             });
         }

--- a/perl/step6_file.pl
+++ b/perl/step6_file.pl
@@ -76,12 +76,12 @@ sub EVAL {
 	    goto &EVAL;
         }
         when ('fn*') {
-            return bless sub {
+            return Mal::Function->new(sub {
                 #print "running fn*\n";
                 my $args = \@_;
 		@_ = ($a2, Mal::Env->new($env, $a1, $args));
                 goto &EVAL;
-            }, 'Mal::CoreFunction';
+            });
         }
         default {
             @_ = @{eval_ast($ast, $env)};
@@ -109,7 +109,7 @@ foreach my $n (keys %core::ns) {
     $repl_env->set(Mal::Symbol->new($n), $core::ns{$n});
 }
 $repl_env->set(Mal::Symbol->new('eval'),
-	       bless sub { EVAL($_[0], $repl_env); }, 'Mal::CoreFunction');
+	       Mal::Function->new(sub { EVAL($_[0], $repl_env) }));
 my @_argv = map {Mal::String->new($_)}  @ARGV[1..$#ARGV];
 $repl_env->set(Mal::Symbol->new('*ARGV*'), Mal::List->new(\@_argv));
 

--- a/perl/step6_file.pl
+++ b/perl/step6_file.pl
@@ -69,7 +69,7 @@ sub EVAL {
         when ('if') {
             my $cond = EVAL($a1, $env);
             if ($cond eq $nil || $cond eq $false) {
-                @_ = ($a3 ? $a3 : $nil, $env);
+                @_ = ($a3 // $nil, $env);
             } else {
                 @_ = ($a2, $env);
             }

--- a/perl/step6_file.pl
+++ b/perl/step6_file.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _list_Q);
+use types qw($nil $true $false);
 use reader;
 use printer;
 use env;
@@ -40,7 +40,7 @@ sub EVAL {
     my($ast, $env) = @_;
 
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
         goto &eval_ast;
     }
 

--- a/perl/step6_file.pl
+++ b/perl/step6_file.pl
@@ -78,8 +78,7 @@ sub EVAL {
         when ('fn*') {
             return Mal::Function->new(sub {
                 #print "running fn*\n";
-                my $args = \@_;
-		@_ = ($a2, Mal::Env->new($env, $a1, $args));
+		@_ = ($a2, Mal::Env->new($env, $a1, \@_));
                 goto &EVAL;
             });
         }

--- a/perl/step7_quote.pl
+++ b/perl/step7_quote.pl
@@ -108,8 +108,7 @@ sub EVAL {
         when ('fn*') {
             return Mal::Function->new(sub {
                 #print "running fn*\n";
-                my $args = \@_;
-		@_ = ($a2, Mal::Env->new($env, $a1, $args));
+		@_ = ($a2, Mal::Env->new($env, $a1, \@_));
                 goto &EVAL;
             });
         }

--- a/perl/step7_quote.pl
+++ b/perl/step7_quote.pl
@@ -99,7 +99,7 @@ sub EVAL {
         when ('if') {
             my $cond = EVAL($a1, $env);
             if ($cond eq $nil || $cond eq $false) {
-                @_ = ($a3 ? $a3 : $nil, $env);
+                @_ = ($a3 // $nil, $env);
             } else {
                 @_ = ($a2, $env);
             }

--- a/perl/step7_quote.pl
+++ b/perl/step7_quote.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _sequential_Q _symbol_Q _list_Q);
+use types qw($nil $true $false _symbol_Q _list_Q);
 use reader;
 use printer;
 use env;
@@ -25,7 +25,7 @@ sub READ {
 # eval
 sub is_pair {
     my ($x) = @_;
-    return _sequential_Q($x) && @$x;
+    return $x->isa('Mal::Sequence') && @$x;
 }
 
 sub quasiquote {

--- a/perl/step7_quote.pl
+++ b/perl/step7_quote.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _symbol_Q _list_Q);
+use types qw($nil $true $false);
 use reader;
 use printer;
 use env;
@@ -32,9 +32,9 @@ sub quasiquote {
     my ($ast) = @_;
     if (!is_pair($ast)) {
         return Mal::List->new([Mal::Symbol->new("quote"), $ast]);
-    } elsif (_symbol_Q($ast->[0]) && ${$ast->[0]} eq 'unquote') {
+    } elsif ($ast->[0]->isa('Mal::Symbol') && ${$ast->[0]} eq 'unquote') {
         return $ast->[1];
-    } elsif (is_pair($ast->[0]) && _symbol_Q($ast->[0]->[0]) &&
+    } elsif (is_pair($ast->[0]) && $ast->[0]->[0]->isa('Mal::Symbol') &&
              ${$ast->[0]->[0]} eq 'splice-unquote') {
         return Mal::List->new([Mal::Symbol->new("concat"),
                           $ast->[0]->[1],
@@ -63,7 +63,7 @@ sub EVAL {
     my($ast, $env) = @_;
 
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
         goto &eval_ast;
     }
 

--- a/perl/step7_quote.pl
+++ b/perl/step7_quote.pl
@@ -62,11 +62,9 @@ sub eval_ast {
 sub EVAL {
     my($ast, $env) = @_;
 
-    while (1) {
-
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
     if (! _list_Q($ast)) {
-        return eval_ast($ast, $env);
+        goto &eval_ast;
     }
 
     # apply list
@@ -83,48 +81,44 @@ sub EVAL {
 		my ($k, $v) = @$pair;
                 $let_env->set($k, EVAL($v, $let_env));
             }
-            $ast = $a2;
-            $env = $let_env;
-            # Continue loop (TCO)
+	    @_ = ($a2, $let_env);
+	    goto &EVAL;
         }
         when ('quote') {
             return $a1;
         }
         when ('quasiquote') {
-            $ast = quasiquote($a1);
-            # Continue loop (TCO)
+            @_ = (quasiquote($a1), $env);
+	    goto &EVAL;
         }
         when ('do') {
             eval_ast($ast->slice(1, $#$ast-1), $env);
-            $ast = $ast->[$#$ast];
-            # Continue loop (TCO)
+            @_ = ($ast->[$#$ast], $env);
+            goto &EVAL;
         }
         when ('if') {
             my $cond = EVAL($a1, $env);
             if ($cond eq $nil || $cond eq $false) {
-                $ast = $a3 ? $a3 : $nil;
+                @_ = ($a3 ? $a3 : $nil, $env);
             } else {
-                $ast = $a2;
+                @_ = ($a2, $env);
             }
-            # Continue loop (TCO)
+	    goto &EVAL;
         }
         when ('fn*') {
-            return Mal::Function->new(\&EVAL, $a2, $env, $a1);
+            return bless sub {
+                #print "running fn*\n";
+                my $args = \@_;
+		@_ = ($a2, Mal::Env->new($env, $a1, $args));
+                goto &EVAL;
+            }, 'Mal::CoreFunction';
         }
         default {
-            my @el = @{eval_ast($ast, $env)};
-            my $f = shift @el;
-            if ($f->isa('Mal::Function')) {
-                $ast = $f->{ast};
-                $env = $f->gen_env(\@el);
-                # Continue loop (TCO)
-            } else {
-                return &$f(@el);
-            }
+            @_ = @{eval_ast($ast, $env)};
+            my $f = shift;
+	    goto &$f;
         }
     }
-
-    } # TCO while loop
 }
 
 # print

--- a/perl/step7_quote.pl
+++ b/perl/step7_quote.pl
@@ -106,12 +106,12 @@ sub EVAL {
 	    goto &EVAL;
         }
         when ('fn*') {
-            return bless sub {
+            return Mal::Function->new(sub {
                 #print "running fn*\n";
                 my $args = \@_;
 		@_ = ($a2, Mal::Env->new($env, $a1, $args));
                 goto &EVAL;
-            }, 'Mal::CoreFunction';
+            });
         }
         default {
             @_ = @{eval_ast($ast, $env)};
@@ -139,7 +139,7 @@ foreach my $n (keys %core::ns) {
     $repl_env->set(Mal::Symbol->new($n), $core::ns{$n});
 }
 $repl_env->set(Mal::Symbol->new('eval'),
-	       bless sub { EVAL($_[0], $repl_env); }, 'Mal::CoreFunction');
+	       Mal::Function->new(sub { EVAL($_[0], $repl_env) }));
 my @_argv = map {Mal::String->new($_)}  @ARGV[1..$#ARGV];
 $repl_env->set(Mal::Symbol->new('*ARGV*'), Mal::List->new(\@_argv));
 

--- a/perl/step8_macros.pl
+++ b/perl/step8_macros.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _symbol_Q _list_Q _clone);
+use types qw($nil $true $false _symbol_Q _list_Q);
 use reader;
 use printer;
 use env;
@@ -125,7 +125,7 @@ sub EVAL {
             # Continue loop (TCO)
         }
         when ('defmacro!') {
-            my $func = _clone(EVAL($a2, $env));
+            my $func = EVAL($a2, $env)->clone;
             $func->{ismacro} = 1;
             return $env->set($a1, $func);
         }

--- a/perl/step8_macros.pl
+++ b/perl/step8_macros.pl
@@ -146,8 +146,7 @@ sub EVAL {
         when ('fn*') {
             return Mal::Function->new(sub {
                 #print "running fn*\n";
-                my $args = \@_;
-		@_ = ($a2, Mal::Env->new($env, $a1, $args));
+		@_ = ($a2, Mal::Env->new($env, $a1, \@_));
                 goto &EVAL;
             });
         }

--- a/perl/step8_macros.pl
+++ b/perl/step8_macros.pl
@@ -86,18 +86,17 @@ sub eval_ast {
 sub EVAL {
     my($ast, $env) = @_;
 
-    while (1) {
-
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
     if (! _list_Q($ast)) {
-        return eval_ast($ast, $env);
+        goto &eval_ast;
     }
     @$ast or return $ast;
 
     # apply list
     $ast = macroexpand($ast, $env);
     if (! _list_Q($ast)) {
-        return eval_ast($ast, $env);
+	@_ = ($ast, $env);
+        goto &eval_ast;
     }
 
     my ($a0, $a1, $a2, $a3) = @$ast;
@@ -113,16 +112,15 @@ sub EVAL {
 		my ($k, $v) = @$pair;
                 $let_env->set($k, EVAL($v, $let_env));
             }
-            $ast = $a2;
-            $env = $let_env;
-            # Continue loop (TCO)
+	    @_ = ($a2, $let_env);
+	    goto &EVAL;
         }
         when ('quote') {
             return $a1;
         }
         when ('quasiquote') {
-            $ast = quasiquote($a1);
-            # Continue loop (TCO)
+            @_ = (quasiquote($a1), $env);
+	    goto &EVAL;
         }
         when ('defmacro!') {
             my $func = EVAL($a2, $env)->clone;
@@ -130,39 +128,37 @@ sub EVAL {
             return $env->set($a1, $func);
         }
         when ('macroexpand') {
+	    @_ = ($a1, $env);
             return macroexpand($a1, $env);
         }
         when ('do') {
             eval_ast($ast->slice(1, $#$ast-1), $env);
-            $ast = $ast->[$#$ast];
-            # Continue loop (TCO)
+            @_ = ($ast->[$#$ast], $env);
+            goto &EVAL;
         }
         when ('if') {
             my $cond = EVAL($a1, $env);
             if ($cond eq $nil || $cond eq $false) {
-                $ast = $a3 ? $a3 : $nil;
+                @_ = ($a3 ? $a3 : $nil, $env);
             } else {
-                $ast = $a2;
+                @_ = ($a2, $env);
             }
-            # Continue loop (TCO)
+	    goto &EVAL;
         }
         when ('fn*') {
-            return Mal::Function->new(\&EVAL, $a2, $env, $a1);
+            return bless sub {
+                #print "running fn*\n";
+                my $args = \@_;
+		@_ = ($a2, Mal::Env->new($env, $a1, $args));
+                goto &EVAL;
+            }, 'Mal::CoreFunction';
         }
         default {
-            my @el = @{eval_ast($ast, $env)};
-            my $f = shift @el;
-            if ($f->isa('Mal::Function')) {
-                $ast = $f->{ast};
-                $env = $f->gen_env(\@el);
-                # Continue loop (TCO)
-            } else {
-                return &$f(@el);
-            }
+            @_ = @{eval_ast($ast, $env)};
+            my $f = shift;
+	    goto &$f;
         }
     }
-
-    } # TCO while loop
 }
 
 # print

--- a/perl/step8_macros.pl
+++ b/perl/step8_macros.pl
@@ -137,7 +137,7 @@ sub EVAL {
         when ('if') {
             my $cond = EVAL($a1, $env);
             if ($cond eq $nil || $cond eq $false) {
-                @_ = ($a3 ? $a3 : $nil, $env);
+                @_ = ($a3 // $nil, $env);
             } else {
                 @_ = ($a2, $env);
             }

--- a/perl/step8_macros.pl
+++ b/perl/step8_macros.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _sequential_Q _symbol_Q _list_Q _clone);
+use types qw($nil $true $false _symbol_Q _list_Q _clone);
 use reader;
 use printer;
 use env;
@@ -25,7 +25,7 @@ sub READ {
 # eval
 sub is_pair {
     my ($x) = @_;
-    return _sequential_Q($x) && @$x;
+    return $x->isa('Mal::Sequence') && @$x;
 }
 
 sub quasiquote {

--- a/perl/step8_macros.pl
+++ b/perl/step8_macros.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _symbol_Q _list_Q);
+use types qw($nil $true $false);
 use reader;
 use printer;
 use env;
@@ -32,9 +32,9 @@ sub quasiquote {
     my ($ast) = @_;
     if (!is_pair($ast)) {
         return Mal::List->new([Mal::Symbol->new("quote"), $ast]);
-    } elsif (_symbol_Q($ast->[0]) && ${$ast->[0]} eq 'unquote') {
+    } elsif ($ast->[0]->isa('Mal::Symbol') && ${$ast->[0]} eq 'unquote') {
         return $ast->[1];
-    } elsif (is_pair($ast->[0]) && _symbol_Q($ast->[0]->[0]) &&
+    } elsif (is_pair($ast->[0]) && $ast->[0]->[0]->isa('Mal::Symbol') &&
              ${$ast->[0]->[0]} eq 'splice-unquote') {
         return Mal::List->new([Mal::Symbol->new("concat"),
                           $ast->[0]->[1],
@@ -48,8 +48,8 @@ sub quasiquote {
 
 sub is_macro_call {
     my ($ast, $env) = @_;
-    if (_list_Q($ast) &&
-        _symbol_Q($ast->[0]) &&
+    if ($ast->isa('Mal::List') &&
+        $ast->[0]->isa("Mal::Symbol") &&
         $env->find($ast->[0])) {
         my ($f) = $env->get($ast->[0]);
         return $f->isa('Mal::Macro');
@@ -85,14 +85,14 @@ sub EVAL {
     my($ast, $env) = @_;
 
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
         goto &eval_ast;
     }
     @$ast or return $ast;
 
     # apply list
     $ast = macroexpand($ast, $env);
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
 	@_ = ($ast, $env);
         goto &eval_ast;
     }

--- a/perl/step9_try.pl
+++ b/perl/step9_try.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _symbol_Q _list_Q _clone);
+use types qw($nil $true $false _symbol_Q _list_Q);
 use reader;
 use printer;
 use env;
@@ -126,7 +126,7 @@ sub EVAL {
             # Continue loop (TCO)
         }
         when ('defmacro!') {
-            my $func = _clone(EVAL($a2, $env));
+            my $func = EVAL($a2, $env)->clone;
             $func->{ismacro} = 1;
             return $env->set($a1, $func);
         }

--- a/perl/step9_try.pl
+++ b/perl/step9_try.pl
@@ -87,18 +87,17 @@ sub eval_ast {
 sub EVAL {
     my($ast, $env) = @_;
 
-    while (1) {
-
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
     if (! _list_Q($ast)) {
-        return eval_ast($ast, $env);
+        goto &eval_ast;
     }
     @$ast or return $ast;
 
     # apply list
     $ast = macroexpand($ast, $env);
     if (! _list_Q($ast)) {
-        return eval_ast($ast, $env);
+	@_ = ($ast, $env);
+        goto &eval_ast;
     }
 
     my ($a0, $a1, $a2, $a3) = @$ast;
@@ -114,16 +113,15 @@ sub EVAL {
 		my ($k, $v) = @$pair;
                 $let_env->set($k, EVAL($v, $let_env));
             }
-            $ast = $a2;
-            $env = $let_env;
-            # Continue loop (TCO)
+	    @_ = ($a2, $let_env);
+	    goto &EVAL;
         }
         when ('quote') {
             return $a1;
         }
         when ('quasiquote') {
-            $ast = quasiquote($a1);
-            # Continue loop (TCO)
+            @_ = (quasiquote($a1), $env);
+	    goto &EVAL;
         }
         when ('defmacro!') {
             my $func = EVAL($a2, $env)->clone;
@@ -146,42 +144,40 @@ sub EVAL {
 		    $exc = Mal::String->new($msg);
 		}
 		my $catch_env = Mal::Env->new($env, [$a2->[1]], [$exc]);
-		return EVAL($a2->[2], $catch_env)
+		@_ = ($a2->[2], $catch_env);
+		goto &EVAL;
 	    } else {
 		die $@;
 	    }
         }
         when ('do') {
             eval_ast($ast->slice(1, $#$ast-1), $env);
-            $ast = $ast->[$#$ast];
-            # Continue loop (TCO)
+            @_ = ($ast->[$#$ast], $env);
+            goto &EVAL;
         }
         when ('if') {
             my $cond = EVAL($a1, $env);
             if ($cond eq $nil || $cond eq $false) {
-                $ast = $a3 ? $a3 : $nil;
+                @_ = ($a3 ? $a3 : $nil, $env);
             } else {
-                $ast = $a2;
+                @_ = ($a2, $env);
             }
-            # Continue loop (TCO)
+	    goto &EVAL;
         }
         when ('fn*') {
-            return Mal::Function->new(\&EVAL, $a2, $env, $a1);
+            return bless sub {
+                #print "running fn*\n";
+                my $args = \@_;
+		@_ = ($a2, Mal::Env->new($env, $a1, $args));
+                goto &EVAL;
+            }, 'Mal::CoreFunction';
         }
         default {
-            my @el = @{eval_ast($ast, $env)};
-            my $f = shift @el;
-            if ($f->isa('Mal::Function')) {
-                $ast = $f->{ast};
-                $env = $f->gen_env(\@el);
-                # Continue loop (TCO)
-            } else {
-                return &$f(@el);
-            }
+            @_ = @{eval_ast($ast, $env)};
+            my $f = shift;
+	    goto &$f;
         }
     }
-
-    } # TCO while loop
 }
 
 # print

--- a/perl/step9_try.pl
+++ b/perl/step9_try.pl
@@ -53,9 +53,7 @@ sub is_macro_call {
         _symbol_Q($ast->[0]) &&
         $env->find($ast->[0])) {
         my ($f) = $env->get($ast->[0]);
-        if ($f->isa('Mal::Function')) {
-            return $f->{ismacro};
-        }
+        return $f->isa('Mal::Macro');
     }
     return 0;
 }
@@ -125,7 +123,7 @@ sub EVAL {
         }
         when ('defmacro!') {
             my $func = EVAL($a2, $env)->clone;
-            $func->{ismacro} = 1;
+            $func = Mal::Macro->new($func);
             return $env->set($a1, $func);
         }
         when ('macroexpand') {
@@ -165,12 +163,12 @@ sub EVAL {
 	    goto &EVAL;
         }
         when ('fn*') {
-            return bless sub {
+            return Mal::Function->new(sub {
                 #print "running fn*\n";
                 my $args = \@_;
 		@_ = ($a2, Mal::Env->new($env, $a1, $args));
                 goto &EVAL;
-            }, 'Mal::CoreFunction';
+            });
         }
         default {
             @_ = @{eval_ast($ast, $env)};
@@ -198,7 +196,7 @@ foreach my $n (keys %core::ns) {
     $repl_env->set(Mal::Symbol->new($n), $core::ns{$n});
 }
 $repl_env->set(Mal::Symbol->new('eval'),
-	       bless sub { EVAL($_[0], $repl_env); }, 'Mal::CoreFunction');
+	       Mal::Function->new(sub { EVAL($_[0], $repl_env) }));
 my @_argv = map {Mal::String->new($_)}  @ARGV[1..$#ARGV];
 $repl_env->set(Mal::Symbol->new('*ARGV*'), Mal::List->new(\@_argv));
 

--- a/perl/step9_try.pl
+++ b/perl/step9_try.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _symbol_Q _list_Q);
+use types qw($nil $true $false);
 use reader;
 use printer;
 use env;
@@ -33,9 +33,9 @@ sub quasiquote {
     my ($ast) = @_;
     if (!is_pair($ast)) {
         return Mal::List->new([Mal::Symbol->new("quote"), $ast]);
-    } elsif (_symbol_Q($ast->[0]) && ${$ast->[0]} eq 'unquote') {
+    } elsif ($ast->[0]->isa('Mal::Symbol') && ${$ast->[0]} eq 'unquote') {
         return $ast->[1];
-    } elsif (is_pair($ast->[0]) && _symbol_Q($ast->[0]->[0]) &&
+    } elsif (is_pair($ast->[0]) && $ast->[0]->[0]->isa('Mal::Symbol') &&
              ${$ast->[0]->[0]} eq 'splice-unquote') {
         return Mal::List->new([Mal::Symbol->new("concat"),
                           $ast->[0]->[1],
@@ -49,8 +49,8 @@ sub quasiquote {
 
 sub is_macro_call {
     my ($ast, $env) = @_;
-    if (_list_Q($ast) &&
-        _symbol_Q($ast->[0]) &&
+    if ($ast->isa('Mal::List') &&
+        $ast->[0]->isa('Mal::Symbol') &&
         $env->find($ast->[0])) {
         my ($f) = $env->get($ast->[0]);
         return $f->isa('Mal::Macro');
@@ -86,14 +86,14 @@ sub EVAL {
     my($ast, $env) = @_;
 
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
         goto &eval_ast;
     }
     @$ast or return $ast;
 
     # apply list
     $ast = macroexpand($ast, $env);
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
 	@_ = ($ast, $env);
         goto &eval_ast;
     }

--- a/perl/step9_try.pl
+++ b/perl/step9_try.pl
@@ -156,7 +156,7 @@ sub EVAL {
         when ('if') {
             my $cond = EVAL($a1, $env);
             if ($cond eq $nil || $cond eq $false) {
-                @_ = ($a3 ? $a3 : $nil, $env);
+                @_ = ($a3 // $nil, $env);
             } else {
                 @_ = ($a2, $env);
             }

--- a/perl/step9_try.pl
+++ b/perl/step9_try.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _sequential_Q _symbol_Q _list_Q _clone);
+use types qw($nil $true $false _symbol_Q _list_Q _clone);
 use reader;
 use printer;
 use env;
@@ -26,7 +26,7 @@ sub READ {
 # eval
 sub is_pair {
     my ($x) = @_;
-    return _sequential_Q($x) && @$x;
+    return $x->isa('Mal::Sequence') && @$x;
 }
 
 sub quasiquote {

--- a/perl/step9_try.pl
+++ b/perl/step9_try.pl
@@ -165,8 +165,7 @@ sub EVAL {
         when ('fn*') {
             return Mal::Function->new(sub {
                 #print "running fn*\n";
-                my $args = \@_;
-		@_ = ($a2, Mal::Env->new($env, $a1, $args));
+		@_ = ($a2, Mal::Env->new($env, $a1, \@_));
                 goto &EVAL;
             });
         }

--- a/perl/stepA_mal.pl
+++ b/perl/stepA_mal.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _symbol_Q _list_Q _clone);
+use types qw($nil $true $false _symbol_Q _list_Q);
 use reader;
 use printer;
 use env;
@@ -125,7 +125,7 @@ sub EVAL {
             # Continue loop (TCO)
         }
         when ('defmacro!') {
-            my $func = _clone(EVAL($a2, $env));
+            my $func = EVAL($a2, $env)->clone;
             $func->{ismacro} = 1;
             return $env->set($a1, $func);
         }

--- a/perl/stepA_mal.pl
+++ b/perl/stepA_mal.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _symbol_Q _list_Q);
+use types qw($nil $true $false);
 use reader;
 use printer;
 use env;
@@ -32,9 +32,9 @@ sub quasiquote {
     my ($ast) = @_;
     if (!is_pair($ast)) {
         return Mal::List->new([Mal::Symbol->new("quote"), $ast]);
-    } elsif (_symbol_Q($ast->[0]) && ${$ast->[0]} eq 'unquote') {
+    } elsif ($ast->[0]->isa('Mal::Symbol') && ${$ast->[0]} eq 'unquote') {
         return $ast->[1];
-    } elsif (is_pair($ast->[0]) && _symbol_Q($ast->[0]->[0]) &&
+    } elsif (is_pair($ast->[0]) && $ast->[0]->[0]->isa('Mal::Symbol') &&
              ${$ast->[0]->[0]} eq 'splice-unquote') {
         return Mal::List->new([Mal::Symbol->new("concat"),
                           $ast->[0]->[1],
@@ -48,8 +48,8 @@ sub quasiquote {
 
 sub is_macro_call {
     my ($ast, $env) = @_;
-    if (_list_Q($ast) &&
-        _symbol_Q($ast->[0]) &&
+    if ($ast->isa('Mal::List') &&
+        $ast->[0]->isa('Mal::Symbol') &&
         $env->find($ast->[0])) {
         my ($f) = $env->get($ast->[0]);
         return $f->isa('Mal::Macro');
@@ -85,14 +85,14 @@ sub EVAL {
     my($ast, $env) = @_;
 
     #print "EVAL: " . printer::_pr_str($ast) . "\n";
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
         goto &eval_ast;
     }
     @$ast or return $ast;
 
     # apply list
     $ast = macroexpand($ast, $env);
-    if (! _list_Q($ast)) {
+    if (! $ast->isa('Mal::List')) {
 	@_ = ($ast, $env);
         goto &eval_ast;
     }

--- a/perl/stepA_mal.pl
+++ b/perl/stepA_mal.pl
@@ -164,8 +164,7 @@ sub EVAL {
         when ('fn*') {
             return Mal::Function->new(sub {
                 #print "running fn*\n";
-                my $args = \@_;
-		@_ = ($a2, Mal::Env->new($env, $a1, $args));
+		@_ = ($a2, Mal::Env->new($env, $a1, \@_));
                 goto &EVAL;
             });
         }

--- a/perl/stepA_mal.pl
+++ b/perl/stepA_mal.pl
@@ -52,9 +52,7 @@ sub is_macro_call {
         _symbol_Q($ast->[0]) &&
         $env->find($ast->[0])) {
         my ($f) = $env->get($ast->[0]);
-        if ($f->isa('Mal::Function')) {
-            return $f->{ismacro};
-        }
+        return $f->isa('Mal::Macro');
     }
     return 0;
 }
@@ -124,7 +122,7 @@ sub EVAL {
         }
         when ('defmacro!') {
             my $func = EVAL($a2, $env)->clone;
-            $func->{ismacro} = 1;
+            $func = Mal::Macro->new($func);
             return $env->set($a1, $func);
         }
         when ('macroexpand') {
@@ -164,12 +162,12 @@ sub EVAL {
 	    goto &EVAL;
         }
         when ('fn*') {
-            return bless sub {
+            return Mal::Function->new(sub {
                 #print "running fn*\n";
                 my $args = \@_;
 		@_ = ($a2, Mal::Env->new($env, $a1, $args));
                 goto &EVAL;
-            }, 'Mal::CoreFunction';
+            });
         }
         default {
             @_ = @{eval_ast($ast, $env)};
@@ -197,7 +195,7 @@ foreach my $n (keys %core::ns) {
     $repl_env->set(Mal::Symbol->new($n), $core::ns{$n});
 }
 $repl_env->set(Mal::Symbol->new('eval'),
-	       bless sub { EVAL($_[0], $repl_env); }, 'Mal::CoreFunction');
+	       Mal::Function->new(sub { EVAL($_[0], $repl_env) }));
 my @_argv = map {Mal::String->new($_)}  @ARGV[1..$#ARGV];
 $repl_env->set(Mal::Symbol->new('*ARGV*'), Mal::List->new(\@_argv));
 

--- a/perl/stepA_mal.pl
+++ b/perl/stepA_mal.pl
@@ -10,7 +10,7 @@ use List::Util qw(pairs pairmap);
 use Scalar::Util qw(blessed);
 
 use readline qw(mal_readline set_rl_mode);
-use types qw($nil $true $false _sequential_Q _symbol_Q _list_Q _clone);
+use types qw($nil $true $false _symbol_Q _list_Q _clone);
 use reader;
 use printer;
 use env;
@@ -25,7 +25,7 @@ sub READ {
 # eval
 sub is_pair {
     my ($x) = @_;
-    return _sequential_Q($x) && @$x;
+    return $x->isa('Mal::Sequence') && @$x;
 }
 
 sub quasiquote {

--- a/perl/stepA_mal.pl
+++ b/perl/stepA_mal.pl
@@ -155,7 +155,7 @@ sub EVAL {
         when ('if') {
             my $cond = EVAL($a1, $env);
             if ($cond eq $nil || $cond eq $false) {
-                @_ = ($a3 ? $a3 : $nil, $env);
+                @_ = ($a3 // $nil, $env);
             } else {
                 @_ = ($a2, $env);
             }

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -222,8 +222,7 @@ sub _function_Q { $_[0]->isa('Mal::Function') }
 {
     package Mal::Atom;
     use parent -norequire, 'Mal::Type';
-    use overload '${}' => sub { \($_[0]->{val}) }, fallback => 1;
-    sub new  { my $class = shift; bless {'val'=>$_[0]}, $class }
+    sub new  { my ($class, $val) = @_; bless \$val, $class }
     sub clone { my $self = shift; ref($self)->new($$self) }
 }
 

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -6,7 +6,7 @@ use Data::Dumper;
 use Exporter 'import';
 our @EXPORT_OK = qw(_equal_Q
                     $nil $true $false
-                    _string_Q _keyword _keyword_Q);
+                    _string_Q _keyword);
 
 # General functions
 
@@ -101,12 +101,17 @@ sub _string_Q { $_[0]->isa('Mal::String') && ${$_[0]} !~ /^\x{029e}/; }
 
 
 sub _keyword { return Mal::String->new(("\x{029e}".$_[0])); }
-sub _keyword_Q { $_[0]->isa('Mal::String') && ${$_[0]} =~ /^\x{029e}/; }
 
 
 {
     package Mal::String;
     use parent -norequire, 'Mal::Scalar';
+    # "isa" can distinguish keywords from other strings.
+    sub isa {
+	my $self = shift;
+	return 1 if ($_[0] eq 'Mal::Keyword' && $$self =~ /^\x{029e}/);
+	return $self->SUPER::isa(@_);
+    }
 }
 
 

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -166,39 +166,22 @@ sub _hash_map_Q { $_[0]->isa('Mal::HashMap') }
 # Functions
 
 {
-    package Mal::Function;
+    package Mal::Callable;
     use parent -norequire, 'Mal::Type';
-    use overload '&{}' => sub { my $f = shift; sub { $f->apply(\@_) } },
-                 fallback => 1;
-    sub new  {
-        my $class = shift;
-        my ($eval, $ast, $env, $params) = @_;
-        bless {'eval'=>$eval,
-               'ast'=>$ast,
-               'env'=>$env,
-               'params'=>$params,
-               'ismacro'=>0}, $class
-    }
-    sub gen_env {
-        my $self = $_[0];
-        return Mal::Env->new($self->{env}, $self->{params}, $_[1]);
-    }
-    sub apply {
-        my $self = $_[0];
-        return &{ $self->{eval} }($self->{ast}, gen_env($self, $_[1]));
-    }
-    sub clone {	my $self = shift; bless { %$self }, ref($self) }
+    sub new  { my $class = shift; bless $_[0], $class }
+    sub clone { my $self = shift; bless sub { goto &$self }, ref($self) }
 }
 
-sub _sub_Q { $_[0]->isa('Mal::CoreFunction') ||  $_[0]->isa('Mal::FunctionRef') }
+{
+    package Mal::Function;
+    use parent -norequire, 'Mal::Callable';
+}
+
 sub _function_Q { $_[0]->isa('Mal::Function') }
 
-
-# Core Functions
-
 {
-    package Mal::CoreFunction;
-    sub clone { my $self = shift; bless sub { goto &$self }, ref($self) }
+    package Mal::Macro;
+    use parent -norequire, 'Mal::Callable';
 }
 
 

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -4,17 +4,13 @@ use warnings;
 
 use Data::Dumper;
 use Exporter 'import';
-our @EXPORT_OK = qw(_sequential_Q _equal_Q
+our @EXPORT_OK = qw(_equal_Q
                     $nil $true $false
-                    _number_Q _symbol _symbol_Q _string_Q _keyword _keyword_Q _list_Q _vector_Q _sub_Q _function_Q
-                    _hash_map _hash_map_Q _atom_Q);
+                    _string_Q _keyword _keyword_Q
+                    _hash_map);
 use List::Util qw(pairs pairmap);
 
 # General functions
-
-sub _sequential_Q {
-    return _list_Q($_[0]) || _vector_Q($_[0])
-}
 
 sub _equal_Q {
     my ($a, $b) = @_;
@@ -95,14 +91,12 @@ our $false = Mal::False->new('false');
     package Mal::Integer;
     use parent -norequire, 'Mal::Scalar';
 }
-sub _number_Q { $_[0]->isa('Mal::Integer') }
 
 
 {
     package Mal::Symbol;
     use parent -norequire, 'Mal::Scalar';
 }
-sub _symbol_Q { $_[0]->isa('Mal::Symbol') }
 
 
 sub _string_Q { $_[0]->isa('Mal::String') && ${$_[0]} !~ /^\x{029e}/; }
@@ -136,8 +130,6 @@ sub _keyword_Q { $_[0]->isa('Mal::String') && ${$_[0]} =~ /^\x{029e}/; }
     use parent -norequire, 'Mal::Sequence';
 }
 
-sub _list_Q { $_[0]->isa('Mal::List') }
-
 
 # Vectors
 
@@ -145,8 +137,6 @@ sub _list_Q { $_[0]->isa('Mal::List') }
     package Mal::Vector;
     use parent -norequire, 'Mal::Sequence';
 }
-
-sub _vector_Q { $_[0]->isa('Mal::Vector') }
 
 
 # Hash Maps
@@ -159,8 +149,6 @@ sub _vector_Q { $_[0]->isa('Mal::Vector') }
 }
 
 sub _hash_map { Mal::HashMap->new( { pairmap { $$a => $b } @_ } ) }
-
-sub _hash_map_Q { $_[0]->isa('Mal::HashMap') }
 
 
 # Functions
@@ -177,8 +165,6 @@ sub _hash_map_Q { $_[0]->isa('Mal::HashMap') }
     use parent -norequire, 'Mal::Callable';
 }
 
-sub _function_Q { $_[0]->isa('Mal::Function') }
-
 {
     package Mal::Macro;
     use parent -norequire, 'Mal::Callable';
@@ -193,7 +179,5 @@ sub _function_Q { $_[0]->isa('Mal::Function') }
     sub new  { my ($class, $val) = @_; bless \$val, $class }
     sub clone { my $self = shift; ref($self)->new($$self) }
 }
-
-sub _atom_Q { $_[0]->isa('Mal::Atom') }
 
 1;

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -164,9 +164,7 @@ sub _vector_Q { $_[0]->isa('Mal::Vector') }
 {
     package Mal::HashMap;
     use parent -norequire, 'Mal::Type';
-    use overload '%{}' => sub { no overloading '%{}'; $_[0]->{val} },
-	         fallback => 1;
-    sub new  { my $class = shift; bless {'val'=>$_[0]}, $class }
+    sub new  { my $class = shift; bless $_[0], $class }
 }
 
 sub _hash_map { Mal::HashMap->new( { pairmap { $$a => $b } @_ } ) }

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -6,7 +6,7 @@ use Data::Dumper;
 use Exporter 'import';
 our @EXPORT_OK = qw(_equal_Q
                     $nil $true $false
-                    _string_Q _keyword);
+                    _string_Q);
 
 # General functions
 
@@ -99,10 +99,6 @@ our $false = Mal::False->new('false');
 
 sub _string_Q { $_[0]->isa('Mal::String') && ${$_[0]} !~ /^\x{029e}/; }
 
-
-sub _keyword { return Mal::String->new(("\x{029e}".$_[0])); }
-
-
 {
     package Mal::String;
     use parent -norequire, 'Mal::Scalar';
@@ -112,6 +108,8 @@ sub _keyword { return Mal::String->new(("\x{029e}".$_[0])); }
 	return 1 if ($_[0] eq 'Mal::Keyword' && $$self =~ /^\x{029e}/);
 	return $self->SUPER::isa(@_);
     }
+    # Pseudo-constructor for making keywords.
+    sub Mal::Keyword::new { shift; Mal::String->new("\x{029e}" . $_[0]) }
 }
 
 

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -133,8 +133,7 @@ sub _keyword_Q { $_[0]->isa('Mal::String') && ${$_[0]} =~ /^\x{029e}/; }
     package Mal::Sequence;
     use parent -norequire, 'Mal::Type';
     use overload '@{}' => sub { $_[0]->{val} }, fallback => 1;
-    sub new  { my $class = shift; bless {'meta'=>$nil, 'val'=>$_[0]}, $class }
-    sub meta { $_[0]->{meta} }
+    sub new  { my $class = shift; bless {'val'=>$_[0]}, $class }
     #sub _val { $_[0]->{val}->[$_[1]]->{val}; } # return value of nth item
     sub rest { my @arr = @{$_[0]->{val}}; Mal::List->new([@arr[1..$#arr]]); }
     sub slice { my @arr = @{$_[0]->{val}}; Mal::List->new([@arr[$_[1]..$_[2]]]); }
@@ -167,8 +166,7 @@ sub _vector_Q { $_[0]->isa('Mal::Vector') }
     use parent -norequire, 'Mal::Type';
     use overload '%{}' => sub { no overloading '%{}'; $_[0]->{val} },
 	         fallback => 1;
-    sub new  { my $class = shift; bless {'meta'=>$nil, 'val'=>$_[0]}, $class }
-    sub meta { no overloading '%{}'; $_[0]->{meta} }
+    sub new  { my $class = shift; bless {'val'=>$_[0]}, $class }
 }
 
 sub _hash_map { Mal::HashMap->new( { pairmap { $$a => $b } @_ } ) }
@@ -186,14 +184,12 @@ sub _hash_map_Q { $_[0]->isa('Mal::HashMap') }
     sub new  {
         my $class = shift;
         my ($eval, $ast, $env, $params) = @_;
-        bless {'meta'=>$nil,
-               'eval'=>$eval,
+        bless {'eval'=>$eval,
                'ast'=>$ast,
                'env'=>$env,
                'params'=>$params,
                'ismacro'=>0}, $class
     }
-    sub meta { $_[0]->{meta} }
     sub gen_env {
         my $self = $_[0];
         return Mal::Env->new($self->{env}, $self->{params}, $_[1]);
@@ -216,18 +212,14 @@ sub _function_Q { $_[0]->isa('Mal::Function') }
     use overload '&{}' => sub { $_[0]->{code} }, fallback => 1;
     sub new {
         my ($class, $code) = @_;
-        bless {'meta'=>$nil,
-               'code'=>$code}, $class
+        bless {'code'=>$code}, $class
     }
-    sub meta { $_[0]->{meta} }
 }
 
 # Core Functions
 
 {
     package Mal::CoreFunction;
-    use parent -norequire, 'Mal::Type';
-    sub meta { $nil }
 }
 
 
@@ -237,8 +229,7 @@ sub _function_Q { $_[0]->isa('Mal::Function') }
     package Mal::Atom;
     use parent -norequire, 'Mal::Type';
     use overload '${}' => sub { \($_[0]->{val}) }, fallback => 1;
-    sub new  { my $class = shift; bless {'meta'=>$nil, 'val'=>$_[0]}, $class }
-    sub meta { $_[0]->{meta} }
+    sub new  { my $class = shift; bless {'val'=>$_[0]}, $class }
 }
 
 sub _atom_Q { $_[0]->isa('Mal::Atom') }

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -6,9 +6,7 @@ use Data::Dumper;
 use Exporter 'import';
 our @EXPORT_OK = qw(_equal_Q
                     $nil $true $false
-                    _string_Q _keyword _keyword_Q
-                    _hash_map);
-use List::Util qw(pairs pairmap);
+                    _string_Q _keyword _keyword_Q);
 
 # General functions
 
@@ -139,16 +137,22 @@ sub _keyword_Q { $_[0]->isa('Mal::String') && ${$_[0]} =~ /^\x{029e}/; }
 }
 
 
-# Hash Maps
+# Hash-maps
 
 {
     package Mal::HashMap;
     use parent -norequire, 'Mal::Type';
-    sub new  { my $class = shift; bless $_[0], $class }
+    use List::Util qw(pairmap);
+    use Scalar::Util qw(reftype);
+    sub new  {
+        my ($class, $src) = @_;
+        if (reftype($src) eq 'ARRAY') {
+            $src = {pairmap { $$a => $b } @$src};
+	}
+        return bless $src, $class;
+    }
     sub clone { my $self = shift; ref($self)->new({%$self}) }
 }
-
-sub _hash_map { Mal::HashMap->new( { pairmap { $$a => $b } @_ } ) }
 
 
 # Functions

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -116,8 +116,8 @@ our $false = Mal::False->new('false');
     package Mal::Sequence;
     use parent -norequire, 'Mal::Type';
     sub new  { my $class = shift; bless $_[0], $class }
-    sub rest { my @arr = @{$_[0]}; Mal::List->new([@arr[1..$#arr]]); }
-    sub slice { my @arr = @{$_[0]}; Mal::List->new([@arr[$_[1]..$_[2]]]); }
+    sub rest { my $arr = $_[0]; Mal::List->new([@$arr[1..$#$arr]]); }
+    sub slice { my $arr = $_[0]; Mal::List->new([@$arr[$_[1]..$_[2]]]); }
     sub clone { my $self = shift; ref($self)->new([@$self]) }
 }
 

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -123,11 +123,9 @@ sub _keyword_Q { $_[0]->isa('Mal::String') && ${$_[0]} =~ /^\x{029e}/; }
 {
     package Mal::Sequence;
     use parent -norequire, 'Mal::Type';
-    use overload '@{}' => sub { $_[0]->{val} }, fallback => 1;
-    sub new  { my $class = shift; bless {'val'=>$_[0]}, $class }
-    #sub _val { $_[0]->{val}->[$_[1]]->{val}; } # return value of nth item
-    sub rest { my @arr = @{$_[0]->{val}}; Mal::List->new([@arr[1..$#arr]]); }
-    sub slice { my @arr = @{$_[0]->{val}}; Mal::List->new([@arr[$_[1]..$_[2]]]); }
+    sub new  { my $class = shift; bless $_[0], $class }
+    sub rest { my @arr = @{$_[0]}; Mal::List->new([@arr[1..$#arr]]); }
+    sub slice { my @arr = @{$_[0]}; Mal::List->new([@arr[$_[1]..$_[2]]]); }
     sub clone { my $self = shift; ref($self)->new([@$self]) }
 }
 

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -196,24 +196,11 @@ sub _sub_Q { $_[0]->isa('Mal::CoreFunction') ||  $_[0]->isa('Mal::FunctionRef') 
 sub _function_Q { $_[0]->isa('Mal::Function') }
 
 
-# FunctionRef
-
-{
-    package Mal::FunctionRef;
-    use parent -norequire, 'Mal::Type';
-    use overload '&{}' => sub { $_[0]->{code} }, fallback => 1;
-    sub new {
-        my ($class, $code) = @_;
-        bless {'code'=>$code}, $class
-    }
-    sub clone { my $self = shift; ref($self)->new($self->{code}) }
-}
-
 # Core Functions
 
 {
     package Mal::CoreFunction;
-    sub clone { my $self = shift; FunctionRef->new($self) }
+    sub clone { my $self = shift; bless sub { goto &$self }, ref($self) }
 }
 
 

--- a/perl/types.pm
+++ b/perl/types.pm
@@ -5,8 +5,7 @@ use warnings;
 use Data::Dumper;
 use Exporter 'import';
 our @EXPORT_OK = qw(_equal_Q
-                    $nil $true $false
-                    _string_Q);
+                    $nil $true $false);
 
 # General functions
 
@@ -96,8 +95,6 @@ our $false = Mal::False->new('false');
     use parent -norequire, 'Mal::Scalar';
 }
 
-
-sub _string_Q { $_[0]->isa('Mal::String') && ${$_[0]} !~ /^\x{029e}/; }
 
 {
     package Mal::String;


### PR DESCRIPTION
The whole reason why I was looking at the Perl implementation was that I wondered whether it used `goto &name`. Here I finally get around to making it do so.

# New metadata

The first major change here is to replace the metadata implementation, symbolised by 28bff72. This uses a `Hash::Util::fieldhash` to hold all the metadata in a hash indexed by object ID, with automatic deletion when objects are garbage-collected. Along with this, most of the composite types lose a layer of indirection (771045a, d64a552, 329c9c2). This has a couple of down-sides:

* Turning a function into a macro causes it to lose its metadata
* Attaching metadata to a sequence or hash-map causes the whole array or hash to be copied, which might be expensive.

On the other hand, this removes a hash lookup from every access to a list, array, hash-map, or atom, which I suspect is a win.

# New TCO

Perl has native support for tail calls. `goto &NAME` calls the subroutine `NAME` in place of the currently-executing subroutine without consuming additional stack. Using this feature (c0d61c2)  makes TCO in mal a lot simpler and slightly more powerful:

* There's no need for a loop in `EVAL`: tail recursion is just `goto &EVAL`.
* All functions can be Perl closures, since it's possible to tail-call into one (`goto &$f`) and back out again (`goto &EVAL`).
* TCO can work in `apply`, which it didn't before.

This does mean that the perl implementation doesn't quite follow the process guide. I think this is reasonable for two reasons:

* The overall structure of the code hasn't changed: everything's still in the same place as in other implementations, so it's easy to find the code you're looking for, it just works a bit differently.
* Support for explicit tail calls is a rare enough language feature that showing it off is interesting.

# Others

There are a few other changes here, some of which depend on the above. The major ones are:

* The `ismacro` flag is now represented by having separate `Mal::Function` and `Mal::Macro` classes.
* All checks for class membership now use `->isa` directly, which is the native Perl way to do that.