### PR TITLE
typescript: Upgrade to 4.0.3 + soft-failure fixes

### DIFF
--- a/impls/ts/core.ts
+++ b/impls/ts/core.ts
@@ -37,6 +37,9 @@ export const ns: Map<MalSymbol, MalFunction> = (() => {
             return new MalBoolean(v.type === Node.Symbol);
         },
         keyword(v: MalType) {
+            if (v.type === Node.Keyword) {
+                return v;
+            }
             if (v.type !== Node.String) {
                 throw new Error(`unexpected symbol: ${v.type}, expected: string`);
             }

--- a/impls/ts/core.ts
+++ b/impls/ts/core.ts
@@ -93,7 +93,7 @@ export const ns: Map<MalSymbol, MalFunction> = (() => {
             if (v.type !== Node.String) {
                 throw new Error(`unexpected symbol: ${v.type}, expected: string`);
             }
-            const content = fs.readFileSync(v.v, "UTF-8");
+            const content = fs.readFileSync(v.v, "utf-8");
             return new MalString(content);
         },
 

--- a/impls/ts/package.json
+++ b/impls/ts/package.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "@types/ffi-napi": "2.4.0",
-    "@types/node": "^7.0.5",
-    "typescript": "^2.2.1",
-    "typescript-formatter": "^4.1.2"
+    "@types/node": "^14.14.3",
+    "typescript": "^4.0.3",
+    "typescript-formatter": "^7.2.2"
   }
 }

--- a/impls/ts/step8_macros.ts
+++ b/impls/ts/step8_macros.ts
@@ -196,8 +196,7 @@ function evalMal(ast: MalType, env: Env): MalType {
                         if (f.type !== Node.Function) {
                             throw new Error(`unexpected token type: ${f.type}, expected: function`);
                         }
-                        f.isMacro = true;
-                        return env.set(key, f);
+                        return env.set(key, f.toMacro());
                     }
                     case "macroexpand": {
                         return macroexpand(ast.list[1], env);

--- a/impls/ts/step9_try.ts
+++ b/impls/ts/step9_try.ts
@@ -196,8 +196,7 @@ function evalMal(ast: MalType, env: Env): MalType {
                         if (f.type !== Node.Function) {
                             throw new Error(`unexpected token type: ${f.type}, expected: function`);
                         }
-                        f.isMacro = true;
-                        return env.set(key, f);
+                        return env.set(key, f.toMacro());
                     }
                     case "macroexpand": {
                         return macroexpand(ast.list[1], env);

--- a/impls/ts/stepA_mal.ts
+++ b/impls/ts/stepA_mal.ts
@@ -196,8 +196,7 @@ function evalMal(ast: MalType, env: Env): MalType {
                         if (f.type !== Node.Function) {
                             throw new Error(`unexpected token type: ${f.type}, expected: function`);
                         }
-                        f.isMacro = true;
-                        return env.set(key, f);
+                        return env.set(key, f.toMacro());
                     }
                     case "macroexpand": {
                         return macroexpand(ast.list[1], env);

--- a/impls/ts/types.ts
+++ b/impls/ts/types.ts
@@ -367,6 +367,18 @@ export class MalFunction {
 
     private constructor() { }
 
+    toMacro() {
+        const f = new MalFunction();
+        f.func = this.func;
+        f.ast = this.ast;
+        f.env = this.env;
+        f.params = this.params;
+        f.isMacro = true;
+        f.meta = this.meta;
+
+        return f;
+    }
+
     withMeta(meta: MalType) {
         const f = new MalFunction();
         f.func = this.func;


### PR DESCRIPTION
TypeScript travis jobs have been failing for a while:

https://travis-ci.org/github/kanaka/mal/jobs/732329501

```
./node_modules/.bin/tsc -p ./
node_modules/@types/node/index.d.ts:20:1 - error TS1084: Invalid 'reference' directive syntax.

20 /// <reference lib="es2016" />
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Makefile:11: recipe for target 'step0_repl.js' failed
```

I upgraded the TypeScript version in package.json (required a minor fix in
core.ts) to solve the issue, and took the chance to fix a couple of soft test
failures.
