### PR TITLE
Improve python.2 performance on perf3 benchmark by 77%

### DIFF
--- a/python.2/env.py
+++ b/python.2/env.py
@@ -12,8 +12,10 @@ class Env(object):
         binds: Optional[List[MalExpression]] = None,
         exprs: Optional[List[MalExpression]] = None,
     ) -> None:
-        self._data: Dict[str, MalExpression] = {}
-        self._outer = outer
+        if outer:
+            self._data: Dict[str, MalExpression] = outer._data.copy()
+        else:
+            self._data = {}
         if binds is not None and exprs is not None:
             for x in range(0, len(binds)):
                 assert isinstance(binds[x], MalSymbol)
@@ -30,16 +32,16 @@ class Env(object):
     def find(self, key: MalExpression) -> Optional["Env"]:
         if str(key) in self._data:
             return self
-        if self._outer is not None:
-            return self._outer.find(key)
         return None
 
     def get(self, key: MalExpression) -> MalExpression:
+        strkey = str(key)
+        if strkey in self._data:
+            return self._data[strkey]
+
         location = self.find(key)
         if location is None:
-            raise MalUnknownSymbolException(str(key))
-        if location is self:
-            return self._data[str(key)]
+            raise MalUnknownSymbolException(strkey)
         return location.get(key)
 
     def __repr__(self) -> str:

--- a/python.2/mal_types.py
+++ b/python.2/mal_types.py
@@ -1,12 +1,10 @@
-from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Any
 
 
-class MalExpression(ABC):
+class MalExpression(object):
     def __init__(self):
         assert False  # cannot instantiate
 
-    @abstractmethod
     def native(self) -> Any:
         """Return a shallow native Python equivalent for the expression.
 
@@ -16,7 +14,6 @@ class MalExpression(ABC):
     def __str__(self) -> str:
         return self.readable_str()
 
-    @abstractmethod
     def readable_str(self) -> str:
         """Return a human-readable (preferably Mal input format) form of the expression."""
         pass

--- a/python.2/run
+++ b/python.2/run
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec python3 $(dirname $0)/${STEP:-stepA_mal}.py "${@}"
+exec python3 -O $(dirname $0)/${STEP:-stepA_mal}.py "${@}"


### PR DESCRIPTION
Performance is improved about 77% on my system
    
Optimizations:
* remove use of `ABC`/`abstractmethod`
* start new environments with copy of `outer`; no need to `find(key)`
* run with asserts off
