### PR TITLE
haskell: clarify reader

### DIFF
--- a/impls/haskell/Env.hs
+++ b/impls/haskell/Env.hs
@@ -25,7 +25,7 @@ env_apply outer keys values = (: outer) . Constant <$> bind keys values Map.empt
 
 bind :: [MalVal] -> [MalVal] -> Map.Map String MalVal -> Maybe (Map.Map String MalVal)
 bind [MalSymbol "&", (MalSymbol k)] vs       m = Just $ Map.insert k (toList vs) m
-bind (MalSymbol k : ks)             (v : vs) m = Map.insert k v <$> bind ks vs m
+bind (MalSymbol k : ks)             (v : vs) m = bind ks vs $ Map.insert k v m
 bind []                             []       m = Just m
 bind _                              _        _ = Nothing
 

--- a/impls/haskell/Env.hs
+++ b/impls/haskell/Env.hs
@@ -1,36 +1,60 @@
 module Env
-( Env, env_new, env_bind, env_get, env_set )
+( Env, env_apply, env_get, env_let, env_put, env_repl, env_set )
 where
 
-import Data.IORef (modifyIORef, newIORef, readIORef)
-import qualified Data.Map  as Map
+import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
+import qualified Data.Map.Strict as Map
 
+import Printer (_pr_str)
 import Types
 
--- The Env type si defined in Types module to avoid dep cycle.
+data Binds = Variable (IORef (Map.Map String MalVal))
+           | Constant (Map.Map String MalVal)
 
-env_new :: Env -> IO Env
-env_new outer = (: outer) <$> newIORef (Map.fromList [])
+type Env = [Binds]
 
---  True means that the actual arguments match the signature.
-env_bind :: Env -> [String] -> [MalVal] -> IO Bool
-env_bind env (k : ks) (v : vs) | k /= "&" = do
-    env_set env k v
-    env_bind env ks vs
-env_bind env ["&", k] vs = do
-    env_set env k $ toList vs
-    return True
-env_bind _ [] [] = return True
-env_bind _ _ _ = return False
+env_repl :: IO Env
+env_repl = (: []) . Variable <$> newIORef Map.empty
+
+env_let :: Env -> IO Env
+env_let outer = (: outer) . Variable <$> newIORef Map.empty
+
+--  catch* should also use this
+env_apply :: Env -> [MalVal] -> [MalVal] -> Maybe (Env)
+env_apply outer keys values = (: outer) . Constant <$> bind keys values Map.empty
+
+bind :: [MalVal] -> [MalVal] -> Map.Map String MalVal -> Maybe (Map.Map String MalVal)
+bind [MalSymbol "&", (MalSymbol k)] vs       m = Just $ Map.insert k (toList vs) m
+bind (MalSymbol k : ks)             (v : vs) m = Map.insert k v <$> bind ks vs m
+bind []                             []       m = Just m
+bind _                              _        _ = Nothing
 
 env_get :: Env -> String -> IO (Maybe MalVal)
-env_get [] _ = return Nothing
-env_get (ref : outer) key = do
-    hm <- readIORef ref
-    case Map.lookup key hm of
-        Nothing -> env_get outer key
-        justVal -> return justVal
+env_get env key = loop env where
+  loop :: Env -> IO (Maybe MalVal)
+  loop [] = return Nothing
+  loop (Constant m : outer) = case Map.lookup key m of
+    Nothing -> loop outer
+    justVal -> return justVal
+  loop (Variable ref : outer) = do
+    m <- readIORef ref
+    case Map.lookup key m of
+      Nothing -> loop outer
+      justVal -> return justVal
 
+--  def! and let*
 env_set :: Env -> String -> MalVal -> IO ()
-env_set (ref : _) key val = modifyIORef ref $ Map.insert key val
-env_set [] _ _ = error "assertion failed in env_set"
+env_set (Variable ref : _) key value = modifyIORef ref $ Map.insert key value
+env_set _         _   _     = error "assertion failed in env.env_set"
+
+put1 :: (String, MalVal) -> IO ()
+put1 (key, value) = do
+  putChar ' '
+  putStr key
+  putChar ':'
+  putStr =<< _pr_str True value
+
+env_put :: Env -> IO ()
+env_put []        = error "assertion failed in Env.env_format"
+env_put (Variable ref : _) = mapM_ put1 =<< Map.assocs <$> readIORef ref
+env_put (Constant m : _) = mapM_ put1 $ Map.assocs m

--- a/impls/haskell/Printer.hs
+++ b/impls/haskell/Printer.hs
@@ -2,47 +2,37 @@ module Printer
 ( _pr_str, _pr_list )
 where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import Data.IORef (readIORef)
+import Data.List (intercalate)
 
 import Types
 
 _pr_list :: Bool -> String -> [MalVal] -> IO String
-_pr_list _  _   []     = return $ []
-_pr_list pr _   [x]    = _pr_str pr x
-_pr_list pr sep (x:xs) = format <$> _pr_str pr x <*> _pr_list pr sep xs where
-    format l r = l ++ sep ++ r
+_pr_list pr sep = fmap (intercalate sep) . mapM (_pr_str pr)
 
-_flatTuples :: [(String, MalVal)] -> [MalVal]
-_flatTuples ((a,b):xs) = MalString a : b : _flatTuples xs
-_flatTuples _          = []
+enclose :: String -> String -> String -> String
+enclose open close middle = open ++ middle ++ close
 
-unescape :: Char -> String
-unescape '\n' = "\\n"
-unescape '\\' = "\\\\"
-unescape '"'  = "\\\""
-unescape c    = [c]
+escape :: Char -> String -> String
+escape '\n' acc = '\\' : 'n'  : acc
+escape '\\' acc = '\\' : '\\' : acc
+escape '"'  acc = '\\' : '"'  : acc
+escape c    acc = c           : acc
 
 _pr_str :: Bool -> MalVal -> IO String
-_pr_str _     (MalString (c : cs)) | c == keywordMagic
-                                 = return $ ':' : cs
-_pr_str True  (MalString str)    = return $ "\"" ++ concatMap unescape str ++ "\""
+_pr_str _     (MalKeyword kwd)   = return $ ':' : kwd
+_pr_str True  (MalString str)    = return $ enclose "\"" "\"" $ foldr escape [] str
 _pr_str False (MalString str)    = return str
 _pr_str _     (MalSymbol name)   = return name
 _pr_str _     (MalNumber num)    = return $ show num
 _pr_str _     (MalBoolean True)  = return "true"
-_pr_str _     (MalBoolean False) = return $ "false"
+_pr_str _     (MalBoolean False) = return "false"
 _pr_str _     Nil                = return "nil"
-_pr_str pr (MalSeq _ (Vect False) items) = format <$> _pr_list pr " " items where
-    format x = "(" ++ x ++ ")"
-_pr_str pr (MalSeq _ (Vect True)  items) = format <$> _pr_list pr " " items where
-    format x = "[" ++ x ++ "]"
-_pr_str pr (MalHashMap _ m) = format <$> _pr_list pr " " (_flatTuples $ Map.assocs m) where
-    format x = "{" ++ x ++ "}"
-_pr_str pr (MalAtom _ r) = format  <$> (_pr_str pr =<< readIORef r) where
-    format x = "(atom " ++ x ++ ")"
-_pr_str _ (MalFunction {f_ast=Nil}) = pure "#<function>"
-_pr_str _ (MalFunction {f_ast=a, f_params=p, macro=False}) = format <$> _pr_str True a where
-    format x = "(fn* " ++ show p ++ " -> " ++ x ++ ")"
-_pr_str _ (MalFunction {f_ast=a, f_params=p, macro=True})  = format <$> _pr_str True a where
-    format x = "(macro* " ++ show p ++ " -> " ++ x ++ ")"
+_pr_str pr (MalSeq _ (Vect False) xs) = enclose "(" ")" <$> _pr_list pr " " xs
+_pr_str pr (MalSeq _ (Vect True)  xs) = enclose "[" "]" <$> _pr_list pr " " xs
+_pr_str pr (MalHashMap _ m)      = enclose "{" "}" <$> _pr_list pr " "
+                                    (Map.foldMapWithKey (\k v -> [decodeKey k, v]) m)
+_pr_str pr (MalAtom _ r)         = enclose "(atom " ")" <$> (_pr_str pr =<< readIORef r)
+_pr_str _ (MalFunction _ _)      = return "<fn>"
+_pr_str _ (MalMacro _)           = return "<macro>"

--- a/impls/haskell/Reader.hs
+++ b/impls/haskell/Reader.hs
@@ -3,109 +3,97 @@ module Reader
 where
 
 import Text.ParserCombinators.Parsec (
-    Parser, parse, char, digit, letter, try,
-    (<|>), oneOf, noneOf, many, many1, skipMany, skipMany1, sepEndBy, string)
+    Parser, (<|>), anyChar, char, digit, many, many1, noneOf, oneOf, parse)
 import qualified Data.Map as Map
 
 import Types
 
-spaces :: Parser ()
-spaces = skipMany1 (oneOf ", \n")
+--  Helpers
 
-comment :: Parser ()
-comment = char ';' *> skipMany (noneOf "\r\n")
+symbolFalseTrueNil :: String -> MalVal
+symbolFalseTrueNil "true"  = MalBoolean True
+symbolFalseTrueNil "false" = MalBoolean False
+symbolFalseTrueNil "nil"   = Nil
+symbolFalseTrueNil s       = MalSymbol s
 
