### PR TITLE
js, es6: meta-data on atoms

### DIFF
--- a/es6/types.mjs
+++ b/es6/types.mjs
@@ -28,6 +28,8 @@ export function _clone(obj, new_meta) {
     } else if (obj instanceof Function) {
         let f = (...a) => obj.apply(f, a)  // new function instance
         new_obj = Object.assign(f, obj)    // copy original properties
+    } else if (obj instanceof Atom) {
+        new_obj = new Atom(obj.val)
     } else {
         throw Error('Unsupported type for clone')
     }

--- a/js/core.js
+++ b/js/core.js
@@ -156,9 +156,9 @@ function with_meta(obj, m) {
 }
 
 function meta(obj) {
-    // TODO: support symbols and atoms
     if ((!types._sequential_Q(obj)) &&
         (!(types._hash_map_Q(obj))) &&
+        (!(types._atom_Q(obj))) &&
         (!(types._function_Q(obj)))) {
         throw new Error("attempt to get metadata from: " + types._obj_type(obj));
     }

--- a/js/types.js
+++ b/js/types.js
@@ -73,6 +73,9 @@ function _clone (obj) {
     case 'function':
         new_obj = obj.clone();
         break;
+    case 'atom':
+        new_obj = _atom(obj.val);
+        break;
     default:
         throw new Error("clone of non-collection: " + _obj_type(obj));
     }

--- a/process/guide.md
+++ b/process/guide.md
@@ -1602,8 +1602,8 @@ implementation.
 
 #### Optional additions
 
-* Add meta-data support to composite data types (lists, vectors
-  and hash-maps), and to functions (native or not), by adding a new
+* Add meta-data support to composite data types (lists, vectors, hash-maps
+  and atoms), and to functions (native or not), by adding a new
   metadata attribute that refers to another mal value/type
   (nil by default). Add the following metadata related core functions
   (and remove any stub versions):


### PR DESCRIPTION
Support the (optional, soft-fail) meta-data on atoms (added to the guide).

Before the fix:

```
Mal [javascript]
user> (meta (with-meta (atom 7) {"a" 1}))
Error: clone of non-collection: atom
    at Object._clone (/home/dubek/world/mal/js/types.js:77:15)
    at Function.with_meta (/home/dubek/world/mal/js/core.js:153:25)
    at _EVAL (/home/dubek/world/mal/js/stepA_mal.js:143:22)
    at EVAL (/home/dubek/world/mal/js/stepA_mal.js:151:18)
    at /home/dubek/world/mal/js/stepA_mal.js:55:45
    at Array.map (<anonymous>)
    at eval_ast (/home/dubek/world/mal/js/stepA_mal.js:55:20)
    at _EVAL (/home/dubek/world/mal/js/stepA_mal.js:138:18)
    at EVAL (/home/dubek/world/mal/js/stepA_mal.js:151:18)
    at rep (/home/dubek/world/mal/js/stepA_mal.js:162:40)
```

After the fix:

```
Mal [javascript]
user> (meta (with-meta (atom 7) {"a" 1}))
{"a" 1}
```

(fixed similarly for the es6 implementation.)