### PR TITLE
tests: step8: Verify nth doesn't throw on nil elements

### DIFF
--- a/tests/step8_macros.mal
+++ b/tests/step8_macros.mal
@@ -49,6 +49,8 @@
 ;=>1
 (nth (list 1 2) 1)
 ;=>2
+(nth (list 1 2 nil) 2)
+;=>nil
 (def! x "x")
 (def! x (nth (list 1 2) 2))
 x
@@ -98,6 +100,8 @@ x
 ;=>1
 (nth [1 2] 1)
 ;=>2
+(nth [1 2 nil] 2)
+;=>nil
 (def! x "x")
 (def! x (nth [1 2] 2))
 x


### PR DESCRIPTION
I had a bug in the Wren implementation of `nth` that slipped all the way to self-hosting.

Adding these tests caught it early in step8 when we introduce `nth`.
