### PR TITLE
Fantom fixes

### DIFF
--- a/impls/fantom/Dockerfile
+++ b/impls/fantom/Dockerfile
@@ -31,7 +31,8 @@ RUN cd /tmp && curl -sfLO https://bitbucket.org/fantom/fan-1.0/downloads/fantom-
     && mv fantom-1.0.70 /opt/fantom \
     && cd /opt/fantom \
     && bash adm/unixsetup \
-    && curl -sfL -o /opt/fantom/lib/java/jline.jar https://repo1.maven.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar
+    && curl -sfL -o /opt/fantom/lib/java/jline.jar https://repo1.maven.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar \
+    && sed -i '/java.options/ s/$/ -Djline.expandevents=false/' /opt/fantom/etc/sys/config.props
 
 ENV PATH /opt/fantom/bin:$PATH
 ENV HOME /mal

--- a/impls/fantom/Dockerfile
+++ b/impls/fantom/Dockerfile
@@ -25,14 +25,14 @@ WORKDIR /mal
 RUN apt-get -y install openjdk-8-jdk unzip
 
 # Fantom and JLine
-RUN cd /tmp && curl -sfLO https://bitbucket.org/fantom/fan-1.0/downloads/fantom-1.0.70.zip \
-    && unzip -q fantom-1.0.70.zip \
-    && rm fantom-1.0.70.zip \
-    && mv fantom-1.0.70 /opt/fantom \
+RUN cd /tmp && curl -sfLO https://github.com/fantom-lang/fantom/releases/download/v1.0.75/fantom-1.0.75.zip \
+    && unzip -q fantom-1.0.75.zip \
+    && rm fantom-1.0.75.zip \
+    && mv fantom-1.0.75 /opt/fantom \
     && cd /opt/fantom \
     && bash adm/unixsetup \
     && curl -sfL -o /opt/fantom/lib/java/jline.jar https://repo1.maven.org/maven2/jline/jline/2.14.6/jline-2.14.6.jar \
-    && sed -i '/java.options/ s/$/ -Djline.expandevents=false/' /opt/fantom/etc/sys/config.props
+    && sed -i '/java.options/ s/^\/\/ *\(.*\)$/\1 -Djline.expandevents=false/' /opt/fantom/etc/sys/config.props
 
 ENV PATH /opt/fantom/bin:$PATH
 ENV HOME /mal

--- a/impls/fantom/src/mallib/fan/core.fan
+++ b/impls/fantom/src/mallib/fan/core.fan
@@ -20,7 +20,7 @@ class Core
 
   static private MalVal concat(MalVal[] a)
   {
-    return MalList(a.reduce(MalVal[,]) |MalVal[] r, MalSeq v -> MalVal[]| { return r.addAll(v.value) })
+    return MalList(a.reduce(MalVal[,]) |MalVal[] r, MalSeq v -> MalVal[]| { r.addAll(v.value) })
   }
 
   static private MalVal apply(MalVal[] a)

--- a/impls/fantom/src/mallib/fan/interop.fan
+++ b/impls/fantom/src/mallib/fan/interop.fan
@@ -47,9 +47,13 @@ internal class Interop
     else if (obj is Int)
       return MalInteger((Int)obj)
     else if (obj is List)
-      return MalList((obj as List).map { fantomToMal(it) })
+      return MalList((obj as List).map |Obj? e -> MalVal| { fantomToMal(e) })
     else if (obj is Map)
-      return MalHashMap.fromMap((obj as Map).map { fantomToMal(it) })
+    {
+      m := [Str:MalVal][:]
+      (obj as Map).each |v, k| { m.set(k.toStr, fantomToMal(v)) }
+      return MalHashMap.fromMap(m)
+    }
     else
       return MalString.make(obj.toStr)
   }

