### PR TITLE
Add test for interaction of let* local atoms and captures

### DIFF
--- a/tests/step6_file.mal
+++ b/tests/step6_file.mal
@@ -93,6 +93,12 @@
 (f)
 ;=>9
 
+;; Test interaction of local atoms from let* that shadow parent scope
+(def! g (let* (aaa (atom 0)) (fn* () (deref aaa))))
+(def! aaa (atom 1))
+(g)
+;=>0
+
 ;>>> deferrable=True
 ;;
 ;; -------- Deferrable Functionality --------


### PR DESCRIPTION
Test the interaction between (possibly shadowing) atoms from a let* scope

this is used in load-file-once, would've been nice to know about the fault in advance