### PR TITLE
Use a real (if primitive) terminal emulator for tests

### DIFF
--- a/olte.py
+++ b/olte.py
@@ -1,0 +1,125 @@
+# OLTE: One-Line Terminal Emulator
+
+# OLTE is a simple terminal emulator library that emulates a terminal
+# one line high and infinitely wide.  It's intended for test suites
+# that want to drive programs with command-line editing and the like.
+
+from __future__ import unicode_literals
+
+import re
+import sys
+
+IS_PY_3 = sys.version_info[0] == 3
+
+if not IS_PY_3:
+    chr = unichr
+
+def isprintable(s):
+    if IS_PY_3: return s.isprintable()
+    return 32 <= ord(s) < 127 or 160 <= ord(s)
+
+class OneLineTerminalEmulator(object):
+    # There are three regular expressions here for each kind of magic
+    # character sequence that we recognise.  The first recognises a
+    # complete sequence.  The second recognises a partial sequence at
+    # the end of a string (so there might be more to come).  The third
+    # recognises any incomplete sequence (and hence an error if the
+    # second didn't also match).
+
+    # Escape sequences (ECMA-35 clause 13):
+    escape_sequence = re.compile(r"\x1b[\x20-\x2f]*[\x30-\x7e]")
+    partial_escape_sequence = re.compile(r"\x1b[\x20-\x2f]*$")
+    invalid_escape_sequence = re.compile(r"\x1b[\x20-\x2f]*")
+    # Two-byte representations of C1 controls:
+    sevenbit_c1 = re.compile(r"\x1b([\x40-\x5f])")
+    # Characters to strip out everywhere:
+    strip_chars = re.compile(r"[\x00\x7f]")
+    # Control sequences (ECMA-48 clause 5.4):
+    control_sequence = re.compile(r"\x9b[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]")
+    partial_control_sequence = re.compile(r"\x9b[\x30-\x3f]*[\x20-\x2f]*$")
+    invalid_control_sequence = re.compile(r"\x9b[\x30-\x3f]*[\x20-\x2f]*")
+    # Command strings (ECMA-48 clause 5.6):
+    command_string = re.compile(r"[\x90\x9d-\x9f][\x08-\x0d\x20-\x7e]*\x9c")
+    partial_command_string = re.compile(
+        r"[\x90\x9d-\x9f][\x08-\x0d\x20-\x7e]*\x1b?$")
+    invalid_command_string = re.compile(
+        r"[\x90\x9d-\x9f][\x08-\x0d\x20-\x7e]*")
+    # Character strings (ECMA-48 clause 5.6):
+    character_string = re.compile(r"\x98[^\x98\x9c]*\x9c")
+    partial_character_string = re.compile(r"\x98[^\x98\x9c]*\x1b?$")
+    invalid_character_string = re.compile(r"\x98[^\x98\x9c]*")
+    # Specific command sequences:
+    CUF = re.compile(r"\x9b([0-9]*)C")
+    EL  = re.compile(r"\x9b([0-9]*)K")
+    # Single characters
+    one_char = re.compile('(?s).')
+    def __init__(self):
+        self.line = []
+        self.past_lines = []
+        self.acc = ""
+        self.pos = 0
+    def match(self, pattern, consume=True):
+        # A silly little method to provide something equivalent to Perl's
+        # $1, $&, etc.
+        self.last_match = pattern.match(self.acc)
+        if self.last_match and consume:
+            self.acc = self.acc[self.last_match.end():]
+        return self.last_match
+    def process(self, data):
+        self.acc += data
+        # ECMA-35 says that DEL should be ignored everywhere.  ECMA-48
+        # says the same about NUL.
+        self.acc = self.strip_chars.sub("", self.acc)
+        # Convert 7-bit C1 controls to 8-bit form.
+        def c1_convert(match): return chr(ord(match.group(1)) + 0x40)
+        self.acc = self.sevenbit_c1.sub(c1_convert, self.acc)
+        while self.acc != '':
+            if (self.match(self.partial_escape_sequence,  consume=False) or
+                self.match(self.partial_control_sequence, consume=False) or
+                self.match(self.partial_command_string,   consume=False) or
+                self.match(self.partial_character_string, consume=False)):
+                # We can't make sense of the input yet.
+                return
+            if (self.match(self.CUF)):
+                param = int(self.last_match.group(1) or '1')
+                self.pos += param
+                continue
+            if (self.match(self.EL)):
+                param = int(self.last_match.group(1) or '0')
+                if param == 0: del self.line[self.pos:]
+                if param == 1: self.line[:self.pos + 1] = [' '] * (self.pos + 1)
+                if param == 2: del self.line[:]
+                continue
+            if (self.match(self.escape_sequence) or
+                self.match(self.control_sequence) or
+                self.match(self.command_string) or
+                self.match(self.character_string)):
+                # For now, ignore valid sequences.
+                continue
+            if (self.match(self.invalid_escape_sequence) or
+                self.match(self.invalid_control_sequence) or
+                self.match(self.invalid_command_string) or
+                self.match(self.invalid_character_string)):
+                # Ignore an invalid sequence.
+                continue
+            char = self.match(self.one_char).group(0)
+            if char == "\r":
+                self.pos = 0
+            elif char == "\b":
+                self.pos -= 1
+            elif char == "\n":
+                self.emit(''.join(self.line))
+                del self.line[:]
+            elif isprintable(char):
+                if len(self.line) <= self.pos:
+                    self.line.extend([" "] * (self.pos - len(self.line) + 1))
+                self.line[self.pos] = char
+                self.pos += 1
+    @property
+    def current_line(self):
+        return "".join(self.line)
+    @property
+    def current_prompt(self):
+        return "".join(self.line[:self.pos])
+    def emit(self, line):
+        self.past_lines.append(self.current_line)

