### PR TITLE
Fix bash interop asterisk quoting

### DIFF
--- a/bash/stepA_mal.sh
+++ b/bash/stepA_mal.sh
@@ -165,9 +165,11 @@ EVAL () {
         sh__STAR__)  EVAL "${a1}" "${env}"
               local output=""
               local line=""
+              r="${ANON["${r}"]}"
+              r="${r//__STAR__/*}"
               while read -r line || [ -n "${line}" ]; do
                 output="${output}${line}"$'\n'
-              done < <(eval ${ANON["${r}"]})
+              done < <(eval "${r}")
               _string "${output%$'\n'}"
               return ;;
         try__STAR__) EVAL "${a1}" "${env}"

--- a/bash/stepA_mal.sh
+++ b/bash/stepA_mal.sh
@@ -166,7 +166,7 @@ EVAL () {
               local output=""
               local line=""
               while read line; do
-                  output="${output}${line}\n"
+                  output="${output}${line}"$'\n'
               done < <(eval ${ANON["${r}"]})
               _string "${output%\\n}"
               return ;;

--- a/bash/stepA_mal.sh
+++ b/bash/stepA_mal.sh
@@ -168,7 +168,7 @@ EVAL () {
               while read line; do
                   output="${output}${line}"$'\n'
               done < <(eval ${ANON["${r}"]})
-              _string "${output%\\n}"
+              _string "${output%$'\n'}"
               return ;;
         try__STAR__) EVAL "${a1}" "${env}"
               [[ -z "${__ERROR}" ]] && return

--- a/bash/stepA_mal.sh
+++ b/bash/stepA_mal.sh
@@ -165,8 +165,8 @@ EVAL () {
         sh__STAR__)  EVAL "${a1}" "${env}"
               local output=""
               local line=""
-              while read line; do
-                  output="${output}${line}"$'\n'
+              while read -r line || [ -n "${line}" ]; do
+                output="${output}${line}"$'\n'
               done < <(eval ${ANON["${r}"]})
               _string "${output%$'\n'}"
               return ;;

--- a/bash/tests/stepA_mal.mal
+++ b/bash/tests/stepA_mal.mal
@@ -24,3 +24,9 @@
 
 (sh* "echo hello; echo foo; echo yes;")
 ;=>"hello\nfoo\nyes"
+
+(sh* "grep -oE '\[.*!\]' core.sh")
+;=>"[reset!]\n[swap!]"
+
+(sh* "ls cor*.sh")
+;=>"core.sh"

--- a/bash/tests/stepA_mal.mal
+++ b/bash/tests/stepA_mal.mal
@@ -15,3 +15,12 @@
 
 (sh* "for x in 1 2 3; do echo -n \"$((1+$x)) \"; done; echo")
 ;=>"2 3 4"
+
+(sh* "for x in {1..10}; do echo $x; done")
+;=>"1\n2\n3\n4\n5\n6\n7\n8\n9\n10"
+
+(sh* "echo -n {1..3}")
+;=>"1 2 3"
+
+(sh* "echo hello; echo foo; echo yes;")
+;=>"hello\nfoo\nyes"


### PR DESCRIPTION
This supercedes kanaka#470 and includes kanaka#471.
This fixes some edge cases when passing an asterisk to an sh* interop call.
Before this fix mal would pass the string with any wildcard character converted to __STAR__ when passing to the subcommand.
For example `(sh* "ls *")` would become `ls __STAR__` when executed.
See the tests for examples of where this would fail to do what the user expects.
See also: chr15m/flk#1