### PR TITLE
runtest: Treat test timeouts as fatal

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -264,6 +264,9 @@ fail_cnt = 0
 soft_fail_cnt = 0
 failures = []
 
+class TestTimeout(Exception):
+    pass
+
 while t.next():
     if args.deferrable == False and t.deferrable:
         log(t.deferrable)
@@ -293,7 +296,10 @@ while t.next():
         res = r.read_to_prompt(['\r\n[^\s()<>]+> ', '\n[^\s()<>]+> '],
                                 timeout=args.test_timeout)
         #print "%s,%s,%s" % (idx, repr(p.before), repr(p.after))
-        if (t.ret == "" and t.out == ""):
+        if (res == None):
+            log(" -> TIMEOUT (line %d)" % t.line_num)
+            raise TestTimeout("TIMEOUT (line %d)" % t.line_num)
+        elif (t.ret == "" and t.out == ""):
             log(" -> SUCCESS (result ignored)")
             pass_cnt += 1
         elif (re.search(expects[0], res, re.S) or


### PR DESCRIPTION
If a test times out, that means the implementation hasn't returned a prompt within reasonable time.  Continuing to type at it is unlikely to be helpful, since the lack of a prompt indicates that the subprocess has hung, so subsequent tests are likely to time out as well.

This is particularly annoying in step 5, where the line that usually times out, `(def! res2 (sum2 10000 0))` has its output ignored, so a timeout is treated as success, meaning that runtest proceeds to the next test, which of course also times out.

This PR converts timeouts into fatal errors (through the existing exception-handing mechanism) so that a timeout immediately aborts the entire test.