-ignored :: Parser ()
-ignored = skipMany (spaces <|> comment)
+addPrefix :: String -> MalVal -> MalVal
+addPrefix s m = toList [MalSymbol s, m]
 
-symbol :: Parser Char
-symbol = oneOf "!#$%&|*+-/:<=>?@^_~"
+with_meta :: MalVal -> MalVal -> MalVal
+with_meta m x = toList [MalSymbol "with-meta", x, m]
 
-escaped :: Parser Char
-escaped = f <$> (char '\\' *> oneOf "\\\"n")
-    where f 'n' = '\n'
-          f x   = x
-
-read_number :: Parser MalVal
-read_number = MalNumber . read <$> many1 digit
-
-read_negative_number :: Parser MalVal
-read_negative_number = f <$> char '-' <*> many1 digit
-    where f sign rest = MalNumber $ read $ sign : rest
-
-read_string :: Parser MalVal
-read_string = MalString <$> (char '"' *> many (escaped <|> noneOf "\\\"") <* char '"')
-
-read_symbol :: Parser MalVal
-read_symbol = f <$> (letter <|> symbol) <*> many (letter <|> digit <|> symbol)
-    where f first rest = g (first : rest)
-          g "true"     = MalBoolean True
-          g "false"    = MalBoolean False
-          g "nil"      = Nil
-          g s          = MalSymbol s
-
-read_keyword :: Parser MalVal
-read_keyword = MalString . (:) keywordMagic <$> (char ':' *> many (letter <|> digit <|> symbol))
-
-read_atom :: Parser MalVal
-read_atom =  read_number
-         <|> try read_negative_number
-         <|> read_string
-         <|> read_keyword
-         <|> read_symbol
-
-read_list :: Parser MalVal
-read_list = toList <$> (char '(' *> ignored *> sepEndBy read_form ignored <* char ')')
-
-read_vector :: Parser MalVal
-read_vector = MalSeq (MetaData Nil) (Vect True) <$> (char '[' *> ignored *> sepEndBy read_form ignored <* char ']')
-
-read_hash_map :: Parser MalVal
-read_hash_map = g . keyValuePairs =<< (char '{' *> ignored *> sepEndBy read_form ignored <* char '}')
-    where g (Just pairs) = return $ MalHashMap (MetaData Nil) (Map.fromList pairs)
+hash_map         :: [MalVal] -> Parser MalVal
+hash_map = g . keyValuePairs
+    where
+          g (Just pairs) = return $ MalHashMap (MetaData Nil) $ Map.fromList pairs
           g Nothing      = fail "invalid contents inside map braces"
 
--- reader macros
-addPrefix :: String -> MalVal -> MalVal
-addPrefix s x = toList [MalSymbol s, x]
+toKeyword :: String -> MalVal
+toKeyword = MalString . (:) keywordMagic
 
-read_quote :: Parser MalVal
-read_quote = addPrefix "quote" <$> (char '\'' *> read_form)
+toVector :: [MalVal] -> MalVal
+toVector = MalSeq (MetaData Nil) (Vect True)
 
-read_quasiquote :: Parser MalVal
-read_quasiquote = addPrefix "quasiquote" <$> (char '`' *> read_form)
+--  Parsing
 
-read_splice_unquote :: Parser MalVal
-read_splice_unquote = addPrefix "splice-unquote" <$> (string "~@" *> read_form)
+--  For efficiency, <|> expects each choice in an alternative to
+--  * either succeed,
+--  * or fall after looking only at the next character
+--  * or consume some input and fail for incorrect input.
 
-read_unquote :: Parser MalVal
-read_unquote = addPrefix "unquote" <$> (char '~' *> read_form)
+--  The grammar should be human-readable in the first and third column
+--  without former knowledge of Haskell, except these two regex-style
+--  combinators:
+--  many  p = (many1 p) | empty     AKA p*, zero or more p
+--  many1 p = p (many p)            AKA p+, one or more p
 
-read_deref :: Parser MalVal
-read_deref = addPrefix "deref" <$> (char '@' *> read_form)
+allowedChar    :: Parser Char
+allowedChar =                                 noneOf "\n\r \"(),;[\\]{}"
 
-read_with_meta :: Parser MalVal
-read_with_meta = f <$> (char '^' *> read_form) <*> read_form
-    where f m x = toList [MalSymbol "with-meta", x, m]
+separChar      :: Parser ()
+separChar   =  ()                         <$  oneOf "\n ,"
+          <|>  ()                         <$  char ';' <* many (noneOf "\n")
 
-read_macro :: Parser MalVal
-read_macro = read_quote
-         <|> read_quasiquote
-         <|> try read_splice_unquote <|> read_unquote
-         <|> read_deref
-         <|> read_with_meta
+sep            :: Parser ()
+sep         =  ()                         <$  many separChar
+--  A comment may also reach the end of the input. The terminator, if
+--  present, will be consumed by the first option later anyway.
 
---
+escapedChar    :: Parser Char
+escapedChar =  '\n'                       <$  char 'n'
+          <|>                                 anyChar
 
-read_form :: Parser MalVal
-read_form = ignored *> (
-         read_macro
-     <|> read_list
-     <|> read_vector
-     <|> read_hash_map
-     <|> read_atom)
+stringChar     :: Parser Char
+stringChar  =                                 char '\\' *> escapedChar
+          <|>                                 noneOf "\""
+
+afterMinus     :: Parser MalVal
+afterMinus  =  MalNumber . negate . read  <$> many1 digit
+          <|>  MalSymbol . (:) '-'        <$> many allowedChar
+
+afterTilde     :: Parser MalVal
+afterTilde  =  addPrefix "splice-unquote" <$> (char '@' *> sep *> form)
+          <|>  addPrefix "unquote"        <$> (sep *> form)
+
+form           :: Parser MalVal
+form        =  MalString                  <$> (char '"' *> many stringChar <* char '"')
+          <|>  addPrefix "quote"          <$> (char '\'' *> sep *> form)
+          <|>  toList                     <$> (char '(' *> sep *> many (form <* sep) <* char ')')
+          <|>                                 char '-' *> afterMinus
+          <|>  MalNumber . read           <$> many1 digit
+          <|>  toKeyword                  <$> (char ':' *> many1 allowedChar)
+          <|>  addPrefix "deref"          <$> (char '@' *> sep *> form)
+          <|>  toVector                   <$> (char '[' *> sep *> many (form <* sep) <* char ']')
+          <|>  with_meta                  <$> (char '^' *> sep *> form <* sep) <*> form
+          <|>  addPrefix "quasiquote"     <$> (char '`' *> sep *> form)
+          <|>  (hash_map                  =<< char '{' *> sep *> many (form <* sep) <* char '}')
+          <|>                                 char '~' *> afterTilde
+          <|>  symbolFalseTrueNil         <$> many1 allowedChar
+
+top            :: Parser MalVal
+top         =                                 sep *> form
 
 read_str :: String -> IOThrows MalVal
-read_str str = case parse read_form "Mal" str of
+read_str str = case parse top "Mal" str of
     Left err -> throwStr $ show err
     Right val -> return val

--- a/impls/haskell/step1_read_print.hs
+++ b/impls/haskell/step1_read_print.hs
@@ -1,6 +1,5 @@
 import System.IO (hFlush, stdout)
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.Except (liftIO, runExceptT)
 
 import Readline (addHistory, readline, load_history)
 import Types
@@ -20,7 +19,7 @@ eval = id
 -- print
 
 mal_print :: MalVal -> IOThrows String
-mal_print = liftIO. Printer._pr_str True
+mal_print = liftIO . Printer._pr_str True
 
 -- repl
 

--- a/impls/haskell/step2_eval.hs
+++ b/impls/haskell/step2_eval.hs
@@ -1,13 +1,17 @@
 import System.IO (hFlush, stdout)
-import Control.Monad ((<=<))
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.Except (liftIO, runExceptT)
 import qualified Data.Map as Map
 
 import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
-import Printer (_pr_str)
+import Printer (_pr_list, _pr_str)
+
+--
+--  Set this to True for a trace of each call to Eval.
+--
+traceEval :: Bool
+traceEval = False
 
 -- read
 
@@ -16,32 +20,35 @@ mal_read = read_str
 
 -- eval
 
--- eval_ast is replaced with pattern matching.
-
-apply_ast :: [MalVal] -> IOThrows MalVal
-
-apply_ast [] = return $ toList []
-
-apply_ast ast = do
-    evd <- mapM eval ast
+apply_ast :: MalVal -> [MalVal] -> IOThrows MalVal
+apply_ast first rest = do
+    evd <- eval first
     case evd of
-        MalFunction {fn=f} : args -> f args
-        _ -> throwStr . (++) "invalid apply: " =<< liftIO (Printer._pr_str True (toList ast))
+        MalFunction _ f -> f =<< mapM eval rest
+        _               -> throwStr . (++) "invalid apply: " =<< liftIO (_pr_list True " " $ first : rest)
 
 eval :: MalVal -> IOThrows MalVal
