### PR TITLE
Fix python.2 Env.find implementation.

### DIFF
--- a/python.2/env.py
+++ b/python.2/env.py
@@ -12,10 +12,8 @@ class Env(object):
         binds: Optional[List[MalExpression]] = None,
         exprs: Optional[List[MalExpression]] = None,
     ) -> None:
-        if outer:
-            self._data: Dict[str, MalExpression] = outer._data.copy()
-        else:
-            self._data = {}
+        self._outer = outer
+        self._data: Dict[str, MalExpression] = {}
         if binds is not None and exprs is not None:
             for x in range(0, len(binds)):
                 assert isinstance(binds[x], MalSymbol)
@@ -32,6 +30,8 @@ class Env(object):
     def find(self, key: MalExpression) -> Optional["Env"]:
         if str(key) in self._data:
             return self
+        if self._outer is not None:
+            return self._outer.find(key)
         return None
 
     def get(self, key: MalExpression) -> MalExpression:
@@ -49,4 +49,4 @@ class Env(object):
         for d in self._data:
             env_str += str(d) + ": " + str(self._data[d]) + ", "
         env_str += "}"
-        return "environment: (data: " + env_str + ")"
+        return f"environment: (data: {env_str} outer: {repr(self._outer) if self._outer is not None else 'None'})"

--- a/tests/step6_file.mal
+++ b/tests/step6_file.mal
@@ -126,6 +126,11 @@
 *ARGV*
 ;=>()
 
+;;
+;; Testing that eval sets aa in root scope, and that it is found in nested scope
+(let* (b 12) (do (eval (read-string "(def! aa 7)")) aa ))
+;=>7
+
 ;>>> soft=True
 ;>>> optional=True
 ;;
@@ -175,3 +180,4 @@ mymap
 ;;; Hopefully less problematic characters can be checked together
 (read-string "1; &()*+,-./:;<=>?@[]^_{|}~")
 ;=>1
+


### PR DESCRIPTION
It should search the outer Env

Currently unit tests fail:
```
$ python -m unittest discover -s tests
.....F...............................4
..........................................................."exc is:" "'abc' not found"
.............
======================================================================
FAIL: test_env_find_outer (test_step3.TestStep3)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aw/Projects/cureatr/dev/cureatr/experiments/lispy/mal/python.2/tests/test_step3.py", line 23, in test_env_find_outer
    self.assertTrue(result is outer)
AssertionError: False is not true

----------------------------------------------------------------------
Ran 109 tests in 0.545s

FAILED (failures=1)
```