--- a/impls/fantom/src/mallib/fan/types.fan
+++ b/impls/fantom/src/mallib/fan/types.fan
@@ -82,7 +82,7 @@ class MalString : MalValBase
 {
   const Str value
   new make(Str v) { value = v }
-  new makeKeyword(Str v) { value = "\u029e$v" }
+  new makeKeyword(Str v) { value = v[0] == '\u029e' ? v : "\u029e$v" }
   override Bool equals(Obj? that) { return that is MalString && (that as MalString).value == value }
   override Str toString(Bool readable)
   {

--- a/impls/fantom/src/mallib/fan/types.fan
+++ b/impls/fantom/src/mallib/fan/types.fan
@@ -119,7 +119,7 @@ abstract class MalSeq : MalValBase
   MalVal nth(Int index) { return index < count ? get(index) : throw Err("nth: index out of range") }
   MalVal first() { return isEmpty ? MalNil.INSTANCE : value[0] }
   MalList rest() { return MalList(isEmpty ? [,] : value[1..-1]) }
-  MalList map(MalFunc f) { return MalList(value.map { f.call([it]) } ) }
+  MalList map(MalFunc f) { return MalList(value.map |MalVal v -> MalVal| { f.call([v]) } ) }
   abstract MalSeq conj(MalVal[] args)
 }
 
@@ -165,7 +165,7 @@ class MalHashMap : MalValBase
   @Operator MalVal get(Str key) { return value[key] }
   MalVal get2(MalString key, MalVal? def := null) { return value.get(key.value, def) }
   Bool containsKey(MalString key) { return value.containsKey(key.value) }
-  MalVal[] keys() { return value.keys.map { MalString.make(it) } }
+  MalVal[] keys() { return value.keys.map |Str k -> MalVal| { MalString.make(k) } }
   MalVal[] vals() { return value.vals }
   MalHashMap assoc(MalVal[] args)
   {

--- a/impls/fantom/src/step2_eval/fan/main.fan
+++ b/impls/fantom/src/step2_eval/fan/main.fan
@@ -16,10 +16,10 @@ class Main
         varVal := env[varName] ?: throw Err("'$varName' not found")
         return (MalVal)varVal
       case MalList#:
-        newElements := (ast as MalList).value.map { EVAL(it, env) }
+        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalList(newElements)
       case MalVector#:
-        newElements := (ast as MalVector).value.map { EVAL(it, env) }
+        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
         newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }

--- a/impls/fantom/src/step2_eval/fan/main.fan
+++ b/impls/fantom/src/step2_eval/fan/main.fan
@@ -22,7 +22,7 @@ class Main
         newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }
+        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalHashMap.fromMap(newElements)
       default:
         return ast

--- a/impls/fantom/src/step3_env/fan/main.fan
+++ b/impls/fantom/src/step3_env/fan/main.fan
@@ -20,7 +20,7 @@ class Main
         newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }
+        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalHashMap.fromMap(newElements)
       default:
         return ast

--- a/impls/fantom/src/step3_env/fan/main.fan
+++ b/impls/fantom/src/step3_env/fan/main.fan
@@ -14,10 +14,10 @@ class Main
       case MalSymbol#:
         return env.get(ast)
       case MalList#:
-        newElements := (ast as MalList).value.map { EVAL(it, env) }
+        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalList(newElements)
       case MalVector#:
-        newElements := (ast as MalVector).value.map { EVAL(it, env) }
+        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
         newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }

--- a/impls/fantom/src/step4_if_fn_do/fan/main.fan
+++ b/impls/fantom/src/step4_if_fn_do/fan/main.fan
@@ -20,7 +20,7 @@ class Main
         newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }
+        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalHashMap.fromMap(newElements)
       default:
         return ast

--- a/impls/fantom/src/step4_if_fn_do/fan/main.fan
+++ b/impls/fantom/src/step4_if_fn_do/fan/main.fan
@@ -14,10 +14,10 @@ class Main
       case MalSymbol#:
         return env.get(ast)
       case MalList#:
-        newElements := (ast as MalList).value.map { EVAL(it, env) }
+        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalList(newElements)
       case MalVector#:
-        newElements := (ast as MalVector).value.map { EVAL(it, env) }
+        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
         newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }

--- a/impls/fantom/src/step5_tco/fan/main.fan
+++ b/impls/fantom/src/step5_tco/fan/main.fan
@@ -20,7 +20,7 @@ class Main
         newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }
+        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalHashMap.fromMap(newElements)
       default:
         return ast

--- a/impls/fantom/src/step5_tco/fan/main.fan
+++ b/impls/fantom/src/step5_tco/fan/main.fan
@@ -14,10 +14,10 @@ class Main
       case MalSymbol#:
         return env.get(ast)
       case MalList#:
-        newElements := (ast as MalList).value.map { EVAL(it, env) }
+        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalList(newElements)
       case MalVector#:
-        newElements := (ast as MalVector).value.map { EVAL(it, env) }
+        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
         newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }

--- a/impls/fantom/src/step6_file/fan/main.fan
+++ b/impls/fantom/src/step6_file/fan/main.fan
@@ -20,7 +20,7 @@ class Main
         newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }
+        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalHashMap.fromMap(newElements)
       default:
         return ast

--- a/impls/fantom/src/step6_file/fan/main.fan
+++ b/impls/fantom/src/step6_file/fan/main.fan
@@ -14,10 +14,10 @@ class Main
       case MalSymbol#:
         return env.get(ast)
       case MalList#:
-        newElements := (ast as MalList).value.map { EVAL(it, env) }
+        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalList(newElements)
       case MalVector#:
-        newElements := (ast as MalVector).value.map { EVAL(it, env) }
+        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
         newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }

--- a/impls/fantom/src/step7_quote/fan/main.fan
+++ b/impls/fantom/src/step7_quote/fan/main.fan
@@ -36,7 +36,7 @@ class Main
         newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }
+        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalHashMap.fromMap(newElements)
       default:
         return ast

--- a/impls/fantom/src/step7_quote/fan/main.fan
+++ b/impls/fantom/src/step7_quote/fan/main.fan
@@ -30,10 +30,10 @@ class Main
       case MalSymbol#:
         return env.get(ast)
       case MalList#:
-        newElements := (ast as MalList).value.map { EVAL(it, env) }
+        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalList(newElements)
       case MalVector#:
-        newElements := (ast as MalVector).value.map { EVAL(it, env) }
+        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
         newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }

--- a/impls/fantom/src/step8_macros/fan/main.fan
+++ b/impls/fantom/src/step8_macros/fan/main.fan
@@ -51,10 +51,10 @@ class Main
       case MalSymbol#:
         return env.get(ast)
       case MalList#:
-        newElements := (ast as MalList).value.map { EVAL(it, env) }
+        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalList(newElements)
       case MalVector#:
-        newElements := (ast as MalVector).value.map { EVAL(it, env) }
+        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
         newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }

--- a/impls/fantom/src/step8_macros/fan/main.fan
+++ b/impls/fantom/src/step8_macros/fan/main.fan
@@ -57,7 +57,7 @@ class Main
         newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }
+        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalHashMap.fromMap(newElements)
       default:
         return ast

--- a/impls/fantom/src/step8_macros/fan/main.fan
+++ b/impls/fantom/src/step8_macros/fan/main.fan
@@ -91,7 +91,7 @@ class Main
           ast = quasiquote(astList[1])
           // TCO
         case "defmacro!":
-          f := EVAL(astList[2], env) as MalUserFunc
+          f := (EVAL(astList[2], env) as MalUserFunc).dup
           f.isMacro = true
           return env.set(astList[1], f)
         case "macroexpand":

--- a/impls/fantom/src/step9_try/fan/main.fan
+++ b/impls/fantom/src/step9_try/fan/main.fan
@@ -51,10 +51,10 @@ class Main
       case MalSymbol#:
         return env.get(ast)
       case MalList#:
-        newElements := (ast as MalList).value.map { EVAL(it, env) }
+        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalList(newElements)
       case MalVector#:
-        newElements := (ast as MalVector).value.map { EVAL(it, env) }
+        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
         newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }

--- a/impls/fantom/src/step9_try/fan/main.fan
+++ b/impls/fantom/src/step9_try/fan/main.fan
@@ -57,7 +57,7 @@ class Main
         newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }
+        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalHashMap.fromMap(newElements)
       default:
         return ast

--- a/impls/fantom/src/step9_try/fan/main.fan
+++ b/impls/fantom/src/step9_try/fan/main.fan
@@ -91,7 +91,7 @@ class Main
           ast = quasiquote(astList[1])
           // TCO
         case "defmacro!":
-          f := EVAL(astList[2], env) as MalUserFunc
+          f := (EVAL(astList[2], env) as MalUserFunc).dup
           f.isMacro = true
           return env.set(astList[1], f)
         case "macroexpand":

--- a/impls/fantom/src/stepA_mal/fan/main.fan
+++ b/impls/fantom/src/stepA_mal/fan/main.fan
@@ -51,10 +51,10 @@ class Main
       case MalSymbol#:
         return env.get(ast)
       case MalList#:
-        newElements := (ast as MalList).value.map { EVAL(it, env) }
+        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalList(newElements)
       case MalVector#:
-        newElements := (ast as MalVector).value.map { EVAL(it, env) }
+        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
         newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }

--- a/impls/fantom/src/stepA_mal/fan/main.fan
+++ b/impls/fantom/src/stepA_mal/fan/main.fan
@@ -57,7 +57,7 @@ class Main
         newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalVector(newElements)
       case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { return EVAL(v, env) }
+        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
         return MalHashMap.fromMap(newElements)
       default:
         return ast

--- a/impls/fantom/src/stepA_mal/fan/main.fan
+++ b/impls/fantom/src/stepA_mal/fan/main.fan
@@ -91,7 +91,7 @@ class Main
           ast = quasiquote(astList[1])
           // TCO
         case "defmacro!":
-          f := EVAL(astList[2], env) as MalUserFunc
+          f := (EVAL(astList[2], env) as MalUserFunc).dup
           f.isMacro = true
           return env.set(astList[1], f)
         case "macroexpand":

--- a/impls/fantom/tests/stepA_mal.mal
+++ b/impls/fantom/tests/stepA_mal.mal
@@ -15,8 +15,14 @@
 (fantom-eval "[7,8,9]")
 ;=>(7 8 9)
 
+(= () (fantom-eval "[,]"))
+;=>true
+
 (fantom-eval "[\"abc\": 789]")
 ;=>{"abc" 789}
+
+(= {} (fantom-eval "[:]"))
+;=>true
 
 (fantom-eval "echo(\"hello\")")
 ;/hello

--- a/impls/tests/step1_read_print.mal
+++ b/impls/tests/step1_read_print.mal
@@ -134,6 +134,8 @@ false
 ;=>"}"
 "~"
 ;=>"~"
+"!"
+;=>"!"
 
 ;; Testing reader errors
 (1 2
@@ -281,8 +283,3 @@ false
 ;=>1
 ;;; Hopefully less problematic characters
 1; &()*+,-./:;<=>?@[]^_{|}~
-
-;; FIXME: These tests have no reasons to be optional, but...
-;; fantom fails this one
-"!"
-;=>"!"


### PR DESCRIPTION
* Fix #513 in Fantom and similar problems with Fantom's interop (all related to empty lists and hash-maps)
* Fix broken step1 (and step6) test involving a `!` char - requires rebuilding the Docker image because I've added a java config option to disable jLine's expand events. I've also moved that test to be mandatory in step1 (because the comment said that fantom is the only offender)
* Fix step9 optional test - `(keyword :abc)`
* Fix stepA optional test - defmacro! doesn't mutate the original function