-eval (MalSymbol sym)            = do
-    case Map.lookup sym repl_env of
-        Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
-        Just val -> return val
-eval (MalSeq _ (Vect False) xs) = apply_ast xs
-eval (MalSeq m (Vect True)  xs) = MalSeq m (Vect True) <$> mapM eval xs
-eval (MalHashMap m xs)          = MalHashMap m         <$> mapM eval xs
-eval ast                        = return ast
+eval ast = do
+    case traceEval of
+        True -> liftIO $ do
+            putStr "EVAL: "
+            putStrLn =<< _pr_str True ast
+            hFlush stdout
+        False -> pure ()
+    case ast of
+        MalSymbol sym -> do
+            case Map.lookup sym repl_env of
+                Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
+                Just val -> return val
+        MalSeq _ (Vect False) (a1 : as) -> apply_ast a1 as
+        MalSeq _ (Vect True)  xs        -> MalSeq (MetaData Nil) (Vect True) <$> mapM eval xs
+        MalHashMap _ xs                 -> MalHashMap (MetaData Nil) <$> mapM eval xs
+        _ -> return ast
 
 -- print
 
 mal_print :: MalVal -> IOThrows String
-mal_print = liftIO. Printer._pr_str True
+mal_print = liftIO . Printer._pr_str True
 
 -- repl
 
@@ -68,7 +75,7 @@ repl_env = Map.fromList [("+", _func add),
                          ("/", _func divd)]
 
 rep :: String -> IOThrows String
-rep = mal_print <=< eval <=< mal_read
+rep line = mal_print =<< eval =<< mal_read line
 
 repl_loop :: IO ()
 repl_loop = do
@@ -87,7 +94,7 @@ repl_loop = do
             repl_loop
 
 _func :: Fn -> MalVal
-_func f = MalFunction {fn=f, f_ast=Nil, f_params=[], macro=False, meta=Nil}
+_func f = MalFunction (MetaData Nil) f
 
 main :: IO ()
 main = do

--- a/impls/haskell/step3_env.hs
+++ b/impls/haskell/step3_env.hs
@@ -1,13 +1,17 @@
 import System.IO (hFlush, stdout)
-import Control.Monad ((<=<))
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.Except (liftIO, runExceptT)
 
 import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
-import Printer (_pr_str)
-import Env (env_new, env_get, env_set)
+import Printer (_pr_list, _pr_str)
+import Env (Env, env_get, env_let, env_put, env_repl, env_set)
+
+--
+--  Set this to True for a trace of each call to Eval.
+--
+traceEval :: Bool
+traceEval = False
 
 -- read
 
@@ -16,8 +20,6 @@ mal_read = read_str
 
 -- eval
 
--- eval_ast is replaced with pattern matching.
-
 let_bind :: Env -> [MalVal] -> IOThrows ()
 let_bind _ [] = return ()
 let_bind env (MalSymbol b : e : xs) = do
@@ -25,43 +27,52 @@ let_bind env (MalSymbol b : e : xs) = do
     let_bind env xs
 let_bind _ _ = throwStr "invalid let*"
 
-apply_ast :: [MalVal] -> Env -> IOThrows MalVal
+apply_ast :: MalVal -> [MalVal] -> Env -> IOThrows MalVal
 
-apply_ast [] _ = return $ toList []
-
-apply_ast [MalSymbol "def!", MalSymbol a1, a2] env = do
+apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
     evd <- eval env a2
     liftIO $ env_set env a1 evd
     return evd
-apply_ast (MalSymbol "def!" : _) _ = throwStr "invalid def!"
+apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
-apply_ast [MalSymbol "let*", MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_new env
+apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
+    let_env <- liftIO $ env_let env
     let_bind let_env params
     eval let_env a2
-apply_ast (MalSymbol "let*" : _) _ = throwStr "invalid let*"
+apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
 
-apply_ast ast env = do
-    evd <- mapM (eval env) ast
+apply_ast first rest env = do
+    evd <- eval env first
     case evd of
-        MalFunction {fn=f} : args -> f args
-        _ -> throwStr . (++) "invalid apply: " =<< liftIO (Printer._pr_str True (toList ast))
+        MalFunction _ f -> f =<< mapM (eval env) rest
+        _               -> throwStr . (++) "invalid apply: " =<< liftIO (_pr_list True " " $ first : rest)
 
 eval :: Env -> MalVal -> IOThrows MalVal
-eval env (MalSymbol sym)            = do
-    maybeVal <- liftIO $ env_get env sym
-    case maybeVal of
-        Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
-        Just val -> return val
-eval env (MalSeq _ (Vect False) xs) = apply_ast xs env
-eval env (MalSeq m (Vect True)  xs) = MalSeq m (Vect True) <$> mapM (eval env) xs
-eval env (MalHashMap m xs)          = MalHashMap m         <$> mapM (eval env) xs
-eval _   ast                        = return ast
+eval env ast = do
+    case traceEval of
+        True -> liftIO $ do
+            putStr "EVAL: "
+            putStr =<< _pr_str True ast
+            putStr "   "
+            env_put env
+            putStrLn ""
+            hFlush stdout
+        False -> pure ()
+    case ast of
+        MalSymbol sym -> do
+            maybeVal <- liftIO $ env_get env sym
+            case maybeVal of
+                Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
+                Just val -> return val
+        MalSeq _ (Vect False) (a1 : as) -> apply_ast a1 as env
+        MalSeq _ (Vect True)  xs        -> MalSeq (MetaData Nil) (Vect True) <$> mapM (eval env) xs
+        MalHashMap _ xs                 -> MalHashMap (MetaData Nil) <$> mapM (eval env) xs
+        _ -> return ast
 
 -- print
 
 mal_print :: MalVal -> IOThrows String
-mal_print = liftIO. Printer._pr_str True
+mal_print = liftIO . Printer._pr_str True
 
 -- repl
 
@@ -82,7 +93,7 @@ divd [MalNumber a, MalNumber b] = return $ MalNumber $ a `div` b
 divd _ = throwStr $ "illegal arguments to /"
 
 rep :: Env -> String -> IOThrows String
-rep env = mal_print <=< eval env <=< mal_read
+rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -102,13 +113,13 @@ repl_loop env = do
 
 defBuiltIn :: Env -> String -> Fn -> IO ()
 defBuiltIn env sym f =
-    env_set env sym $ MalFunction {fn=f, f_ast=Nil, f_params=[], macro=False, meta=Nil}
+    env_set env sym $ MalFunction (MetaData Nil) f
 
 main :: IO ()
 main = do
     load_history
 
-    repl_env <- env_new []
+    repl_env <- env_repl
 
     defBuiltIn repl_env "+" add
     defBuiltIn repl_env "-" sub

--- a/impls/haskell/step6_file.hs
+++ b/impls/haskell/step6_file.hs
@@ -1,16 +1,20 @@
 import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
-import Control.Monad ((<=<))
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM)
 
 import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
-import Printer (_pr_str)
-import Env (env_new, env_bind, env_get, env_set)
+import Printer(_pr_list, _pr_str)
+import Env (Env, env_apply, env_get, env_let, env_put, env_repl, env_set)
 import Core (ns)
+
+--
+--  Set this to True for a trace of each call to Eval.
+--
+traceEval :: Bool
+traceEval = False
 
 -- read
 
@@ -19,8 +23,6 @@ mal_read = read_str
 
 -- eval
 
--- eval_ast is replaced with pattern matching.
-
 let_bind :: Env -> [MalVal] -> IOThrows ()
 let_bind _ [] = return ()
 let_bind env (MalSymbol b : e : xs) = do
@@ -28,80 +30,84 @@ let_bind env (MalSymbol b : e : xs) = do
     let_bind env xs
 let_bind _ _ = throwStr "invalid let*"
 
-unWrapSymbol :: MalVal -> IOThrows String
-unWrapSymbol (MalSymbol s) = return s
-unWrapSymbol _ = throwStr "fn* parameter must be symbols"
+apply_ast :: MalVal -> [MalVal] -> Env -> IOThrows MalVal
 
-newFunction :: MalVal -> Env -> [String] -> MalVal
-newFunction a env p = MalFunction {f_ast=a, f_params=p, macro=False, meta=Nil,
-    fn=(\args -> do
-        fn_env <- liftIO $ env_new env
-        ok <- liftIO $ env_bind fn_env p args
-        case ok of
-            True  -> eval fn_env a
-            False -> throwStr $ "actual parameters do not match signature " ++ show p)}
-
-apply_ast :: [MalVal] -> Env -> IOThrows MalVal
-
-apply_ast [] _ = return $ toList []
-
-apply_ast [MalSymbol "def!", MalSymbol a1, a2] env = do
+apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
     evd <- eval env a2
     liftIO $ env_set env a1 evd
     return evd
