### PR TITLE
es6, js, python, ruby: defmacro! doesn't mutate original function

### DIFF
--- a/es6/step8_macros.mjs
+++ b/es6/step8_macros.mjs
@@ -1,6 +1,6 @@
 import rl from './node_readline.js'
 const readline = rl.readline
-import { _list_Q, _malfunc, _malfunc_Q } from './types'
+import { _clone, _list_Q, _malfunc, _malfunc_Q } from './types'
 import { BlankException, read_str } from './reader'
 import { pr_str } from './printer'
 import { new_env, env_set, env_get } from './env'
@@ -79,7 +79,7 @@ const EVAL = (ast, env) => {
             ast = quasiquote(a1)
             break // continue TCO loop
         case 'defmacro!':
-            let func = EVAL(a2, env)
+            let func = _clone(EVAL(a2, env))
             func.ismacro = true
             return env_set(env, a1, func)
         case 'macroexpand':

--- a/es6/step9_try.mjs
+++ b/es6/step9_try.mjs
@@ -1,6 +1,6 @@
 import rl from './node_readline.js'
 const readline = rl.readline
-import { _list_Q, _malfunc, _malfunc_Q } from './types'
+import { _clone, _list_Q, _malfunc, _malfunc_Q } from './types'
 import { BlankException, read_str } from './reader'
 import { pr_str } from './printer'
 import { new_env, env_set, env_get } from './env'
@@ -79,7 +79,7 @@ const EVAL = (ast, env) => {
             ast = quasiquote(a1)
             break // continue TCO loop
         case 'defmacro!':
-            let func = EVAL(a2, env)
+            let func = _clone(EVAL(a2, env))
             func.ismacro = true
             return env_set(env, a1, func)
         case 'macroexpand':

--- a/es6/stepA_mal.mjs
+++ b/es6/stepA_mal.mjs
@@ -1,6 +1,6 @@
 import rl from './node_readline.js'
 const readline = rl.readline
-import { _list_Q, _malfunc, _malfunc_Q } from './types'
+import { _clone, _list_Q, _malfunc, _malfunc_Q } from './types'
 import { BlankException, read_str } from './reader'
 import { pr_str } from './printer'
 import { new_env, env_set, env_get } from './env'
@@ -79,7 +79,7 @@ const EVAL = (ast, env) => {
             ast = quasiquote(a1)
             break // continue TCO loop
         case 'defmacro!':
-            let func = EVAL(a2, env)
+            let func = _clone(EVAL(a2, env))
             func.ismacro = true
             return env_set(env, a1, func)
         case 'macroexpand':

--- a/js/step8_macros.js
+++ b/js/step8_macros.js
@@ -104,7 +104,7 @@ function _EVAL(ast, env) {
         ast = quasiquote(a1);
         break;
     case 'defmacro!':
-        var func = EVAL(a2, env);
+        var func = types._clone(EVAL(a2, env));
         func._ismacro_ = true;
         return env.set(a1, func);
     case 'macroexpand':

--- a/js/step9_try.js
+++ b/js/step9_try.js
@@ -104,7 +104,7 @@ function _EVAL(ast, env) {
         ast = quasiquote(a1);
         break;
     case 'defmacro!':
-        var func = EVAL(a2, env);
+        var func = types._clone(EVAL(a2, env));
         func._ismacro_ = true;
         return env.set(a1, func);
     case 'macroexpand':

--- a/js/stepA_mal.js
+++ b/js/stepA_mal.js
@@ -104,7 +104,7 @@ function _EVAL(ast, env) {
         ast = quasiquote(a1);
         break;
     case 'defmacro!':
-        var func = EVAL(a2, env);
+        var func = types._clone(EVAL(a2, env));
         func._ismacro_ = true;
         return env.set(a1, func);
     case 'macroexpand':

--- a/python/step8_macros.py
+++ b/python/step8_macros.py
@@ -87,7 +87,7 @@ def EVAL(ast, env):
             ast = quasiquote(ast[1]);
             # Continue loop (TCO)
         elif 'defmacro!' == a0:
-            func = EVAL(ast[2], env)
+            func = types._clone(EVAL(ast[2], env))
             func._ismacro_ = True
             return env.set(ast[1], func)
         elif 'macroexpand' == a0:

--- a/python/step9_try.py
+++ b/python/step9_try.py
@@ -87,7 +87,7 @@ def EVAL(ast, env):
             ast = quasiquote(ast[1]);
             # Continue loop (TCO)
         elif 'defmacro!' == a0:
-            func = EVAL(ast[2], env)
+            func = types._clone(EVAL(ast[2], env))
             func._ismacro_ = True
             return env.set(ast[1], func)
         elif 'macroexpand' == a0:

--- a/python/stepA_mal.py
+++ b/python/stepA_mal.py
@@ -87,7 +87,7 @@ def EVAL(ast, env):
             ast = quasiquote(ast[1]);
             # Continue loop (TCO)
         elif 'defmacro!' == a0:
-            func = EVAL(ast[2], env)
+            func = types._clone(EVAL(ast[2], env))
             func._ismacro_ = True
             return env.set(ast[1], func)
         elif 'macroexpand' == a0:

--- a/ruby/step8_macros.rb
+++ b/ruby/step8_macros.rb
@@ -94,7 +94,7 @@ def EVAL(ast, env)
     when :quasiquote
         ast = quasiquote(a1); # Continue loop (TCO)
     when :defmacro!
-        func = EVAL(a2, env)
+        func = EVAL(a2, env).clone
         func.is_macro = true
         return env.set(a1, func)
     when :macroexpand

--- a/ruby/step9_try.rb
+++ b/ruby/step9_try.rb
@@ -94,7 +94,7 @@ def EVAL(ast, env)
     when :quasiquote
         ast = quasiquote(a1); # Continue loop (TCO)
     when :defmacro!
-        func = EVAL(a2, env)
+        func = EVAL(a2, env).clone
         func.is_macro = true
         return env.set(a1, func)
     when :macroexpand

--- a/ruby/stepA_mal.rb
+++ b/ruby/stepA_mal.rb
@@ -94,7 +94,7 @@ def EVAL(ast, env)
     when :quasiquote
         ast = quasiquote(a1); # Continue loop (TCO)
     when :defmacro!
-        func = EVAL(a2, env)
+        func = EVAL(a2, env).clone
         func.is_macro = true
         return env.set(a1, func)
     when :macroexpand


### PR DESCRIPTION
Modify `defmacro!` to clone the given function before setting the `ismacro` flag.

This fixes a soft-fail test in stepA.

(there are other implementations which still don't support it.)
