### PR TITLE
Simplify runtest.py's input handling

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -28,8 +28,7 @@ def log(data, end='\n'):
     print(data, end=end)
     sys.stdout.flush()
 
-# TODO: do we need to support '\n' too
-sep = "\r\n"
+sep = "\n"
 rundir = None
 
 parser = argparse.ArgumentParser(
@@ -127,11 +126,7 @@ class Runner():
                 #print("new_data: '%s'" % new_data)
                 debug(new_data)
                 # Perform newline cleanup
-                if self.no_pty:
-                    self.buf += new_data.replace("\n", "\r\n")
-                else:
-                    self.buf += new_data
-                self.buf = self.buf.replace("\r\r", "\r")
+                self.buf += new_data.replace("\r", "")
                 for prompt in prompts:
                     regexp = re.compile(prompt)
                     match = regexp.search(self.buf)
@@ -216,10 +211,10 @@ class TestReader:
                     break
             if self.ret != None: break
 
-        if self.out[-2:] == sep and not self.ret:
+        if self.out[-1:] == sep and not self.ret:
             # If there is no return value, output should not end in
             # separator
-            self.out = self.out[0:-2]
+            self.out = self.out[0:-1]
         return self.form
 
 args = parser.parse_args(sys.argv[1:])

--- a/runtest.py
+++ b/runtest.py
@@ -132,13 +132,6 @@ class Runner():
                 else:
                     self.buf += new_data
                 self.buf = self.buf.replace("\r\r", "\r")
-                # Remove ANSI codes generally
-                #ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
-                # Remove rustyline ANSI CSI codes:
-                #  - [6C - CR + cursor forward
-                #  - [6K - CR + erase in line
-                ansi_escape = re.compile(r'\r\x1B\[[0-9]*[CK]')
-                self.buf = ansi_escape.sub('', self.buf)
                 for prompt in prompts:
                     regexp = re.compile(prompt)
                     match = regexp.search(self.buf)
@@ -147,7 +140,7 @@ class Runner():
                         buf = self.buf[0:match.start()]
                         self.buf = self.buf[end:]
                         self.last_prompt = prompt
-                        return buf.replace("^M", "\r")
+                        return buf
         return None
 
     def writeline(self, str):
@@ -296,11 +289,8 @@ while t.next():
     # The repeated form is to get around an occasional OS X issue
     # where the form is repeated.
     # https://github.com/kanaka/mal/issues/30
-    expects = ["%s%s%s%s" % (re.escape(t.form), sep,
-                              t.out, re.escape(t.ret)),
-               "%s%s%s%s%s%s" % (re.escape(t.form), sep,
-                                  re.escape(t.form), sep,
-                                  t.out, re.escape(t.ret))]
+    expects = [".*%s%s%s" % (sep, t.out, re.escape(t.ret)),
+               ".*%s.*%s%s%s" % (sep, sep, t.out, re.escape(t.ret))]
 
     r.writeline(t.form)
     try:


### PR DESCRIPTION
This is a successor to #469. There, I found that my BCPL implementation (now almost finished!) was tripping up `runtest.py` by omitting carriage returns in its output where they would have no effect. This appears to be a feature of the BCPL standard library and hard to avoid.  More recently, I've started on an APL implementation and found that GNU APL's readline-alike is very enthusiastic about emitting escape sequences.

This PR modifies `runtest.py` so that it's more tolerant of this kind of behaviour without the extravagant overhead of building an entire terminal emulator into it.

The important feature is that I've stopped `runtest.py` caring about how its input is echoed.  Previously when testing a form, it would check not only that the form was evaluated correctly, but also that it was echoed back correctly on the REPL command line.  This is unnecessary and unhelpful, since it almost all cases that echoing will be provided by that host-language readline library or the operating system terminal driver.  Even if those are somewhat under the control of the programmer, Mal should be primarily about making a LISP, not wrangling readline libraries. `runtest.py` now assumes that everything up to the first line feed after the prompt is echoed input, and ignores it. It still allows for the possibility of a second such line, to work around #30.

Similarly, I've stopped `runtest.py` caring about carriage returns at all.  These are inserted either by the host-language runtime or by the terminal driver, so they don't reflect whether the implementation works properly.  The input routine now strips them out and none of the rest of the code expects them.

These changes are sufficient to allow `runtest.py` to handle my nascent APL implementation, and almost enough for BCPL (there's another problem there, but I think it might be the implementation's job to fix that).