-apply_ast (MalSymbol "def!" : _) _ = throwStr "invalid def!"
+apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
-apply_ast [MalSymbol "let*", MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_new env
+apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
+    let_env <- liftIO $ env_let env
     let_bind let_env params
     eval let_env a2
-apply_ast (MalSymbol "let*" : _) _ = throwStr "invalid let*"
+apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
 
-apply_ast (MalSymbol "do" : args) env = foldlM (const $ eval env) Nil args
+apply_ast (MalSymbol "do") args env = foldlM (const $ eval env) Nil args
 
-apply_ast [MalSymbol "if", a1, a2, a3] env = do
+apply_ast (MalSymbol "if") [a1, a2, a3] env = do
     cond <- eval env a1
     eval env $ case cond of
         Nil              -> a3
         MalBoolean False -> a3
         _                -> a2
-apply_ast [MalSymbol "if", a1, a2] env = do
+apply_ast (MalSymbol "if") [a1, a2] env = do
     cond <- eval env a1
     case cond of
         Nil              -> return Nil
         MalBoolean False -> return Nil
         _                -> eval env a2
-apply_ast (MalSymbol "if" : _) _ = throwStr "invalid if"
+apply_ast (MalSymbol "if") _ _ = throwStr "invalid if"
 
-apply_ast [MalSymbol "fn*", MalSeq _ _ params, ast] env = newFunction ast env <$> mapM unWrapSymbol params
-apply_ast (MalSymbol "fn*" : _) _ = throwStr "invalid fn*"
+apply_ast (MalSymbol "fn*") [MalSeq _ _ params, ast] env = return $ MalFunction (MetaData Nil) fn where
+    fn :: [MalVal] -> IOThrows MalVal
+    fn args = do
+        case env_apply env params args of
+            Just fn_env -> eval fn_env ast
+            Nothing -> do
+                p <- liftIO $ _pr_list True " " params
+                a <- liftIO $ _pr_list True " " args
+                throwStr $ "actual parameters: " ++ a ++ " do not match signature: " ++ p
+apply_ast (MalSymbol "fn*") _ _ = throwStr "invalid fn*"
 
-apply_ast ast env = do
-    evd <- mapM (eval env) ast
+apply_ast first rest env = do
+    evd <- eval env first
     case evd of
-        MalFunction {fn=f} : args -> f args
-        _ -> throwStr . (++) "invalid apply: " =<< liftIO (Printer._pr_str True (toList ast))
+        MalFunction _ f -> f =<< mapM (eval env) rest
+        _               -> throwStr . (++) "invalid apply: " =<< liftIO (_pr_list True " " $ first : rest)
 
 eval :: Env -> MalVal -> IOThrows MalVal
-eval env (MalSymbol sym)            = do
-    maybeVal <- liftIO $ env_get env sym
-    case maybeVal of
-        Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
-        Just val -> return val
-eval env (MalSeq _ (Vect False) xs) = apply_ast xs env
-eval env (MalSeq m (Vect True)  xs) = MalSeq m (Vect True) <$> mapM (eval env) xs
-eval env (MalHashMap m xs)          = MalHashMap m         <$> mapM (eval env) xs
-eval _   ast                        = return ast
+eval env ast = do
+    case traceEval of
+        True -> liftIO $ do
+            putStr "EVAL: "
+            putStr =<< _pr_str True ast
+            putStr "   "
+            env_put env
+            putStrLn ""
+            hFlush stdout
+        False -> pure ()
+    case ast of
+        MalSymbol sym -> do
+            maybeVal <- liftIO $ env_get env sym
+            case maybeVal of
+                Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
+                Just val -> return val
+        MalSeq _ (Vect False) (a1 : as) -> apply_ast a1 as env
+        MalSeq _ (Vect True)  xs        -> MalSeq (MetaData Nil) (Vect True) <$> mapM (eval env) xs
+        MalHashMap _ xs                 -> MalHashMap (MetaData Nil) <$> mapM (eval env) xs
+        _ -> return ast
 
 -- print
 
 mal_print :: MalVal -> IOThrows String
-mal_print = liftIO. Printer._pr_str True
+mal_print = liftIO . Printer._pr_str True
 
 -- repl
 
 rep :: Env -> String -> IOThrows String
-rep env = mal_print <=< eval env <=< mal_read
+rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -130,7 +136,7 @@ re repl_env line = do
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()
 defBuiltIn env (sym, f) =
-    env_set env sym $ MalFunction {fn=f, f_ast=Nil, f_params=[], macro=False, meta=Nil}
+    env_set env sym $ MalFunction (MetaData Nil) f
 
 evalFn :: Env -> Fn
 evalFn env [ast] = eval env ast
@@ -141,7 +147,7 @@ main = do
     args <- getArgs
     load_history
 
-    repl_env <- env_new []
+    repl_env <- env_repl
 
     -- core.hs: defined using Haskell
     mapM_ (defBuiltIn repl_env) Core.ns

--- a/impls/haskell/step7_quote.hs
+++ b/impls/haskell/step7_quote.hs
@@ -1,16 +1,20 @@
 import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
-import Control.Monad ((<=<))
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM, foldrM)
 
 import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
-import Printer (_pr_str)
-import Env (env_new, env_bind, env_get, env_set)
+import Printer(_pr_list, _pr_str)
+import Env (Env, env_apply, env_get, env_let, env_put, env_repl, env_set)
 import Core (ns)
+
+--
+--  Set this to True for a trace of each call to Eval.
+--
+traceEval :: Bool
+traceEval = False
 
 -- read
 
@@ -18,8 +22,6 @@ mal_read :: String -> IOThrows MalVal
 mal_read = read_str
 
 -- eval
-
--- starts-with is replaced with pattern matching.
 
 qqIter :: MalVal -> MalVal -> IOThrows MalVal
 qqIter (MalSeq _ (Vect False) [MalSymbol "splice-unquote", x]) acc = return $ toList [MalSymbol "concat", x, acc]
@@ -39,8 +41,6 @@ quasiquote ast@(MalHashMap _ _) = return $ toList [MalSymbol "quote", ast]
 quasiquote ast@(MalSymbol _)    = return $ toList [MalSymbol "quote", ast]
 quasiquote ast = return ast
 
--- eval_ast is replaced with pattern matching.
-
 let_bind :: Env -> [MalVal] -> IOThrows ()
 let_bind _ [] = return ()
 let_bind env (MalSymbol b : e : xs) = do
@@ -48,89 +48,93 @@ let_bind env (MalSymbol b : e : xs) = do
     let_bind env xs
 let_bind _ _ = throwStr "invalid let*"
 
-unWrapSymbol :: MalVal -> IOThrows String
-unWrapSymbol (MalSymbol s) = return s
-unWrapSymbol _ = throwStr "fn* parameter must be symbols"
+apply_ast :: MalVal -> [MalVal] -> Env -> IOThrows MalVal
 
-newFunction :: MalVal -> Env -> [String] -> MalVal
-newFunction a env p = MalFunction {f_ast=a, f_params=p, macro=False, meta=Nil,
-    fn=(\args -> do
-        fn_env <- liftIO $ env_new env
-        ok <- liftIO $ env_bind fn_env p args
-        case ok of
-            True  -> eval fn_env a
-            False -> throwStr $ "actual parameters do not match signature " ++ show p)}
-
-apply_ast :: [MalVal] -> Env -> IOThrows MalVal
-
-apply_ast [] _ = return $ toList []
-
-apply_ast [MalSymbol "def!", MalSymbol a1, a2] env = do
+apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
     evd <- eval env a2
     liftIO $ env_set env a1 evd
     return evd
