### PR TITLE
Fix Travis test script to work with Bash 5

### DIFF
--- a/.travis_test.sh
+++ b/.travis_test.sh
@@ -35,7 +35,8 @@ if [ "${NO_SELF_HOST_PERF}" -a "${DO_SELF_HOST}" -a "${ACTION}" = "perf" ]; then
     exit 0
 fi
 
-mode_var=${MAL_IMPL:-${IMPL}}_MODE
+raw_mode_var=${MAL_IMPL:-${IMPL}}_MODE
+mode_var=${raw_mode_var/./__}
 mode_val=${!mode_var}
 
 MAKE="make ${mode_val:+${mode_var}=${mode_val}}"


### PR DESCRIPTION
Bash 5 doesn't like periods in variable names so this commit performs a substitution to double underscores to avoid them. Fixes #456. 