--- a/runtest.py
+++ b/runtest.py
@@ -114,7 +114,7 @@ class Runner():
         self.olte = olte.OneLineTerminalEmulator()
         self.last_prompt = ""
 
-    def read_to_prompt(self, prompts, timeout):
+    def read_to_prompt(self, prompt, timeout):
         end_time = time.time() + timeout
         while time.time() < end_time:
             [outs,_,_] = select([self.stdout], [], [], 1)
@@ -132,7 +132,7 @@ class Runner():
                 if (len(self.olte.past_lines) == 0 and
                     searchee.startswith("\n"+self.last_prompt)):
                     searchee = searchee[len("\n"+self.last_prompt):]
-                for prompt in prompts:
+                for prompt in [prompt]:
                     regexp = re.compile(prompt)
                     match = regexp.search(searchee)
                     if match:
@@ -241,21 +241,21 @@ r = Runner(args.mal_cmd, no_pty=args.no_pty)
 t = TestReader(args.test_file)
 
 
-def assert_prompt(runner, prompts, timeout):
+def assert_prompt(runner, prompt, timeout):
     # Wait for the initial prompt
-    header = runner.read_to_prompt(prompts, timeout=timeout)
+    header = runner.read_to_prompt(prompt, timeout=timeout)
     if not header == None:
         if header:
             log("Started with:\n%s" % header)
     else:
-        log("Did not receive one of following prompt(s): %s" % repr(prompts))
+        log("Did not receive the following prompt: %s" % repr(prompt))
         log("    Got      : %s" % repr(r.buf))
         sys.exit(1)
 
 
 # Wait for the initial prompt
 try:
-    assert_prompt(r, ['[^\s()<>]+> '], args.start_timeout)
+    assert_prompt(r, '[^\s()<>]+> ', args.start_timeout)
 except:
     _, exc, _ = sys.exc_info()
     log("\nException: %s" % repr(exc))
@@ -266,7 +266,7 @@ except:
 if args.pre_eval:
     sys.stdout.write("RUNNING pre-eval: %s" % args.pre_eval)
     r.writeline(args.pre_eval)
-    assert_prompt(r, ['[^\s()<>]+> '], args.test_timeout)
+    assert_prompt(r, '[^\s()<>]+> ', args.test_timeout)
 
 test_cnt = 0
 pass_cnt = 0
@@ -303,7 +303,7 @@ while t.next():
     r.writeline(t.form)
     try:
         test_cnt += 1