-apply_ast (MalSymbol "def!" : _) _ = throwStr "invalid def!"
+apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
-apply_ast [MalSymbol "let*", MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_new env
+apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
+    let_env <- liftIO $ env_let env
     let_bind let_env params
     eval let_env a2
-apply_ast (MalSymbol "let*" : _) _ = throwStr "invalid let*"
+apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
 
-apply_ast [MalSymbol "quote", a1] _ = return a1
-apply_ast (MalSymbol "quote" : _) _ = throwStr "invalid quote"
+apply_ast (MalSymbol "quote") [a1] _ = return a1
+apply_ast (MalSymbol "quote") _ _ = throwStr "invalid quote"
 
-apply_ast [MalSymbol "quasiquoteexpand", a1] _ = quasiquote a1
-apply_ast (MalSymbol "quasiquoteexpand" : _) _ = throwStr "invalid quasiquote"
+apply_ast (MalSymbol "quasiquoteexpand") [a1] _ = quasiquote a1
+apply_ast (MalSymbol "quasiquoteexpand") _ _ = throwStr "invalid quasiquote"
 
-apply_ast [MalSymbol "quasiquote", a1] env = eval env =<< quasiquote a1
-apply_ast (MalSymbol "quasiquote" : _) _ = throwStr "invalid quasiquote"
+apply_ast (MalSymbol "quasiquote") [a1] env = eval env =<< quasiquote a1
+apply_ast (MalSymbol "quasiquote") _ _ = throwStr "invalid quasiquote"
 
-apply_ast (MalSymbol "do" : args) env = foldlM (const $ eval env) Nil args
+apply_ast (MalSymbol "do") args env = foldlM (const $ eval env) Nil args
 
-apply_ast [MalSymbol "if", a1, a2, a3] env = do
+apply_ast (MalSymbol "if") [a1, a2, a3] env = do
     cond <- eval env a1
     eval env $ case cond of
         Nil              -> a3
         MalBoolean False -> a3
         _                -> a2
-apply_ast [MalSymbol "if", a1, a2] env = do
+apply_ast (MalSymbol "if") [a1, a2] env = do
     cond <- eval env a1
     case cond of
         Nil              -> return Nil
         MalBoolean False -> return Nil
         _                -> eval env a2
-apply_ast (MalSymbol "if" : _) _ = throwStr "invalid if"
+apply_ast (MalSymbol "if") _ _ = throwStr "invalid if"
 
-apply_ast [MalSymbol "fn*", MalSeq _ _ params, ast] env = newFunction ast env <$> mapM unWrapSymbol params
-apply_ast (MalSymbol "fn*" : _) _ = throwStr "invalid fn*"
+apply_ast (MalSymbol "fn*") [MalSeq _ _ params, ast] env = return $ MalFunction (MetaData Nil) fn where
+    fn :: [MalVal] -> IOThrows MalVal
+    fn args = do
+        case env_apply env params args of
+            Just fn_env -> eval fn_env ast
+            Nothing -> do
+                p <- liftIO $ _pr_list True " " params
+                a <- liftIO $ _pr_list True " " args
+                throwStr $ "actual parameters: " ++ a ++ " do not match signature: " ++ p
+apply_ast (MalSymbol "fn*") _ _ = throwStr "invalid fn*"
 
-apply_ast ast env = do
-    evd <- mapM (eval env) ast
+apply_ast first rest env = do
+    evd <- eval env first
     case evd of
-        MalFunction {fn=f} : args -> f args
-        _ -> throwStr . (++) "invalid apply: " =<< liftIO (Printer._pr_str True (toList ast))
+        MalFunction _ f -> f =<< mapM (eval env) rest
+        _               -> throwStr . (++) "invalid apply: " =<< liftIO (_pr_list True " " $ first : rest)
 
 eval :: Env -> MalVal -> IOThrows MalVal
-eval env (MalSymbol sym)            = do
-    maybeVal <- liftIO $ env_get env sym
-    case maybeVal of
-        Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
-        Just val -> return val
-eval env (MalSeq _ (Vect False) xs) = apply_ast xs env
-eval env (MalSeq m (Vect True)  xs) = MalSeq m (Vect True) <$> mapM (eval env) xs
-eval env (MalHashMap m xs)          = MalHashMap m         <$> mapM (eval env) xs
-eval _   ast                        = return ast
+eval env ast = do
+    case traceEval of
+        True -> liftIO $ do
+            putStr "EVAL: "
+            putStr =<< _pr_str True ast
+            putStr "   "
+            env_put env
+            putStrLn ""
+            hFlush stdout
+        False -> pure ()
+    case ast of
+        MalSymbol sym -> do
+            maybeVal <- liftIO $ env_get env sym
+            case maybeVal of
+                Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
+                Just val -> return val
+        MalSeq _ (Vect False) (a1 : as) -> apply_ast a1 as env
+        MalSeq _ (Vect True)  xs        -> MalSeq (MetaData Nil) (Vect True) <$> mapM (eval env) xs
+        MalHashMap _ xs                 -> MalHashMap (MetaData Nil) <$> mapM (eval env) xs
+        _ -> return ast
 
 -- print
 
 mal_print :: MalVal -> IOThrows String
-mal_print = liftIO. Printer._pr_str True
+mal_print = liftIO . Printer._pr_str True
 
 -- repl
 
 rep :: Env -> String -> IOThrows String
-rep env = mal_print <=< eval env <=< mal_read
+rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -159,7 +163,7 @@ re repl_env line = do
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()
 defBuiltIn env (sym, f) =
-    env_set env sym $ MalFunction {fn=f, f_ast=Nil, f_params=[], macro=False, meta=Nil}
+    env_set env sym $ MalFunction (MetaData Nil) f
 
 evalFn :: Env -> Fn
 evalFn env [ast] = eval env ast
@@ -170,7 +174,7 @@ main = do
     args <- getArgs
     load_history
 
-    repl_env <- env_new []
+    repl_env <- env_repl
 
     -- core.hs: defined using Haskell
     mapM_ (defBuiltIn repl_env) Core.ns

--- a/impls/haskell/step8_macros.hs
+++ b/impls/haskell/step8_macros.hs
@@ -1,16 +1,20 @@
 import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
-import Control.Monad ((<=<))
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM, foldrM)
 
 import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
-import Printer (_pr_str)
-import Env (env_new, env_bind, env_get, env_set)
+import Printer(_pr_list, _pr_str)
+import Env (Env, env_apply, env_get, env_let, env_put, env_repl, env_set)
 import Core (ns)
+
+--
+--  Set this to True for a trace of each call to Eval.
+--
+traceEval :: Bool
+traceEval = False
 
 -- read
 
@@ -18,8 +22,6 @@ mal_read :: String -> IOThrows MalVal
 mal_read = read_str
 
 -- eval
-
--- starts-with is replaced with pattern matching.
 
 qqIter :: MalVal -> MalVal -> IOThrows MalVal
 qqIter (MalSeq _ (Vect False) [MalSymbol "splice-unquote", x]) acc = return $ toList [MalSymbol "concat", x, acc]
@@ -39,17 +41,13 @@ quasiquote ast@(MalHashMap _ _) = return $ toList [MalSymbol "quote", ast]
 quasiquote ast@(MalSymbol _)    = return $ toList [MalSymbol "quote", ast]
 quasiquote ast = return ast
 
--- is-macro-call is replaced with pattern matching.
-
 macroexpand :: Env -> MalVal -> IOThrows MalVal
 macroexpand env ast@(MalSeq _ (Vect False) (MalSymbol a0 : args)) = do
     maybeMacro <- liftIO $ env_get env a0
     case maybeMacro of
-        Just (MalFunction {fn=f, macro=True}) -> macroexpand env =<< f args
+        Just (MalMacro f)                     -> macroexpand env =<< f args
         _                                     -> return ast
 macroexpand _ ast = return ast
-
--- eval_ast is replaced with pattern matching.
 
 let_bind :: Env -> [MalVal] -> IOThrows ()
 let_bind _ [] = return ()
@@ -58,105 +56,107 @@ let_bind env (MalSymbol b : e : xs) = do
     let_bind env xs
 let_bind _ _ = throwStr "invalid let*"
 
-unWrapSymbol :: MalVal -> IOThrows String
-unWrapSymbol (MalSymbol s) = return s
-unWrapSymbol _ = throwStr "fn* parameter must be symbols"
+apply_ast :: MalVal -> [MalVal] -> Env -> IOThrows MalVal
 
-newFunction :: MalVal -> Env -> [String] -> MalVal
-newFunction a env p = MalFunction {f_ast=a, f_params=p, macro=False, meta=Nil,
-    fn=(\args -> do
-        fn_env <- liftIO $ env_new env
-        ok <- liftIO $ env_bind fn_env p args
-        case ok of
-            True  -> eval fn_env a
-            False -> throwStr $ "actual parameters do not match signature " ++ show p)}
-
-apply_ast :: [MalVal] -> Env -> IOThrows MalVal
-
-apply_ast [] _ = return $ toList []
-
-apply_ast [MalSymbol "def!", MalSymbol a1, a2] env = do
+apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
     evd <- eval env a2
     liftIO $ env_set env a1 evd
     return evd
