### PR TITLE
Update and fixes for the lua implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Each implementation of mal is separated into
 11 incremental, self-contained (and testable) steps that demonstrate
 core concepts of Lisp. The last step is capable of self-hosting
 (running the mal implementation of mal). See the [make-a-lisp process
-guide](process/guide.md). 
+guide](process/guide.md).
 
 The make-a-lisp steps are:
 
@@ -647,13 +647,12 @@ logo stepX_YYY.lg
 
 ### Lua
 
-The Lua implementation of mal has been tested with Lua 5.2. The
-implementation requires that luarocks and the lua-rex-pcre library
-are installed.
+The Lua implementation of mal has been tested with Lua 5.3.5 The
+implementation requires luarocks to be installed.
 
 ```
 cd impls/lua
-make  # to build and link linenoise.so
+make  # to build and link linenoise.so and rex_pcre.so
 ./stepX_YYY.lua
 ```
 

--- a/impls/.gitignore
+++ b/impls/.gitignore
@@ -81,6 +81,7 @@ kotlin/.idea
 kotlin/*.iml
 lua/lib
 lua/linenoise.so
+lua/rex_pcre.so
 lua/mal.lua
 make/mal.mk
 mal/mal.mal

--- a/impls/lua/Dockerfile
+++ b/impls/lua/Dockerfile
@@ -22,9 +22,22 @@ WORKDIR /mal
 ##########################################################
 
 # Lua
-RUN apt-get -y install lua5.2 liblua5.2-dev lua-rex-pcre luarocks
-RUN luarocks install linenoise
-RUN luarocks install luasocket
+RUN apt-get -y install gcc wget unzip libpcre3-dev
+
+RUN \
+curl -R -O http://www.lua.org/ftp/lua-5.3.5.tar.gz && \
+tar -zxf lua-5.3.5.tar.gz && \
+cd lua-5.3.5 && \
+make linux test && \
+make install
+
+RUN \
+wget https://luarocks.org/releases/luarocks-3.3.1.tar.gz && \
+tar zxpf luarocks-3.3.1.tar.gz && \
+cd luarocks-3.3.1 && \
+./configure && \
+make && \
+make install
 
 # luarocks .cache directory is relative to HOME
 ENV HOME /mal

--- a/impls/lua/Makefile
+++ b/impls/lua/Makefile
@@ -24,12 +24,12 @@ mal: mal.lua
 
 clean:
 	rm -f linenoise.so mal.lua mal
-	rm -rf lib/lua/5.1
+	rm -rf lib
 
 .PHONY: libs
 libs: linenoise.so
 
 linenoise.so:
 	luarocks install --tree=./ linenoise
-	ln -sf lib/lua/5.1/linenoise.so $@
+	ln -sf $$(find . -name linenoise.so) $@
 

--- a/impls/lua/Makefile
+++ b/impls/lua/Makefile
@@ -23,13 +23,17 @@ mal: mal.lua
 
 
 clean:
-	rm -f linenoise.so mal.lua mal
+	rm -f linenoise.so rex_pcre.so mal.lua mal
 	rm -rf lib
 
 .PHONY: libs
-libs: linenoise.so
+libs: linenoise.so rex_pcre.so
 
 linenoise.so:
 	luarocks install --tree=./ linenoise
 	ln -sf $$(find . -name linenoise.so) $@
+
+rex_pcre.so:
+	luarocks install --tree=./ lrexlib-pcre
+	ln -sf $$(find . -name rex_pcre.so) $@
 

--- a/impls/lua/core.lua
+++ b/impls/lua/core.lua
@@ -3,7 +3,6 @@ local types = require('types')
 local reader = require('reader')
 local printer = require('printer')
 local readline = require('readline')
--- local socket = require('socket')
 
 local Nil, List, HashMap, _pr_str = types.Nil, types.List, types.HashMap, printer._pr_str
 
@@ -278,7 +277,7 @@ M.ns = {
     ['-'] =  function(a,b) return a-b end,
     ['*'] =  function(a,b) return a*b end,
     ['/'] =  function(a,b) return math.floor(a/b) end,
-    ['time-ms'] = function() return math.floor(os.clock()*1000) end,
+    ['time-ms'] = function() return math.floor(os.clock()*1000000) end,
 
     list = function(...) return List:new(table.pack(...)) end,
     ['list?'] = function(a) return types._list_Q(a) end,

--- a/impls/lua/core.lua
+++ b/impls/lua/core.lua
@@ -3,7 +3,7 @@ local types = require('types')
 local reader = require('reader')
 local printer = require('printer')
 local readline = require('readline')
-local socket = require('socket')
+-- local socket = require('socket')
 
 local Nil, List, HashMap, _pr_str = types.Nil, types.List, types.HashMap, printer._pr_str
 
@@ -272,7 +272,7 @@ M.ns = {
     ['-'] =  function(a,b) return a-b end,
     ['*'] =  function(a,b) return a*b end,
     ['/'] =  function(a,b) return math.floor(a/b) end,
-    ['time-ms'] = function() return math.floor(socket.gettime() * 1000) end,
+    -- ['time-ms'] = function() return math.floor(socket.gettime() * 1000) end,
 
     list = function(...) return List:new(table.pack(...)) end,
     ['list?'] = function(a) return types._list_Q(a) end,

--- a/impls/lua/core.lua
+++ b/impls/lua/core.lua
@@ -233,7 +233,7 @@ local function lua_to_mal(a)
 end
 
 local function lua_eval(str)
-    local f, err = loadstring("return "..str)
+    local f, err = load("return "..str)
     if err then
         types.throw("lua-eval: can't load code: "..err)
     end
@@ -250,8 +250,14 @@ M.ns = {
     ['number?'] = function(a) return types._number_Q(a) end,
     symbol = function(a) return types.Symbol:new(a) end,
     ['symbol?'] = function(a) return types._symbol_Q(a) end,
-    ['string?'] = function(a) return types._string_Q(a) and "\177" ~= string.sub(a,1,1) end,
-    keyword = function(a) return "\177"..a end,
+    ['string?'] = function(a) return types._string_Q(a) and "\u{029e}" ~= string.sub(a,1,2) end,
+    keyword = function(a)
+        if types._keyword_Q(a) then
+            return a
+        else
+            return "\u{029e}"..a
+        end
+    end,
     ['keyword?'] = function(a) return types._keyword_Q(a) end,
     ['fn?'] = function(a) return types._fn_Q(a) end,
     ['macro?'] = function(a) return types._macro_Q(a) end,
@@ -272,7 +278,7 @@ M.ns = {
     ['-'] =  function(a,b) return a-b end,
     ['*'] =  function(a,b) return a*b end,
     ['/'] =  function(a,b) return math.floor(a/b) end,
-    -- ['time-ms'] = function() return math.floor(socket.gettime() * 1000) end,
+    ['time-ms'] = function() return math.floor(os.clock()*1000) end,
 
     list = function(...) return List:new(table.pack(...)) end,
     ['list?'] = function(a) return types._list_Q(a) end,

--- a/impls/lua/printer.lua
+++ b/impls/lua/printer.lua
@@ -23,8 +23,8 @@ function M._pr_str(obj, print_readably)
         end
         return "{".. table.concat(res, " ").."}"
     elseif type(obj) == 'string' then
-        if string.sub(obj,1,1) == "\177" then
-            return ':' .. string.sub(obj,2)
+        if string.sub(obj,1,2) == "\u{029e}" then
+            return ':' .. string.sub(obj,3)
         else
             if _r then
                 local sval = obj:gsub('\\', '\\\\')

--- a/impls/lua/reader.lua
+++ b/impls/lua/reader.lua
@@ -46,15 +46,15 @@ function M.read_atom(rdr)
     elseif float_re:exec(token) then return tonumber(token)
     elseif string_re:exec(token) then
         local sval = string.sub(token,2,string.len(token)-1)
-        sval = string.gsub(sval, '\\\\', '\177')
+        sval = string.gsub(sval, '\\\\', '\u{029e}')
         sval = string.gsub(sval, '\\"', '"')
         sval = string.gsub(sval, '\\n', '\n')
-        sval = string.gsub(sval, '\177', '\\')
+        sval = string.gsub(sval, '\u{029e}', '\\')
         return sval
     elseif string.sub(token,1,1) == '"' then
         throw("expected '\"', got EOF")
     elseif string.sub(token,1,1) == ':' then
-        return "\177" .. string.sub(token,2)
+        return "\u{029e}" .. string.sub(token,2)
     elseif token == "nil" then       return Nil
     elseif token == "true" then      return true
     elseif token == "false" then     return false

--- a/impls/lua/types.lua
+++ b/impls/lua/types.lua
@@ -118,7 +118,7 @@ end
 
 -- Keywords
 function M._keyword_Q(obj)
-    return M._string_Q(obj) and "\177" == string.sub(obj,1,1)
+    return M._string_Q(obj) and "\u{029e}" == string.sub(obj,1,2)
 end
 
 


### PR DESCRIPTION
I tried the lua implementation with lua 5.3.5 and found a various issues.

- Readme said it was tested with 5.2 but the makefile is looking for the libraries in a 5.1 directory. I updated the makefile to be version agnostic. I also added a step to install rex_pcre.so through luarocks.
- It seems it also needs LuaSocket. To make it easier I just commented the require and changed `ms-time` to use `os.clock` (won't give time in ms).
- `loadstring` is now `load` in newer versions of lua.
- Lua now supports unicode, so I changed `\177` to `\u{029e}` to be more like some of the other implementations.
- Some tests were failing, reason was that the `keyword` implementation was wrong.
- There is still one test soft failing that I haven't looked at in detail yet (I don't think it's lua version related):
```
Test that defining a macro does not mutate an existing function.
TEST: '(f (+ 1 1))' -> ['',true] -> SOFT FAIL (line 295):
    Expected : '\\(f\\ \\(\\+\\ 1\\ 1\\)\\)\r\ntrue'
    Got      : '(f (+ 1 1))\r\nfalse'
```