### PR TITLE
Fix Bash implementation interop carriage returns.

### DIFF
--- a/bash/stepA_mal.sh
+++ b/bash/stepA_mal.sh
@@ -166,7 +166,7 @@ EVAL () {
               local output=""
               local line=""
               while read line; do
-                  output="${output}${line}\n"
+                  output="${output}${line}"$'\n'
               done < <(eval ${ANON["${r}"]})
               _string "${output%\\n}"
               return ;;

--- a/bash/stepA_mal.sh
+++ b/bash/stepA_mal.sh
@@ -168,7 +168,7 @@ EVAL () {
               while read line; do
                   output="${output}${line}"$'\n'
               done < <(eval ${ANON["${r}"]})
-              _string "${output%\\n}"
+              _string "${output%$'\n'}"
               return ;;
         try__STAR__) EVAL "${a1}" "${env}"
               [[ -z "${__ERROR}" ]] && return

--- a/bash/stepA_mal.sh
+++ b/bash/stepA_mal.sh
@@ -165,8 +165,8 @@ EVAL () {
         sh__STAR__)  EVAL "${a1}" "${env}"
               local output=""
               local line=""
-              while read line; do
-                  output="${output}${line}"$'\n'
+              while read -r line || [ -n "${line}" ]; do
+                output="${output}${line}"$'\n'
               done < <(eval ${ANON["${r}"]})
               _string "${output%$'\n'}"
               return ;;

--- a/bash/tests/stepA_mal.mal
+++ b/bash/tests/stepA_mal.mal
@@ -15,3 +15,12 @@
 
 (sh* "for x in 1 2 3; do echo -n \"$((1+$x)) \"; done; echo")
 ;=>"2 3 4"
+
+(sh* "for x in {1..10}; do echo $x; done")
+;=>"1\n2\n3\n4\n5\n6\n7\n8\n9\n10"
+
+(sh* "echo -n {1..3}")
+;=>"1 2 3"
+
+(sh* "echo hello; echo foo; echo yes;")
+;=>"hello\nfoo\nyes"


### PR DESCRIPTION
Before this fix the 'sh*' function was joining the lines of the output of whatever command was run in a way that resulted in '\n' instead of a literal carriage return.

Without this fix:

```
$ ./mal
Mal [bash]
user> (println (sh* "head mal"))
#!/usr/bin/env bash\n#\n# mal (Make a Lisp) object types\n#\n\nif [ -z "${__mal_types_included__}" ]; then\n__mal_types_included=true\n\ndeclare -A ANON\n
nil
```

After this fix (carriage returns correctly inserted by `sh*`):

```
$ ./mal
Mal [bash]
user> (println (sh* "head mal"))
#!/usr/bin/env bash
#
# mal (Make a Lisp) object types
#

if [ -z "${__mal_types_included__}" ]; then
__mal_types_included=true

declare -A ANON


nil
```