-apply_ast (MalSymbol "def!" : _) _ = throwStr "invalid def!"
+apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
-apply_ast [MalSymbol "let*", MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_new env
+apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
+    let_env <- liftIO $ env_let env
     let_bind let_env params
     eval let_env a2
-apply_ast (MalSymbol "let*" : _) _ = throwStr "invalid let*"
+apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
 
-apply_ast [MalSymbol "quote", a1] _ = return a1
-apply_ast (MalSymbol "quote" : _) _ = throwStr "invalid quote"
+apply_ast (MalSymbol "quote") [a1] _ = return a1
+apply_ast (MalSymbol "quote") _ _ = throwStr "invalid quote"
 
-apply_ast [MalSymbol "quasiquoteexpand", a1] _ = quasiquote a1
-apply_ast (MalSymbol "quasiquoteexpand" : _) _ = throwStr "invalid quasiquote"
+apply_ast (MalSymbol "quasiquoteexpand") [a1] _ = quasiquote a1
+apply_ast (MalSymbol "quasiquoteexpand") _ _ = throwStr "invalid quasiquote"
 
-apply_ast [MalSymbol "quasiquote", a1] env = eval env =<< quasiquote a1
-apply_ast (MalSymbol "quasiquote" : _) _ = throwStr "invalid quasiquote"
+apply_ast (MalSymbol "quasiquote") [a1] env = eval env =<< quasiquote a1
+apply_ast (MalSymbol "quasiquote") _ _ = throwStr "invalid quasiquote"
 
-apply_ast [MalSymbol "defmacro!", MalSymbol a1, a2] env = do
+apply_ast (MalSymbol "defmacro!") [MalSymbol a1, a2] env = do
     func <- eval env a2
     case func of
-        MalFunction {macro=False} -> do
-            let m = func {macro=True}
+        MalFunction _ f -> do
+            let m = MalMacro f
             liftIO $ env_set env a1 m
             return m
         _ -> throwStr "defmacro! on non-function"
-apply_ast (MalSymbol "defmacro!" : _) _ = throwStr "invalid defmacro!"
+apply_ast (MalSymbol "defmacro!") _ _ = throwStr "invalid defmacro!"
 
-apply_ast [MalSymbol "macroexpand", a1] env = macroexpand env a1
-apply_ast (MalSymbol "macroexpand" : _) _ = throwStr "invalid macroexpand"
+apply_ast (MalSymbol "macroexpand") [a1] env = macroexpand env  a1
+apply_ast (MalSymbol "macroexpand") _ _ = throwStr "invalid macroexpand"
 
-apply_ast (MalSymbol "do" : args) env = foldlM (const $ eval env) Nil args
+apply_ast (MalSymbol "do") args env = foldlM (const $ eval env) Nil args
 
-apply_ast [MalSymbol "if", a1, a2, a3] env = do
+apply_ast (MalSymbol "if") [a1, a2, a3] env = do
     cond <- eval env a1
     eval env $ case cond of
         Nil              -> a3
         MalBoolean False -> a3
         _                -> a2
-apply_ast [MalSymbol "if", a1, a2] env = do
+apply_ast (MalSymbol "if") [a1, a2] env = do
     cond <- eval env a1
     case cond of
         Nil              -> return Nil
         MalBoolean False -> return Nil
         _                -> eval env a2
-apply_ast (MalSymbol "if" : _) _ = throwStr "invalid if"
+apply_ast (MalSymbol "if") _ _ = throwStr "invalid if"
 
-apply_ast [MalSymbol "fn*", MalSeq _ _ params, ast] env = newFunction ast env <$> mapM unWrapSymbol params
-apply_ast (MalSymbol "fn*" : _) _ = throwStr "invalid fn*"
+apply_ast (MalSymbol "fn*") [MalSeq _ _ params, ast] env = return $ MalFunction (MetaData Nil) fn where
+    fn :: [MalVal] -> IOThrows MalVal
+    fn args = do
+        case env_apply env params args of
+            Just fn_env -> eval fn_env ast
+            Nothing -> do
+                p <- liftIO $ _pr_list True " " params
+                a <- liftIO $ _pr_list True " " args
+                throwStr $ "actual parameters: " ++ a ++ " do not match signature: " ++ p
+apply_ast (MalSymbol "fn*") _ _ = throwStr "invalid fn*"
 
-apply_ast ast env = do
-    evd <- mapM (eval env) ast
+apply_ast first rest env = do
+    evd <- eval env first
     case evd of
-        MalFunction {fn=f, macro=False} : args -> f args
-        _ -> throwStr . (++) "invalid apply: " =<< liftIO (Printer._pr_str True (toList ast))
+        MalFunction _ f -> f =<< mapM (eval env) rest
+        MalMacro m      -> eval env =<< m rest
+        _               -> throwStr . (++) "invalid apply: " =<< liftIO (_pr_list True " " $ first : rest)
 
 eval :: Env -> MalVal -> IOThrows MalVal
 eval env ast = do
-    newAst <- macroexpand env ast
-    case newAst of
+    case traceEval of
+        True -> liftIO $ do
+            putStr "EVAL: "
+            putStr =<< _pr_str True ast
+            putStr "   "
+            env_put env
+            putStrLn ""
+            hFlush stdout
+        False -> pure ()
+    case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
             case maybeVal of
                 Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
                 Just val -> return val
-        MalSeq _ (Vect False) xs -> apply_ast xs env
-        MalSeq m (Vect True)  xs -> MalSeq m (Vect True) <$> mapM (eval env) xs
-        MalHashMap m xs          -> MalHashMap m         <$> mapM (eval env) xs
-        _ -> return newAst
+        MalSeq _ (Vect False) (a1 : as) -> apply_ast a1 as env
+        MalSeq _ (Vect True)  xs        -> MalSeq (MetaData Nil) (Vect True) <$> mapM (eval env) xs
+        MalHashMap _ xs                 -> MalHashMap (MetaData Nil) <$> mapM (eval env) xs
+        _ -> return ast
 
 -- print
 
 mal_print :: MalVal -> IOThrows String
-mal_print = liftIO. Printer._pr_str True
+mal_print = liftIO . Printer._pr_str True
 
 -- repl
 
 rep :: Env -> String -> IOThrows String
-rep env = mal_print <=< eval env <=< mal_read
+rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -185,7 +185,7 @@ re repl_env line = do
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()
 defBuiltIn env (sym, f) =
-    env_set env sym $ MalFunction {fn=f, f_ast=Nil, f_params=[], macro=False, meta=Nil}
+    env_set env sym $ MalFunction (MetaData Nil) f
 
 evalFn :: Env -> Fn
 evalFn env [ast] = eval env ast
@@ -196,7 +196,7 @@ main = do
     args <- getArgs
     load_history
 
-    repl_env <- env_new []
+    repl_env <- env_repl
 
     -- core.hs: defined using Haskell
     mapM_ (defBuiltIn repl_env) Core.ns

--- a/impls/haskell/step9_try.hs
+++ b/impls/haskell/step9_try.hs
@@ -1,16 +1,20 @@
 import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
-import Control.Monad ((<=<))
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM, foldrM)
 
 import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
-import Printer (_pr_str)
-import Env (env_new, env_bind, env_get, env_set)
+import Printer(_pr_list, _pr_str)
+import Env (Env, env_apply, env_get, env_let, env_put, env_repl, env_set)
 import Core (ns)
+
+--
+--  Set this to True for a trace of each call to Eval.
+--
+traceEval :: Bool
+traceEval = False
 
 -- read
 
@@ -18,8 +22,6 @@ mal_read :: String -> IOThrows MalVal
 mal_read = read_str
 
 -- eval
-
--- starts-with is replaced with pattern matching.
 
 qqIter :: MalVal -> MalVal -> IOThrows MalVal
 qqIter (MalSeq _ (Vect False) [MalSymbol "splice-unquote", x]) acc = return $ toList [MalSymbol "concat", x, acc]
@@ -39,17 +41,13 @@ quasiquote ast@(MalHashMap _ _) = return $ toList [MalSymbol "quote", ast]
 quasiquote ast@(MalSymbol _)    = return $ toList [MalSymbol "quote", ast]
 quasiquote ast = return ast
 
--- is-macro-call is replaced with pattern matching.
-
 macroexpand :: Env -> MalVal -> IOThrows MalVal
 macroexpand env ast@(MalSeq _ (Vect False) (MalSymbol a0 : args)) = do
     maybeMacro <- liftIO $ env_get env a0
     case maybeMacro of
-        Just (MalFunction {fn=f, macro=True}) -> macroexpand env =<< f args
+        Just (MalMacro f)                     -> macroexpand env =<< f args
         _                                     -> return ast
 macroexpand _ ast = return ast
-
--- eval_ast is replaced with pattern matching.
 
 let_bind :: Env -> [MalVal] -> IOThrows ()
 let_bind _ [] = return ()
@@ -58,116 +56,117 @@ let_bind env (MalSymbol b : e : xs) = do
     let_bind env xs
 let_bind _ _ = throwStr "invalid let*"
 
-unWrapSymbol :: MalVal -> IOThrows String
-unWrapSymbol (MalSymbol s) = return s
-unWrapSymbol _ = throwStr "fn* parameter must be symbols"
+apply_ast :: MalVal -> [MalVal] -> Env -> IOThrows MalVal
 
-newFunction :: MalVal -> Env -> [String] -> MalVal
-newFunction a env p = MalFunction {f_ast=a, f_params=p, macro=False, meta=Nil,
-    fn=(\args -> do
-        fn_env <- liftIO $ env_new env
-        ok <- liftIO $ env_bind fn_env p args
-        case ok of
-            True  -> eval fn_env a
-            False -> throwStr $ "actual parameters do not match signature " ++ show p)}
-
-apply_ast :: [MalVal] -> Env -> IOThrows MalVal
-
-apply_ast [] _ = return $ toList []
-
-apply_ast [MalSymbol "def!", MalSymbol a1, a2] env = do
+apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
     evd <- eval env a2
     liftIO $ env_set env a1 evd
     return evd
