### PR TITLE
swift5: get rid of swift dependency to run tests

### DIFF
--- a/swift5/.gitignore
+++ b/swift5/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/out
 /Packages
 /*.xcodeproj
 xcuserdata/

--- a/swift5/Makefile
+++ b/swift5/Makefile
@@ -1,9 +1,9 @@
-all:
-	swift build
-
 step%: 
+	mkdir -p ./out
 	swift build --product $@
+	cp "$(shell swift build --show-bin-path)/$@" "./out/$@"
 
 clean:
+	rm -rf ./out
 	rm -rf ./.build
 

--- a/swift5/run
+++ b/swift5/run
@@ -1,3 +1,2 @@
 #!/bin/bash
-swift run --skip-build ${STEP:-stepA_mal} "${@}"
-
+exec $(dirname $0)/out/${STEP:-stepA_mal} "${@}"


### PR DESCRIPTION
Get rid of swift dependency to run tests as discussed in #467