-        res = r.read_to_prompt(['\n[^\s()<>]+> '],
+        res = r.read_to_prompt('\n[^\s()<>]+> ',
                                 timeout=args.test_timeout)
         #print "%s,%s,%s" % (idx, repr(p.before), repr(p.after))
         if (t.ret == "" and t.out == ""):

--- a/runtest.py
+++ b/runtest.py
@@ -32,6 +32,7 @@ def log(data, end='\n'):
 
 sep = "\n"
 rundir = None
+prompt_re = re.compile('[^\s()<>]+> ')
 
 parser = argparse.ArgumentParser(
         description="Run a test file against a Mal implementation")
@@ -139,8 +140,7 @@ class Runner():
                 else:
                     self.olte.process(new_data)
                 if check_first_line or len(self.olte.past_lines) > 0:
-                    regexp = re.compile(prompt)
-                    match = regexp.match(self.olte.current_line)
+                    match = re.match(prompt, self.olte.current_line)
                     if match:
                         end = match.end()
                         buf = "".join([x + "\n" for x in self.olte.past_lines])
@@ -259,7 +259,7 @@ def assert_prompt(runner, prompt, timeout):
 
 # Wait for the initial prompt
 try:
-    assert_prompt(r, '[^\s()<>]+> ', args.start_timeout)
+    assert_prompt(r, prompt_re, args.start_timeout)
 except:
     _, exc, _ = sys.exc_info()
     log("\nException: %s" % repr(exc))
@@ -270,7 +270,7 @@ except:
 if args.pre_eval:
     sys.stdout.write("RUNNING pre-eval: %s" % args.pre_eval)
     r.writeline(args.pre_eval)
-    assert_prompt(r, '[^\s()<>]+> ', args.test_timeout)
+    assert_prompt(r, prompt_re, args.test_timeout)
 
 test_cnt = 0
 pass_cnt = 0
@@ -307,8 +307,7 @@ while t.next():
     r.writeline(t.form)
     try:
         test_cnt += 1
-        res = r.read_to_prompt('[^\s()<>]+> ',
-                                timeout=args.test_timeout)
+        res = r.read_to_prompt(prompt_re, timeout=args.test_timeout)
         #print "%s,%s,%s" % (idx, repr(p.before), repr(p.after))
         if (t.ret == "" and t.out == ""):
             log(" -> SUCCESS (result ignored)")

--- a/runtest.py
+++ b/runtest.py
@@ -131,9 +131,9 @@ class Runner():
             [outs,_,_] = select([self.stdout], [], [], 1)
             if self.stdout in outs:
                 new_data = self.stdout.read(1)
+                debug(new_data)
                 new_data = self.decoder.decode(new_data)
                 #print("new_data: '%s'" % new_data)
-                debug(new_data)
                 # Perform newline cleanup
                 if self.no_pty:
                     self.olte.process(new_data.replace("\n", "\r\n"))
@@ -234,7 +234,7 @@ if sys.argv.count('--') > 0:
 if args.rundir: os.chdir(args.rundir)
 
 if args.log_file:   log_file   = open(args.log_file, "a")
-if args.debug_file: debug_file = open(args.debug_file, "a")
+if args.debug_file: debug_file = open(args.debug_file, "ab")
 
 r = Runner(args.mal_cmd, no_pty=args.no_pty)
 t = TestReader(args.test_file)
@@ -344,7 +344,7 @@ TEST RESULTS (for %s):
         pass_cnt, test_cnt)
 log(results)
 
-debug("\n") # add some separate to debug log
+debug(b"\n") # add some separate to debug log
 
 if fail_cnt > 0:
     sys.exit(1)

--- a/runtest.py
+++ b/runtest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import os, sys, re
+import codecs, os, sys, re
 import argparse, time
 import signal, atexit
 
@@ -112,6 +112,7 @@ class Runner():
             self.stdout = self.stdin
 
         #print "started"
+        self.decoder = codecs.getincrementaldecoder('utf-8')(errors='replace')
         self.olte = olte.OneLineTerminalEmulator()
 
     def read_to_prompt(self, prompt, timeout):
@@ -130,7 +131,7 @@ class Runner():
             [outs,_,_] = select([self.stdout], [], [], 1)
             if self.stdout in outs:
                 new_data = self.stdout.read(1)
-                new_data = new_data.decode("utf-8") if IS_PY_3 else new_data
+                new_data = self.decoder.decode(new_data)
                 #print("new_data: '%s'" % new_data)
                 debug(new_data)
                 # Perform newline cleanup

--- a/runtest.py
+++ b/runtest.py
@@ -30,8 +30,7 @@ def log(data, end='\n'):
     print(data, end=end)
     sys.stdout.flush()
 