-apply_ast (MalSymbol "def!" : _) _ = throwStr "invalid def!"
+apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
-apply_ast [MalSymbol "let*", MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_new env
+apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
+    let_env <- liftIO $ env_let env
     let_bind let_env params
     eval let_env a2
-apply_ast (MalSymbol "let*" : _) _ = throwStr "invalid let*"
+apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
 
-apply_ast [MalSymbol "quote", a1] _ = return a1
-apply_ast (MalSymbol "quote" : _) _ = throwStr "invalid quote"
+apply_ast (MalSymbol "quote") [a1] _ = return a1
+apply_ast (MalSymbol "quote") _ _ = throwStr "invalid quote"
 
-apply_ast [MalSymbol "quasiquoteexpand", a1] _ = quasiquote a1
-apply_ast (MalSymbol "quasiquoteexpand" : _) _ = throwStr "invalid quasiquote"
+apply_ast (MalSymbol "quasiquoteexpand") [a1] _ = quasiquote a1
+apply_ast (MalSymbol "quasiquoteexpand") _ _ = throwStr "invalid quasiquote"
 
-apply_ast [MalSymbol "quasiquote", a1] env = eval env =<< quasiquote a1
-apply_ast (MalSymbol "quasiquote" : _) _ = throwStr "invalid quasiquote"
+apply_ast (MalSymbol "quasiquote") [a1] env = eval env =<< quasiquote a1
+apply_ast (MalSymbol "quasiquote") _ _ = throwStr "invalid quasiquote"
 
-apply_ast [MalSymbol "defmacro!", MalSymbol a1, a2] env = do
+apply_ast (MalSymbol "defmacro!") [MalSymbol a1, a2] env = do
     func <- eval env a2
     case func of
-        MalFunction {macro=False} -> do
-            let m = func {macro=True}
+        MalFunction _ f -> do
+            let m = MalMacro f
             liftIO $ env_set env a1 m
             return m
         _ -> throwStr "defmacro! on non-function"
-apply_ast (MalSymbol "defmacro!" : _) _ = throwStr "invalid defmacro!"
+apply_ast (MalSymbol "defmacro!") _ _ = throwStr "invalid defmacro!"
 
-apply_ast [MalSymbol "macroexpand", a1] env = macroexpand env a1
-apply_ast (MalSymbol "macroexpand" : _) _ = throwStr "invalid macroexpand"
+apply_ast (MalSymbol "macroexpand") [a1] env = macroexpand env  a1
+apply_ast (MalSymbol "macroexpand") _ _ = throwStr "invalid macroexpand"
 
-apply_ast [MalSymbol "try*", a1] env = eval env a1
-apply_ast [MalSymbol "try*", a1, MalSeq _ (Vect False) [MalSymbol "catch*", MalSymbol a21, a22]] env = do
+apply_ast (MalSymbol "try*") [a1] env = eval env a1
+apply_ast (MalSymbol "try*") [a1, MalSeq _ (Vect False) [MalSymbol "catch*", a21, a22]] env = do
     res <- liftIO $ runExceptT $ eval env a1
     case res of
         Right val -> return val
-        Left exc -> do
-            try_env <- liftIO $ env_new env
-            liftIO $ env_set try_env a21 exc
-            eval try_env a22
-apply_ast (MalSymbol "try*" : _) _ = throwStr "invalid try*"
+        Left exc -> case env_apply env [a21] [exc] of
+            Just try_env -> eval try_env a22
+            Nothing    -> throwStr "invalid catch*"
+apply_ast (MalSymbol "try*") _ _ = throwStr "invalid try*"
 
-apply_ast (MalSymbol "do" : args) env = foldlM (const $ eval env) Nil args
+apply_ast (MalSymbol "do") args env = foldlM (const $ eval env) Nil args
 
-apply_ast [MalSymbol "if", a1, a2, a3] env = do
+apply_ast (MalSymbol "if") [a1, a2, a3] env = do
     cond <- eval env a1
     eval env $ case cond of
         Nil              -> a3
         MalBoolean False -> a3
         _                -> a2
-apply_ast [MalSymbol "if", a1, a2] env = do
+apply_ast (MalSymbol "if") [a1, a2] env = do
     cond <- eval env a1
     case cond of
         Nil              -> return Nil
         MalBoolean False -> return Nil
         _                -> eval env a2
-apply_ast (MalSymbol "if" : _) _ = throwStr "invalid if"
+apply_ast (MalSymbol "if") _ _ = throwStr "invalid if"
 
-apply_ast [MalSymbol "fn*", MalSeq _ _ params, ast] env = newFunction ast env <$> mapM unWrapSymbol params
-apply_ast (MalSymbol "fn*" : _) _ = throwStr "invalid fn*"
+apply_ast (MalSymbol "fn*") [MalSeq _ _ params, ast] env = return $ MalFunction (MetaData Nil) fn where
+    fn :: [MalVal] -> IOThrows MalVal
+    fn args = do
+        case env_apply env params args of
+            Just fn_env -> eval fn_env ast
+            Nothing -> do
+                p <- liftIO $ _pr_list True " " params
+                a <- liftIO $ _pr_list True " " args
+                throwStr $ "actual parameters: " ++ a ++ " do not match signature: " ++ p
+apply_ast (MalSymbol "fn*") _ _ = throwStr "invalid fn*"
 
-apply_ast ast env = do
-    evd <- mapM (eval env) ast
+apply_ast first rest env = do
+    evd <- eval env first
     case evd of
-        MalFunction {fn=f, macro=False} : args -> f args
-        _ -> throwStr . (++) "invalid apply: " =<< liftIO (Printer._pr_str True (toList ast))
+        MalFunction _ f -> f =<< mapM (eval env) rest
+        MalMacro m      -> eval env =<< m rest
+        _               -> throwStr . (++) "invalid apply: " =<< liftIO (_pr_list True " " $ first : rest)
 
 eval :: Env -> MalVal -> IOThrows MalVal
 eval env ast = do
-    newAst <- macroexpand env ast
-    case newAst of
+    case traceEval of
+        True -> liftIO $ do
+            putStr "EVAL: "
+            putStr =<< _pr_str True ast
+            putStr "   "
+            env_put env
+            putStrLn ""
+            hFlush stdout
+        False -> pure ()
+    case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
             case maybeVal of
                 Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
                 Just val -> return val
-        MalSeq _ (Vect False) xs -> apply_ast xs env
-        MalSeq m (Vect True)  xs -> MalSeq m (Vect True) <$> mapM (eval env) xs
-        MalHashMap m xs          -> MalHashMap m         <$> mapM (eval env) xs
-        _ -> return newAst
+        MalSeq _ (Vect False) (a1 : as) -> apply_ast a1 as env
+        MalSeq _ (Vect True)  xs        -> MalSeq (MetaData Nil) (Vect True) <$> mapM (eval env) xs
+        MalHashMap _ xs                 -> MalHashMap (MetaData Nil) <$> mapM (eval env) xs
+        _ -> return ast
 
 -- print
 
 mal_print :: MalVal -> IOThrows String
-mal_print = liftIO. Printer._pr_str True
+mal_print = liftIO . Printer._pr_str True
 
 -- repl
 
 rep :: Env -> String -> IOThrows String
-rep env = mal_print <=< eval env <=< mal_read
+rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -196,7 +195,7 @@ re repl_env line = do
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()
 defBuiltIn env (sym, f) =
-    env_set env sym $ MalFunction {fn=f, f_ast=Nil, f_params=[], macro=False, meta=Nil}
+    env_set env sym $ MalFunction (MetaData Nil) f
 
 evalFn :: Env -> Fn
 evalFn env [ast] = eval env ast
@@ -207,7 +206,7 @@ main = do
     args <- getArgs
     load_history
 
-    repl_env <- env_new []
+    repl_env <- env_repl
 
     -- core.hs: defined using Haskell
     mapM_ (defBuiltIn repl_env) Core.ns

--- a/impls/haskell/stepA_mal.hs
+++ b/impls/haskell/stepA_mal.hs
@@ -1,16 +1,20 @@
 import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
-import Control.Monad ((<=<))
-import Control.Monad.Except (runExceptT)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM, foldrM)
 
 import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
-import Printer (_pr_str)
-import Env (env_new, env_bind, env_get, env_set)
+import Printer(_pr_list, _pr_str)
+import Env (Env, env_apply, env_get, env_let, env_put, env_repl, env_set)
 import Core (ns)
+
+--
+--  Set this to True for a trace of each call to Eval.
+--
+traceEval :: Bool
+traceEval = False
 
 -- read
 
@@ -18,8 +22,6 @@ mal_read :: String -> IOThrows MalVal
 mal_read = read_str
 
 -- eval
-
--- starts-with is replaced with pattern matching.
 
 qqIter :: MalVal -> MalVal -> IOThrows MalVal
 qqIter (MalSeq _ (Vect False) [MalSymbol "splice-unquote", x]) acc = return $ toList [MalSymbol "concat", x, acc]
@@ -39,17 +41,13 @@ quasiquote ast@(MalHashMap _ _) = return $ toList [MalSymbol "quote", ast]
 quasiquote ast@(MalSymbol _)    = return $ toList [MalSymbol "quote", ast]
 quasiquote ast = return ast
 
--- is-macro-call is replaced with pattern matching.
-
 macroexpand :: Env -> MalVal -> IOThrows MalVal
 macroexpand env ast@(MalSeq _ (Vect False) (MalSymbol a0 : args)) = do
     maybeMacro <- liftIO $ env_get env a0
     case maybeMacro of
-        Just (MalFunction {fn=f, macro=True}) -> macroexpand env =<< f args
+        Just (MalMacro f)                     -> macroexpand env =<< f args
         _                                     -> return ast
 macroexpand _ ast = return ast
-
--- eval_ast is replaced with pattern matching.
 
 let_bind :: Env -> [MalVal] -> IOThrows ()
 let_bind _ [] = return ()
@@ -58,116 +56,117 @@ let_bind env (MalSymbol b : e : xs) = do
     let_bind env xs
 let_bind _ _ = throwStr "invalid let*"
 
-unWrapSymbol :: MalVal -> IOThrows String
-unWrapSymbol (MalSymbol s) = return s
-unWrapSymbol _ = throwStr "fn* parameter must be symbols"
+apply_ast :: MalVal -> [MalVal] -> Env -> IOThrows MalVal
 
-newFunction :: MalVal -> Env -> [String] -> MalVal
-newFunction a env p = MalFunction {f_ast=a, f_params=p, macro=False, meta=Nil,
-    fn=(\args -> do
-        fn_env <- liftIO $ env_new env
-        ok <- liftIO $ env_bind fn_env p args
-        case ok of
-            True  -> eval fn_env a
-            False -> throwStr $ "actual parameters do not match signature " ++ show p)}
-
-apply_ast :: [MalVal] -> Env -> IOThrows MalVal
-
-apply_ast [] _ = return $ toList []
-
-apply_ast [MalSymbol "def!", MalSymbol a1, a2] env = do
+apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
     evd <- eval env a2
     liftIO $ env_set env a1 evd
     return evd
