### PR TITLE
Step 2: Test empty vectors and hash-maps

### DIFF
--- a/impls/tests/step2_eval.mal
+++ b/impls/tests/step2_eval.mal
@@ -41,3 +41,9 @@
 
 {:a (+ 7 8)}
 ;=>{:a 15}
+
+;; Check that evaluation hasn't broken empty collections
+[]
+;=>[]
+{}
+;=>{}

--- a/impls/yorick/step2_eval.i
+++ b/impls/yorick/step2_eval.i
@@ -17,6 +17,7 @@ func eval_ast(ast, env)
     return val
   } else if (type == MalList) {
     seq = *(ast.val)
+    if (numberof(seq) == 0) return ast
     res = array(pointer, numberof(seq))
     for (i = 1; i <= numberof(seq); ++i) {
       e = EVAL(*seq(i), env)
@@ -26,6 +27,7 @@ func eval_ast(ast, env)
     return MalList(val=&res)
   } else if (type == MalVector) {
     seq = *(ast.val)
+    if (numberof(seq) == 0) return ast
     res = array(pointer, numberof(seq))
     for (i = 1; i <= numberof(seq); ++i) {
       e = EVAL(*seq(i), env)

--- a/impls/yorick/step3_env.i
+++ b/impls/yorick/step3_env.i
@@ -16,6 +16,7 @@ func eval_ast(ast, env)
     return env_get(env, ast.val)
   } else if (type == MalList) {
     seq = *(ast.val)
+    if (numberof(seq) == 0) return ast
     res = array(pointer, numberof(seq))
     for (i = 1; i <= numberof(seq); ++i) {
       e = EVAL(*seq(i), env)
@@ -25,6 +26,7 @@ func eval_ast(ast, env)
     return MalList(val=&res)
   } else if (type == MalVector) {
     seq = *(ast.val)
+    if (numberof(seq) == 0) return ast
     res = array(pointer, numberof(seq))
     for (i = 1; i <= numberof(seq); ++i) {
       e = EVAL(*seq(i), env)


### PR DESCRIPTION
An empty vector or hash-map should evaluate to itself, but I reached the test of `(empty? [])` in step 4 before I discovered that I'd got `[]` evaluating to `0`.  Add tests for both cases to step 2.  This shouldn't cause any new failures, unless I suppose there's an implementation where `(empty? 0)` is true. It just means that this bug in `eval_ast` can be caught before it propagates to two more stage files.
- [x] yorick