### PR TITLE
Test equality of other kinds of empty list

### DIFF
--- a/impls/tests/step7_quote.mal
+++ b/impls/tests/step7_quote.mal
@@ -27,6 +27,8 @@ a
 ;=>()
 (concat (list) (list))
 ;=>()
+(= () (concat))
+;=>true
 
 (def! a (list 1 2))
 (def! b (list 3 4))

--- a/impls/tests/step9_try.mal
+++ b/impls/tests/step9_try.mal
@@ -174,6 +174,8 @@
 ;=>false
 (vector 3 4 5)
 ;=>[3 4 5]
+(= [] (vector))
+;=>true
 
 (map? {})
 ;=>true
@@ -368,6 +370,8 @@
 ;;
 ;; Testing equality of hash-maps
 (= {} {})
+;=>true
+(= {} (hash-map))
 ;=>true
 (= {:a 11 :b 22} (hash-map :b 22 :a 11))
 ;=>true

--- a/impls/tests/step9_try.mal
+++ b/impls/tests/step9_try.mal
@@ -94,6 +94,8 @@
 ;=>(2 4 6)
 (map (fn* (x) (symbol? x)) (list 1 (quote two) "three"))
 ;=>(false true false)
+(= () (map str ()))
+;=>true
 
 ;>>> deferrable=True
 ;;
@@ -237,6 +239,8 @@
 ;;; TODO: fix. Clojure returns nil but this breaks mal impl
 (keys hm1)
 ;=>()
+(= () (keys hm1))
+;=>true
 
 (keys hm2)
 ;=>("a")
@@ -247,6 +251,8 @@
 ;;; TODO: fix. Clojure returns nil but this breaks mal impl
 (vals hm1)
 ;=>()
+(= () (vals hm1))
+;=>true
 
 (vals hm2)
 ;=>(1)


### PR DESCRIPTION
In #513, @dubek noted two additional ways to make empty lists in fantom that compare different from an empty list made by evaluating an empty list.  This adds tests for those, along with another two that might fail similarly (but don't in fantom).