### PR TITLE
Add tests for nested exception handlers

### DIFF
--- a/impls/tests/step9_try.mal
+++ b/impls/tests/step9_try.mal
@@ -27,6 +27,12 @@
 ;/"exc:" "my exception"
 ;=>7
 
+;; Test that exception handlers get restored correctly
+(try* (do (try* "t1" (catch* e "c1")) (throw "e1")) (catch* e "c2"))
+;=>"c2"
+(try* (try* (throw "e1") (catch* e (throw "e2"))) (catch* e "c2"))
+;=>"c2"
+
 ;;; Test that throw is a function:
 (try* (map throw (list "my err")) (catch* exc exc))
 ;=>"my err"


### PR DESCRIPTION
In BCPL, my `throw` implementation uses `longjump()`, which is similar to C's `longjmp()`.  I have a pair of global variables that specify the current exception handler, and `try*` updates them on entry. While making sure that `try*` also restored the exception handler on exit, I noticed that no current tests in step 9 covers this case: they don't try using `throw` after `try*` has returned, or from inside a `catch*` block.  So here are a couple of tests that do.

- [ ] ps