### PR TITLE
tcl: Soft failure fixes

### DIFF
--- a/impls/tcl/core.tcl
+++ b/impls/tcl/core.tcl
@@ -33,7 +33,11 @@ proc mal_string_q {a} {
 }
 
 proc mal_keyword {a} {
-    keyword_new [obj_val [lindex $a 0]]
+    lassign $a a0
+    if {[keyword_q $a0]} {
+        return $a0
+    }
+    keyword_new [obj_val $a0]
 }
 
 proc mal_keyword_q {a} {

--- a/impls/tcl/step8_macros.tcl
+++ b/impls/tcl/step8_macros.tcl
@@ -162,10 +162,7 @@ proc EVAL {ast env} {
             "defmacro!" {
                 set varname [obj_val $a1]
                 set value [EVAL $a2 $env]
-                set fn [obj_val $value]
-                dict set fn is_macro 1
-                obj_set_val $value $fn
-                return [$env set $varname $value]
+                return [$env set $varname [macro_new $value]]
             }
             "macroexpand" {
                 return [macroexpand $a1 $env]

--- a/impls/tcl/step9_try.tcl
+++ b/impls/tcl/step9_try.tcl
@@ -162,10 +162,7 @@ proc EVAL {ast env} {
             "defmacro!" {
                 set varname [obj_val $a1]
                 set value [EVAL $a2 $env]
-                set fn [obj_val $value]
-                dict set fn is_macro 1
-                obj_set_val $value $fn
-                return [$env set $varname $value]
+                return [$env set $varname [macro_new $value]]
             }
             "macroexpand" {
                 return [macroexpand $a1 $env]

--- a/impls/tcl/stepA_mal.tcl
+++ b/impls/tcl/stepA_mal.tcl
@@ -162,10 +162,7 @@ proc EVAL {ast env} {
             "defmacro!" {
                 set varname [obj_val $a1]
                 set value [EVAL $a2 $env]
-                set fn [obj_val $value]
-                dict set fn is_macro 1
-                obj_set_val $value $fn
-                return [$env set $varname $value]
+                return [$env set $varname [macro_new $value]]
             }
             "macroexpand" {
                 return [macroexpand $a1 $env]

--- a/impls/tcl/types.tcl
+++ b/impls/tcl/types.tcl
@@ -175,6 +175,15 @@ proc function_new {body env binds} {
     obj_new "function" $funcdict $::mal_nil
 }
 
+proc macro_new {funcobj} {
+    set fn [obj_val $funcobj]
+    set body [dict get $fn body]
+    set env [dict get $fn env]
+    set binds [dict get $fn binds]
+    set funcdict [dict create body $body env $env binds $binds is_macro 1]
+    obj_new "function" $funcdict $::mal_nil
+}
+
 proc function_q {obj} {
     expr {[obj_type $obj] == "function"}
 }


### PR DESCRIPTION
Fixes of soft test failures in step 9 and step A:

- tcl: Fix (keyword) of keywords
- tcl: defmacro! doesn't modify existing functions