-# TODO: do we need to support '\n' too
-sep = "\r\n"
+sep = "\n"
 rundir = None
 
 parser = argparse.ArgumentParser(
@@ -138,7 +137,7 @@ class Runner():
                     match = regexp.search(searchee)
                     if match:
                         end = match.end()
-                        buf = "\r\n".join(
+                        buf = "\n".join(
                             self.olte.past_lines +
                             [searchee[0:match.start()]])
                         if buf.startswith(self.last_prompt):
@@ -146,7 +145,7 @@ class Runner():
                         self.olte.past_lines = []
                         self.last_prompt = (
                             self.olte.current_line[0:match.end()])
-                        return buf.replace("^M", "\r")
+                        return buf.replace("^M", "")
         return None
 
     def writeline(self, str):
@@ -222,10 +221,10 @@ class TestReader:
                     break
             if self.ret != None: break
 
-        if self.out[-2:] == sep and not self.ret:
+        if self.out.endswith(sep) and not self.ret:
             # If there is no return value, output should not end in
             # separator
-            self.out = self.out[0:-2]
+            self.out = self.out[0:-len(sep)]
         return self.form
 
 args = parser.parse_args(sys.argv[1:])
@@ -304,7 +303,7 @@ while t.next():
     r.writeline(t.form)
     try:
         test_cnt += 1
-        res = r.read_to_prompt(['\r\n[^\s()<>]+> ', '\n[^\s()<>]+> '],
+        res = r.read_to_prompt(['\n[^\s()<>]+> '],
                                 timeout=args.test_timeout)
         #print "%s,%s,%s" % (idx, repr(p.before), repr(p.after))
         if (t.ret == "" and t.out == ""):

--- a/runtest.py
+++ b/runtest.py
@@ -292,11 +292,8 @@ while t.next():
     # The repeated form is to get around an occasional OS X issue
     # where the form is repeated.
     # https://github.com/kanaka/mal/issues/30
-    expects = ["%s%s%s%s" % (re.escape(t.form), sep,
-                              t.out, re.escape(t.ret)),
-               "%s%s%s%s%s%s" % (re.escape(t.form), sep,
-                                  re.escape(t.form), sep,
-                                  t.out, re.escape(t.ret))]
+    expect = "(?:%s%s){1,2}%s%s" % (re.escape(t.form), sep,
+                                    t.out, re.escape(t.ret))
 
     r.writeline(t.form)
     try:
@@ -306,8 +303,7 @@ while t.next():
         if (t.ret == "" and t.out == ""):
             log(" -> SUCCESS (result ignored)")
             pass_cnt += 1
-        elif (re.search(expects[0], res, re.S) or
-                re.search(expects[1], res, re.S)):
+        elif (re.search(expect, res, re.S)):
             log(" -> SUCCESS")
             pass_cnt += 1
         else:
@@ -319,12 +315,12 @@ while t.next():
                 log(" -> FAIL (line %d):" % t.line_num)
                 fail_cnt += 1
                 fail_type = ""
-            log("    Expected : %s" % repr(expects[0]))
+            log("    Expected : %s" % repr(expect))
             log("    Got      : %s" % repr(res))
             failed_test = """%sFAILED TEST (line %d): %s -> [%s,%s]:
     Expected : %s
     Got      : %s""" % (fail_type, t.line_num, t.form, repr(t.out),
-                        t.ret, repr(expects[0]), repr(res))
+                        t.ret, repr(expect), repr(res))
             failures.append(failed_test)
     except:
         _, exc, _ = sys.exc_info()

--- a/runtest.py
+++ b/runtest.py
@@ -113,7 +113,6 @@ class Runner():
 
         #print "started"
         self.olte = olte.OneLineTerminalEmulator()
-        self.last_prompt = ""
 
     def read_to_prompt(self, prompt, timeout):
         """
@@ -142,13 +141,8 @@ class Runner():
                 if check_first_line or len(self.olte.past_lines) > 0:
                     match = re.match(prompt, self.olte.current_line)
                     if match:
-                        end = match.end()
                         buf = "".join([x + "\n" for x in self.olte.past_lines])
-                        if buf.startswith(self.last_prompt):
-                            buf = buf[len(self.last_prompt):]
                         self.olte.past_lines = []
-                        self.last_prompt = (
-                            self.olte.current_line[0:match.end()])
                         return buf.replace("^M", "")
         return None
 

--- a/test_olte.py
+++ b/test_olte.py
@@ -1,0 +1,76 @@
+#! /usr/bin/python
+
+from __future__ import unicode_literals
+
+import unittest
+
+from olte import OneLineTerminalEmulator
+
+class TestOLTE(unittest.TestCase):
+    def assertProduces(self, input, past, current):
+        o = OneLineTerminalEmulator()
+        o.process(input)
+        self.assertEqual(o.past_lines, past)
+        self.assertEqual(o.current_line, current)
+    def test_empty(self):
+        o = OneLineTerminalEmulator()
+        self.assertEqual(o.current_line, "")
+    def test_trivial(self):
+        self.assertProduces("Hello", [], "Hello")
+    def test_cr(self):
+        self.assertProduces("Hello\rWorld", [], "World")
+    def test_bs(self):
+        self.assertProduces("Hello\bWorld", [], "HellWorld")
+    def test_bel(self):
+        # BEL should have no effect (and not appear in the output).
+        self.assertProduces("Hello\aWorld", [], "HelloWorld")
+    def test_lf(self):
+        self.assertProduces("Hello\r\nWorld\r\n", ["Hello", "World"], "")
+    def test_escseq(self):
+        self.assertProduces("Hello\x1bpWorld", [], "HelloWorld")        
+    def test_csi(self):
+        self.assertProduces("Hello\x1b[1mWorld", [], "HelloWorld")
+    def test_cuf(self):
+        self.assertProduces("Hello\r\x1b[2CWorld", [], "HeWorld")
+    def test_el0(self):
+        self.assertProduces("Hello World\b\b\b\b\b\b\x9bK", [], "Hello")
+    def test_el1(self):
+        self.assertProduces("Hello World\b\b\b\b\b\b\b\x1b[1K", [],
+                            "      World")
+    def test_el2(self):
+        self.assertProduces("Hello World\b\b\b\b\b\b\x1b[2K", [], "")
+    def test_prompt(self):
+        o = OneLineTerminalEmulator()
+        o.process("1234567890\r> ")
+        self.assertEqual(o.current_prompt, "> ")
+
+class TestRegexps(unittest.TestCase):
+    def multi_test(self, specs):
+        for spec in specs:
+            for x in spec["matches"]:
+#               with self.subTest(input=x):
+                    self.assertTrue(spec["regex"].match(x))
+            for x in spec["matches_not"]:
+#               with self.subTest(input=x):
+                    self.assertFalse(spec["regex"].match(x))
+    def test_regexps(self):
+        self.multi_test([
+            { "regex": OneLineTerminalEmulator.escape_sequence,
+              "matches": ["\x1b0", "\x1b~", "\x1b !A"],
+              "matches_not": ["\x1b\x7f", "\x1b\x1b", "\x1b", "Hello\x1bA"] },
+            { "regex": OneLineTerminalEmulator.partial_escape_sequence,
+              "matches": ["\x1b", "\x1b "],
+              "matches_not": ["\x1b0", "Hello"] },
+            { "regex": OneLineTerminalEmulator.invalid_escape_sequence,
+              "matches": ["\x1b\x1b", "\x1b\n"],
+              "matches_not": ["Hello"] },
+            { "regex": OneLineTerminalEmulator.control_sequence,
+              "matches": ["\x9b12;34H", "\x9b z"],
+              "matches_not": ["Hello"] },
+            { "regex": OneLineTerminalEmulator.partial_control_sequence,
+              "matches": ["\x9b12;3", "\x9b "],
+              "matches_not": ["Hello"] },
+            ])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
One problem I ran into in my BCPL implementation was that the BCPL runtime optimised away certain CR characters from its output, which meant that `runtest.py` thought there was something wrong because CRs that it was expecting weren't there. Initially I solved this by adding extra complexity to the regular expressions in `runtest.py`, but this whole approach felt wrong.

So here's my new approach.  I've written a simple terminal emulator called "olte" that implements an ANSI terminal one line high and infinitely wide. `runtest.py` then looks at what appears on the display (and scrolled off the top) of this terminal to decide if the implementation output the correct thing.  This has the advantage that it doesn't care how the implementation gets its output right: it can muck about with CR, BS, and (supported) escape sequences and as long as the display ends up right, that's acceptable.

This has left `runtest.py` rather cleaner, albeit at the expense of adding a a great lump of additional code. I think it's probably a good idea, but I could well be wrong.