### PR TITLE
Step 6: Test read-string of a single atom at the end of input

### DIFF
--- a/impls/tests/step6_file.mal
+++ b/impls/tests/step6_file.mal
@@ -9,6 +9,9 @@
 (read-string "(1 2 (3 4) nil)")
 ;=>(1 2 (3 4) nil)
 
+(= nil (read-string "nil"))
+;=>true
+
 (read-string "(+ 2 3)")
 ;=>(+ 2 3)
 


### PR DESCRIPTION
All of the existing `read-string` tests test forms whose end can be detected before the end of the input string, either because they're naturally self-terminating (lists, strings) or because there's white space after them.  All of the uses of the reader from the REPL are similarly likely to have input with a newline or similar at the end.

My BCPL implementation turned out to read one character past the end of the input when the input ended inside an atom, and to incorporate that one byte into the output.  The consequences of a buffer over-read are a little unpredictable, so I've just written a test that was good enough to catch the bug for me.