-apply_ast (MalSymbol "def!" : _) _ = throwStr "invalid def!"
+apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
-apply_ast [MalSymbol "let*", MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_new env
+apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
+    let_env <- liftIO $ env_let env
     let_bind let_env params
     eval let_env a2
-apply_ast (MalSymbol "let*" : _) _ = throwStr "invalid let*"
+apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
 
-apply_ast [MalSymbol "quote", a1] _ = return a1
-apply_ast (MalSymbol "quote" : _) _ = throwStr "invalid quote"
+apply_ast (MalSymbol "quote") [a1] _ = return a1
+apply_ast (MalSymbol "quote") _ _ = throwStr "invalid quote"
 
-apply_ast [MalSymbol "quasiquoteexpand", a1] _ = quasiquote a1
-apply_ast (MalSymbol "quasiquoteexpand" : _) _ = throwStr "invalid quasiquote"
+apply_ast (MalSymbol "quasiquoteexpand") [a1] _ = quasiquote a1
+apply_ast (MalSymbol "quasiquoteexpand") _ _ = throwStr "invalid quasiquote"
 
-apply_ast [MalSymbol "quasiquote", a1] env = eval env =<< quasiquote a1
-apply_ast (MalSymbol "quasiquote" : _) _ = throwStr "invalid quasiquote"
+apply_ast (MalSymbol "quasiquote") [a1] env = eval env =<< quasiquote a1
+apply_ast (MalSymbol "quasiquote") _ _ = throwStr "invalid quasiquote"
 
-apply_ast [MalSymbol "defmacro!", MalSymbol a1, a2] env = do
+apply_ast (MalSymbol "defmacro!") [MalSymbol a1, a2] env = do
     func <- eval env a2
     case func of
-        MalFunction {macro=False} -> do
-            let m = func {macro=True}
+        MalFunction _ f -> do
+            let m = MalMacro f
             liftIO $ env_set env a1 m
             return m
         _ -> throwStr "defmacro! on non-function"
-apply_ast (MalSymbol "defmacro!" : _) _ = throwStr "invalid defmacro!"
+apply_ast (MalSymbol "defmacro!") _ _ = throwStr "invalid defmacro!"
 
-apply_ast [MalSymbol "macroexpand", a1] env = macroexpand env a1
-apply_ast (MalSymbol "macroexpand" : _) _ = throwStr "invalid macroexpand"
+apply_ast (MalSymbol "macroexpand") [a1] env = macroexpand env  a1
+apply_ast (MalSymbol "macroexpand") _ _ = throwStr "invalid macroexpand"
 
-apply_ast [MalSymbol "try*", a1] env = eval env a1
-apply_ast [MalSymbol "try*", a1, MalSeq _ (Vect False) [MalSymbol "catch*", MalSymbol a21, a22]] env = do
+apply_ast (MalSymbol "try*") [a1] env = eval env a1
+apply_ast (MalSymbol "try*") [a1, MalSeq _ (Vect False) [MalSymbol "catch*", a21, a22]] env = do
     res <- liftIO $ runExceptT $ eval env a1
     case res of
         Right val -> return val
-        Left exc -> do
-            try_env <- liftIO $ env_new env
-            liftIO $ env_set try_env a21 exc
-            eval try_env a22
-apply_ast (MalSymbol "try*" : _) _ = throwStr "invalid try*"
+        Left exc -> case env_apply env [a21] [exc] of
+            Just try_env -> eval try_env a22
+            Nothing    -> throwStr "invalid catch*"
+apply_ast (MalSymbol "try*") _ _ = throwStr "invalid try*"
 
-apply_ast (MalSymbol "do" : args) env = foldlM (const $ eval env) Nil args
+apply_ast (MalSymbol "do") args env = foldlM (const $ eval env) Nil args
 
-apply_ast [MalSymbol "if", a1, a2, a3] env = do
+apply_ast (MalSymbol "if") [a1, a2, a3] env = do
     cond <- eval env a1
     eval env $ case cond of
         Nil              -> a3
         MalBoolean False -> a3
         _                -> a2
-apply_ast [MalSymbol "if", a1, a2] env = do
+apply_ast (MalSymbol "if") [a1, a2] env = do
     cond <- eval env a1
     case cond of
         Nil              -> return Nil
         MalBoolean False -> return Nil
         _                -> eval env a2
-apply_ast (MalSymbol "if" : _) _ = throwStr "invalid if"
+apply_ast (MalSymbol "if") _ _ = throwStr "invalid if"
 
-apply_ast [MalSymbol "fn*", MalSeq _ _ params, ast] env = newFunction ast env <$> mapM unWrapSymbol params
-apply_ast (MalSymbol "fn*" : _) _ = throwStr "invalid fn*"
+apply_ast (MalSymbol "fn*") [MalSeq _ _ params, ast] env = return $ MalFunction (MetaData Nil) fn where
+    fn :: [MalVal] -> IOThrows MalVal
+    fn args = do
+        case env_apply env params args of
+            Just fn_env -> eval fn_env ast
+            Nothing -> do
+                p <- liftIO $ _pr_list True " " params
+                a <- liftIO $ _pr_list True " " args
+                throwStr $ "actual parameters: " ++ a ++ " do not match signature: " ++ p
+apply_ast (MalSymbol "fn*") _ _ = throwStr "invalid fn*"
 
-apply_ast ast env = do
-    evd <- mapM (eval env) ast
+apply_ast first rest env = do
+    evd <- eval env first
     case evd of
-        MalFunction {fn=f, macro=False} : args -> f args
-        _ -> throwStr . (++) "invalid apply: " =<< liftIO (Printer._pr_str True (toList ast))
+        MalFunction _ f -> f =<< mapM (eval env) rest
+        MalMacro m      -> eval env =<< m rest
+        _               -> throwStr . (++) "invalid apply: " =<< liftIO (_pr_list True " " $ first : rest)
 
 eval :: Env -> MalVal -> IOThrows MalVal
 eval env ast = do
-    newAst <- macroexpand env ast
-    case newAst of
+    case traceEval of
+        True -> liftIO $ do
+            putStr "EVAL: "
+            putStr =<< _pr_str True ast
+            putStr "   "
+            env_put env
+            putStrLn ""
+            hFlush stdout
+        False -> pure ()
+    case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
             case maybeVal of
                 Nothing  -> throwStr $ "'" ++ sym ++ "' not found"
                 Just val -> return val
-        MalSeq _ (Vect False) xs -> apply_ast xs env
-        MalSeq m (Vect True)  xs -> MalSeq m (Vect True) <$> mapM (eval env) xs
-        MalHashMap m xs          -> MalHashMap m         <$> mapM (eval env) xs
-        _ -> return newAst
+        MalSeq _ (Vect False) (a1 : as) -> apply_ast a1 as env
+        MalSeq _ (Vect True)  xs        -> MalSeq (MetaData Nil) (Vect True) <$> mapM (eval env) xs
+        MalHashMap _ xs                 -> MalHashMap (MetaData Nil) <$> mapM (eval env) xs
+        _ -> return ast
 
 -- print
 
 mal_print :: MalVal -> IOThrows String
-mal_print = liftIO. Printer._pr_str True
+mal_print = liftIO . Printer._pr_str True
 
 -- repl
 
 rep :: Env -> String -> IOThrows String
-rep env = mal_print <=< eval env <=< mal_read
+rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -196,7 +195,7 @@ re repl_env line = do
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()
 defBuiltIn env (sym, f) =
-    env_set env sym $ MalFunction {fn=f, f_ast=Nil, f_params=[], macro=False, meta=Nil}
+    env_set env sym $ MalFunction (MetaData Nil) f
 
 evalFn :: Env -> Fn
 evalFn env [ast] = eval env ast
@@ -207,7 +206,7 @@ main = do
     args <- getArgs
     load_history
 
-    repl_env <- env_new []
+    repl_env <- env_repl
 
     -- core.hs: defined using Haskell
     mapM_ (defBuiltIn repl_env) Core.ns

--- a/impls/tests/step3_env.mal
+++ b/impls/tests/step3_env.mal
@@ -76,3 +76,12 @@ y
 ;; Testing vector evaluation
 (let* (a 5 b 6) [3 4 a [b 7] 8])
 ;=>[3 4 5 [6 7] 8]
+
+;>>> soft=True
+;>>> optional=True
+;;
+;; -------- Optional Functionality --------
+
+;; Check that last assignment takes priority
+(let* (x 2 x 3) x)
+;=>3

--- a/impls/tests/step4_if_fn_do.mal
+++ b/impls/tests/step4_if_fn_do.mal
@@ -204,6 +204,8 @@ a
 
 
 ;; Testing recursive function in environment.
+(let* (f (fn* () x) x 3) (f))
+;=>3
 (let* (cst (fn* (n) (if (= n 0) nil (cst (- n 1))))) (cst 1))
 ;=>nil
 (let* (f (fn* (n) (if (= n 0) 0 (g (- n 1)))) g (fn* (n) (f n))) (f 2))


### PR DESCRIPTION
The grammar is not fully equivalent to the one in the process, but it
passes all tests.

I suggest that it becomes a formal/testable reference (are tabs
allowed as spaces? is "a~" valid? is "' a" valid?...).

As it is formuled here, it can directly be translated either to
another language with high-level parsers, or to a low-level language
as each production only switches after a look at the next input
character.