### PR TITLE
step 4: Test that (= (list) ()) is true

### DIFF
--- a/impls/tests/step4_if_fn_do.mal
+++ b/impls/tests/step4_if_fn_do.mal
@@ -119,6 +119,8 @@
 
 (= (list) (list))
 ;=>true
+(= (list) ())
+;=>true
 (= (list 1 2) (list 1 2))
 ;=>true
 (= (list 1) (list))


### PR DESCRIPTION
Another  test of empty things, because those are special in APL.  Since #512 smoked out a bug elsewhere, I think this one is worth trying.

In APL, empty arrays have type, and the `≡` function pays attention to that, so if you're not careful empty lists produced by different means compare different.  This test detects that by comparing an empty list produced by `list` with one produced by evaluating an empty list.

My bug was found by a deferrable step 4 test, but the bug should be non-deferrable.

- [ ] fantom
- [x] jq