### PR TITLE
ruby: (keyword :abc) should just return same keyword

### DIFF
--- a/impls/ruby/core.rb
+++ b/impls/ruby/core.rb
@@ -11,7 +11,7 @@ $core_ns = {
     :string? =>   lambda {|a| (a.is_a? String) && "\u029e" != a[0]},
     :symbol =>    lambda {|a| a.to_sym},
     :symbol? =>   lambda {|a| a.is_a? Symbol},
-    :keyword =>   lambda {|a| "\u029e"+a},
+    :keyword =>   lambda {|a| (a.is_a? String) && "\u029e" == a[0] ? a : "\u029e"+a},
     :keyword? =>  lambda {|a| (a.is_a? String) && "\u029e" == a[0]},
     :number? =>   lambda {|a| a.is_a? Numeric},
     :fn? =>       lambda {|a| (a.is_a? Proc) && (!(a.is_a? Function) || !a.is_macro)},


### PR DESCRIPTION
Before the fix Ruby had one soft fail in step9:

```
TEST: '(keyword :abc)' -> ['',:abc] -> SOFT FAIL (line 386):
    Expected : '.*\n\\:abc'
    Got      : '(keyword :abc)\n:\xca\x9eabc'
```

The fix causes `(keyword :abc)` to return its keyword argument without modification.
