### PR TITLE
Add Janet implementation

### DIFF
--- a/IMPLS.yml
+++ b/IMPLS.yml
@@ -39,6 +39,7 @@ IMPL:
   - {IMPL: haxe, haxe_MODE: js}
   - {IMPL: hy}
   - {IMPL: io, NO_SELF_HOST_PERF: 1}  # perf OOM
+  - {IMPL: janet}
   - {IMPL: java}
   - {IMPL: jq}
   - {IMPL: js}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ FAQ](docs/FAQ.md) where I attempt to answer some common questions.
 | [Haxe](#haxe-neko-python-c-and-javascript) (Neko, Python, C++, &amp; JS) | [Joel Martin](https://github.com/kanaka) |
 | [Hy](#hy) | [Joel Martin](https://github.com/kanaka)  |
 | [Io](#io) | [Dov Murik](https://github.com/dubek) |
+| [Janet|(#janet) | [sogaiu](https://github.com/sogaiu) |
 | [Java](#java-17) | [Joel Martin](https://github.com/kanaka)  |
 | [JavaScript](#javascriptnode) ([Demo](http://kanaka.github.io/mal)) | [Joel Martin](https://github.com/kanaka) |
 | [jq](#jq) | [Ali MohammadPur](https://github.com/alimpfard) |
@@ -577,6 +578,15 @@ The Io implementation of mal has been tested with Io version 20110905.
 ```
 cd impls/io
 io ./stepX_YYY.io
+```
+
+### Janet
+
+The Janet implementation of mal has been tested with Janet version 1.12.2.
+
+```
+cd impls/janet
+janet ./stepX_YYY.janet
 ```
 
 ### Java 1.7

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ guide](process/guide.md) there is also a [mal/make-a-lisp
 FAQ](docs/FAQ.md) where I attempt to answer some common questions.
 
 
-**3. Mal is implemented in 83 languages (86 different implementations and 106 runtime modes)**
+**3. Mal is implemented in 84 languages (87 different implementations and 107 runtime modes)**
 
 | Language | Creator |
 | -------- | ------- |

--- a/impls/janet/Dockerfile
+++ b/impls/janet/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:20.04
+MAINTAINER Joel Martin <github@martintribe.org>
+
+##########################################################
+# General requirements for testing or common across many
+# implementations
+##########################################################
+
+RUN apt-get -y update
+
+# Required for running tests
+RUN apt-get -y install make python
+
+# Some typical implementation and test requirements
+RUN apt-get -y install wget libreadline-dev libedit-dev
+
+RUN mkdir -p /mal
+WORKDIR /mal
+
+##########################################################
+# Specific implementation requirements
+##########################################################
+
+# janet
+RUN cd /usr/lib/x86_64-linux-gnu/ \
+    && wget https://github.com/janet-lang/janet/releases/download/v1.12.2/janet-v1.12.2-linux.tar.gz \
+    && tar xvzf janet-v1.12.2-linux.tar.gz \
+    && ln -sf /usr/lib/x86_64-linux-gnu/janet-v1.12.2-linux/janet /usr/bin/janet \
+    && rm janet-v1.12.2-linux.tar.gz

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -36,21 +36,6 @@
   [ast]
   (= (ast :tag) :vector))
 
-(def mal-vec
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "vec requires 1 argument")))
-      (let [ast (in asts 0)]
-        (cond
-          (vector?* ast)
-          ast
-          ##
-          (list?* ast)
-          (make-vector (ast :content))
-          ##
-          (throw* (make-string "vec requires a vector or list")))))))
-
 (def mal-vector?
   (make-function
     (fn [asts]
@@ -335,6 +320,24 @@
       (if (nil?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
+
+(def mal-vec
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "vec requires 1 argument")))
+      (let [ast (in asts 0)]
+        (cond
+          (vector?* ast)
+          ast
+          ##
+          (list?* ast)
+          (make-vector (ast :content))
+          ##
+          (nil?* ast)
+          (make-vector ())
+          ##
+          (throw* (make-string "vec requires a vector, list, or nil")))))))
 
 (defn true?*
   [ast]

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -324,8 +324,8 @@
 (def mal-map
   (make-function
     (fn [asts]
-      (assert (< 1 (length asts))
-              "map requires at least 2 arguments")
+      (when (< (length asts) 2)
+        (throw* (make-string "map requires at least 2 arguments")))
       (let [the-fn ((in asts 0) :content)
             coll ((in asts 1) :content)]
         (make-list (map |(the-fn [$])

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -1,0 +1,171 @@
+(import ./types :prefix "")
+(import ./printer)
+
+(defn arith-fn
+  [op]
+  (make-function
+    (fn [asts]
+      (let [ast-1 (in asts 0)
+            ast-2 (in asts 1)]
+        (make-number (string (op (scan-number (ast-1 :content))
+                                 (scan-number (ast-2 :content)))))))))
+
+(def create-list
+  (make-function
+    (fn [asts]
+      (make-list asts))))
+
+(defn is-list?*
+  [ast]
+  (= (ast :tag) :list))
+
+(def is-list?
+  (make-function
+    (fn [asts]
+      (if (is-list?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(defn is-vector?*
+  [ast]
+  (= (ast :tag) :vector))
+
+(def is-vector?
+  (make-function
+    (fn [asts]
+      (if (is-vector?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(defn is-empty?*
+  [ast]
+  (empty? (ast :content)))
+
+(def is-empty?
+  (make-function
+    (fn [asts]
+      (let [ast (in asts 0)]
+        (if (is-empty?* ast)
+          (make-boolean true)
+          (make-boolean false))))))
+
+(def count-elts
+  (make-function
+    (fn [asts]
+      (let [ast (in asts 0)]
+        (let [tag (ast :tag)]
+          (if (= tag :nil)
+            (make-number "0")
+            (make-number (string (length (ast :content))))))))))
+
+(defn equals?*
+  [ast-1 ast-2]
+  (let [tag-1 (ast-1 :tag)
+        tag-2 (ast-2 :tag)]
+    (if (and (not= tag-1 tag-2)
+             # XXX: not elegant
+             (not (and (= tag-1 :list) (= tag-2 :vector)))
+             (not (and (= tag-2 :list) (= tag-1 :vector))))
+      false
+      (let [val-1 (ast-1 :content)
+            val-2 (ast-2 :content)]
+        # XXX: when not a collection...
+        (if (and (not (is-list?* ast-1))
+                 (not (is-vector?* ast-1)))
+          (= val-1 val-2)
+          (if (not= (length val-1) (length val-2))
+            false
+            (do
+              (var found-unequal false)
+              (each [v1 v2] (partition 2 (interleave val-1 val-2))
+                    (when (not (equals?* v1 v2))
+                      (set found-unequal true)
+                      (break)))
+              (not found-unequal))))))))
+
+(def equals?
+  (make-function
+    (fn [asts]
+      (let [ast-1 (in asts 0)
+            ast-2 (in asts 1)]
+        (if (equals?* ast-1 ast-2)
+          (make-boolean true)
+          (make-boolean false))))))
+
+(defn cmp-fn
+  [op]
+  (make-function
+    (fn [asts]
+      (let [ast-1 (in asts 0)
+            ast-2 (in asts 1)]
+        (let [val-1 (scan-number (ast-1 :content))
+              val-2 (scan-number (ast-2 :content))]
+          (if (op val-1 val-2)
+            (make-boolean true)
+            (make-boolean false)))))))
+
+(def pr-str
+  (make-function
+    (fn [asts]
+      (def buf @"")
+      (when (> (length asts) 0)
+        (each ast asts
+              (buffer/push-string buf (printer/pr_str ast true))
+              (buffer/push-string buf " "))
+        # remove extra space at end
+        (buffer/popn buf 1))
+      (make-string (string buf)))))
+
+(def str
+  (make-function
+    (fn [asts]
+      (def buf @"")
+      (when (> (length asts) 0)
+        (each ast asts
+              (buffer/push-string buf (printer/pr_str ast false))))
+      (make-string (string buf)))))
+
+(def prn
+  (make-function
+    (fn [asts]
+      (def buf @"")
+      (when (> (length asts) 0)
+        (each ast asts
+              (buffer/push-string buf (printer/pr_str ast true))
+              (buffer/push-string buf " "))
+        # remove extra space at end
+        (buffer/popn buf 1))
+      (print (string buf))
+      (make-nil))))
+
+(def println
+  (make-function
+    (fn [asts]
+      (def buf @"")
+      (when (> (length asts) 0)
+        (each ast asts
+              (buffer/push-string buf (printer/pr_str ast false))
+              (buffer/push-string buf " "))
+        # remove extra space at end
+        (buffer/popn buf 1))
+      (print (string buf))
+      (make-nil))))
+
+(def ns
+  {(make-symbol "+") (arith-fn +)
+   (make-symbol "-") (arith-fn -)
+   (make-symbol "*") (arith-fn *)
+   (make-symbol "/") (arith-fn /)
+   (make-symbol "list") create-list
+   (make-symbol "list?") is-list?
+   (make-symbol "empty?") is-empty?
+   (make-symbol "count") count-elts
+   (make-symbol "=") equals?
+   (make-symbol "<") (cmp-fn <)
+   (make-symbol "<=") (cmp-fn <=)
+   (make-symbol ">") (cmp-fn >)
+   (make-symbol ">=") (cmp-fn >=)
+   (make-symbol "pr-str") pr-str
+   (make-symbol "str") str
+   (make-symbol "prn") prn
+   (make-symbol "println") println})

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -290,6 +290,48 @@
     ##
     ast))
 
+(defn nth*
+  [coll-ast num-ast]
+  (let [elts (coll-ast :content)
+        n-elts (length elts)
+        i (scan-number (num-ast :content))]
+    (if (< i n-elts)
+      (in elts i)
+      (error (string "Index out of range: " i)))))
+
+(def nth
+  (make-function
+    (fn [asts]
+      (let [coll-ast (in asts 0)
+            num-ast (in asts 1)]
+        (nth* coll-ast num-ast)))))
+
+(defn first*
+  [coll-or-nil-ast]
+  (if (or (= (coll-or-nil-ast :tag) :nil)
+          (is-empty?* coll-or-nil-ast))
+    (make-nil)
+    (in (coll-or-nil-ast :content) 0)))
+
+(def mal-first
+  (make-function
+    (fn [asts]
+      (let [coll-or-nil-ast (in asts 0)]
+        (first* coll-or-nil-ast)))))
+
+(defn rest*
+  [coll-or-nil-ast]
+  (if (or (= (coll-or-nil-ast :tag) :nil)
+          (is-empty?* coll-or-nil-ast))
+    (make-list [])
+    (make-list (slice (coll-or-nil-ast :content) 1))))
+
+(def rest
+  (make-function
+    (fn [asts]
+      (let [coll-or-nil-ast (in asts 0)]
+        (rest* coll-or-nil-ast)))))
+
 (def ns
   {(make-symbol "+") (arith-fn +)
    (make-symbol "-") (arith-fn -)
@@ -319,4 +361,7 @@
    (make-symbol "swap!") swap!
    (make-symbol "cons") cons
    (make-symbol "concat") concat
+   (make-symbol "nth") nth
+   (make-symbol "first") mal-first
+   (make-symbol "rest") rest
 })

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -6,6 +6,189 @@
   [ast]
   (error ast))
 
+(defn nil?*
+  [ast]
+  (= :nil (ast :tag)))
+
+(defn true?*
+  [ast]
+  (and (= :boolean (ast :tag))
+       (= "true" (ast :content))))
+
+(defn false?*
+  [ast]
+  (and (= :boolean (ast :tag))
+       (= "false" (ast :content))))
+
+(defn number?*
+  [ast]
+  (= (ast :tag) :number))
+
+(defn symbol?*
+  [ast]
+  (= :symbol (ast :tag)))
+
+(defn keyword?*
+  [ast]
+  (= (ast :tag) :keyword))
+
+(defn string?*
+  [ast]
+  (= (ast :tag) :string))
+
+(defn list?*
+  [ast]
+  (= (ast :tag) :list))
+
+(defn vector?*
+  [ast]
+  (= (ast :tag) :vector))
+
+(defn hash-map?*
+  [ast]
+  (= (ast :tag) :hash-map))
+
+(defn fn?*
+  [ast]
+  (= (ast :tag) :function))
+
+(defn macro?*
+  [ast]
+  (and (fn?* ast)
+       (ast :is-macro)))
+
+(defn atom?*
+  [ast]
+  (= (ast :tag) :atom))
+
+(defn empty?*
+  [ast]
+  (empty? (ast :content)))
+
+# XXX: likely this could be simpler
+(defn equals?*
+  [ast-1 ast-2]
+  (let [tag-1 (ast-1 :tag)
+        tag-2 (ast-2 :tag)]
+    (if (and (not= tag-1 tag-2)
+             # XXX: not elegant
+             (not (and (= tag-1 :list) (= tag-2 :vector)))
+             (not (and (= tag-2 :list) (= tag-1 :vector))))
+      false
+      (let [val-1 (ast-1 :content)
+            val-2 (ast-2 :content)]
+        # XXX: when not a collection...
+        (if (and (not (list?* ast-1))
+                 (not (vector?* ast-1))
+                 (not (hash-map?* ast-1)))
+          (= val-1 val-2)
+          (if (not= (length val-1) (length val-2))
+            false
+            (if (and (not (hash-map?* ast-1))
+                     (not (hash-map?* ast-2)))
+              (do
+                (var found-unequal false)
+                (each [v1 v2] (partition 2 (interleave val-1 val-2))
+                      (when (not (equals?* v1 v2))
+                        (set found-unequal true)
+                        (break)))
+                (not found-unequal))
+              (if (or (not (hash-map?* ast-1))
+                      (not (hash-map?* ast-2)))
+                false
+                (do
+                  (var found-unequal false)
+                  (each [k1 k2] (partition 2 (interleave (keys val-1)
+                                                         (keys val-2)))
+                        (when (not (equals?* k1 k2))
+                          (set found-unequal true)
+                          (break))
+                        (when (not (equals?* (val-1 k1) (val-2 k2)))
+                          (set found-unequal true)
+                          (break)))
+                  (not found-unequal))))))))))
+
+(defn deref*
+  [ast]
+  (if (not (atom?* ast))
+    (throw* (make-string (string "Expected atom, got: " (ast :tag))))
+    (ast :content)))
+
+(defn reset!*
+  [atom-ast val-ast]
+  (put atom-ast
+       :content val-ast)
+  val-ast)
+
+(defn cons*
+  [head-ast tail-ast]
+  [head-ast ;(tail-ast :content)])
+
+(defn concat*
+  [& list-asts]
+  (reduce (fn [acc list-ast]
+            [;acc ;(list-ast :content)])
+          []
+          list-asts))
+
+(defn nth*
+  [coll-ast num-ast]
+  (let [elts (coll-ast :content)
+        n-elts (length elts)
+        i (num-ast :content)]
+    (if (< i n-elts)
+      (in elts i)
+      (throw* (make-string (string "Index out of range: " i))))))
+
+(defn first*
+  [coll-or-nil-ast]
+  (if (or (nil?* coll-or-nil-ast)
+          (empty?* coll-or-nil-ast))
+    (make-nil)
+    (in (coll-or-nil-ast :content) 0)))
+
+(defn rest*
+  [coll-or-nil-ast]
+  (if (or (nil?* coll-or-nil-ast)
+          (empty?* coll-or-nil-ast))
+    (make-list [])
+    (make-list (slice (coll-or-nil-ast :content) 1))))
+
+(defn janet-eval*
+  [janet-val]
+  (case (type janet-val)
+    :nil
+    (make-nil)
+    ##
+    :boolean
+    (make-boolean janet-val)
+    ##
+    :number # XXX: there may be some incompatibilities
+    (make-number janet-val)
+    ##
+    :string
+    (make-string janet-val)
+    ##
+    :keyword # XXX: there may be some incompatibilities
+    (make-keyword (string ":" janet-val))
+    ##
+    :symbol # XXX: there may be some incompatibilities
+    (make-symbol (string janet-val))
+    ##
+    :tuple
+    (make-list (map janet-eval* janet-val))
+    ##
+    :array
+    (make-list (map janet-eval* janet-val))
+    ##
+    :struct
+    (make-hash-map (struct ;(map janet-eval* (kvs janet-val))))
+    ##
+    :table
+    (make-hash-map (struct ;(map janet-eval* (kvs janet-val))))
+    ##
+    (throw* (make-string (string "Unsupported type: " (type janet-val))))))
+
 (defn arith-fn
   [op]
   (make-function
@@ -14,53 +197,82 @@
         (op ;(map |($ :content)
                   asts))))))
 
+(defn cmp-fn
+  [op]
+  (make-function
+    (fn [asts]
+      (if (op ;(map |($ :content) asts))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(defn spawn-function
+  [fn-ast overrides]
+  (merge fn-ast overrides))
+
+(def mal-symbol
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "symbol requires 1 argument")))
+      (make-symbol ((in asts 0) :content)))))
+
+(def mal-keyword
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "keyword requires 1 argument")))
+      (let [arg-ast (in asts 0)]
+        (cond
+          (keyword?* arg-ast)
+          arg-ast
+          ##
+          (string?* arg-ast)
+          (make-keyword (string ":" (arg-ast :content)))
+          ##
+          (throw* (make-string "Expected string")))))))
+
 (def mal-list
   (make-function
     (fn [asts]
       (make-list asts))))
 
-(defn list?*
-  [ast]
-  (= (ast :tag) :list))
+(def mal-vector
+  (make-function
+    (fn [asts]
+      (make-vector asts))))
 
-(def mal-list?
+(def mal-vec
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (make-string "list? requires 1 argument")))
-      (if (list?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
+        (throw* (make-string "vec requires 1 argument")))
+      (let [ast (in asts 0)]
+        (cond
+          (vector?* ast)
+          ast
+          ##
+          (list?* ast)
+          (make-vector (ast :content))
+          ##
+          (nil?* ast)
+          (make-vector ())
+          ##
+          (throw* (make-string "vec requires a vector, list, or nil")))))))
 
-(defn vector?*
-  [ast]
-  (= (ast :tag) :vector))
+(def mal-hash-map
+  (make-function
+    (fn [asts]
+      (when (= 1 (% (length asts) 2))
+        (throw* (make-string
+                  "hash-map requires an even number of arguments")))
+      (make-hash-map asts))))
 
-(def mal-vector?
+(def mal-atom
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (make-string "vector? requires 1 argument")))
-      (if (vector?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(defn empty?*
-  [ast]
-  (empty? (ast :content)))
-
-(def mal-empty?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "empty? requires 1 argument")))
-      (if (empty?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(defn nil?*
-  [ast]
-  (= :nil (ast :tag)))
+        (throw* (make-string "atom requires 1 argument")))
+      (make-atom (in asts 0)))))
 
 (def mal-nil?
   (make-function
@@ -71,23 +283,193 @@
         (make-boolean true)
         (make-boolean false)))))
 
-(def mal-count
+(def mal-true?
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (make-string "count requires 1 argument")))
-      (let [ast (in asts 0)]
-        (if (nil?* ast)
-          (make-number 0)
-          (make-number (length (ast :content))))))))
-
-(defn cmp-fn
-  [op]
-  (make-function
-    (fn [asts]
-      (if (op ;(map |($ :content) asts))
+        (throw* (make-string "true? requires 1 argument")))
+      (if (true?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
+
+(def mal-false?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "false? requires 1 argument")))
+      (if (false?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-number?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "number? requires 1 argument")))
+      (if (number?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-symbol?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "symbol? requires 1 argument")))
+      (if (symbol?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-keyword?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "keyword? requires 1 argument")))
+      (if (keyword?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-string?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "string? requires 1 argument")))
+      (if (string?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-list?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "list? requires 1 argument")))
+      (if (list?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-vector?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "vector? requires 1 argument")))
+      (if (vector?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-map?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "map? requires 1 argument")))
+      (if (hash-map?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-fn?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "fn? requires 1 argument")))
+      (let [target-ast (in asts 0)]
+        (if (and (fn?* target-ast)
+                 (not (target-ast :is-macro)))
+          (make-boolean true)
+          (make-boolean false))))))
+
+(def mal-macro?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "macro? requires 1 argument")))
+      (let [the-ast (in asts 0)]
+        (if (macro?* the-ast)
+          (make-boolean true)
+          (make-boolean false))))))
+
+(def mal-atom?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "atom? requires 1 argument")))
+      (if (atom?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-sequential?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "sequential? requires 1 argument")))
+      (if (or (list?* (in asts 0))
+              (vector?* (in asts 0)))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-=
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "= requires 2 arguments")))
+      (let [ast-1 (in asts 0)
+            ast-2 (in asts 1)]
+        (if (equals?* ast-1 ast-2)
+          (make-boolean true)
+          (make-boolean false))))))
+
+(def mal-empty?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "empty? requires 1 argument")))
+      (if (empty?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-contains?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "contains? requires 2 arguments")))
+      (let [head-ast (in asts 0)]
+        (when (not (or (hash-map?* head-ast)
+                       (nil?* head-ast)))
+          (throw* (make-string
+                    "contains? first argument should be a hash-map or nil")))
+        (if (nil?* head-ast)
+          (make-nil)
+          (let [item-struct (head-ast :content)
+                key-ast (in asts 1)]
+            (if-let [val-ast (get item-struct key-ast)]
+              (make-boolean true)
+              (make-boolean false))))))))
+
+(def mal-deref
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "deref requires 1 argument")))
+      (let [ast (in asts 0)]
+        (deref* ast)))))
+
+(def mal-reset!
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "reset! requires 2 arguments")))
+      (let [atom-ast (in asts 0)
+            val-ast (in asts 1)]
+        (reset!* atom-ast val-ast)))))
+
+(def mal-swap!
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "swap! requires at least 2 arguments")))
+      (let [atom-ast (in asts 0)
+            fn-ast (in asts 1)
+            args-asts (slice asts 2)
+            inner-ast (deref* atom-ast)]
+        (reset!* atom-ast
+                 ((fn-ast :content) [inner-ast ;args-asts]))))))
 
 (def mal-pr-str
   (make-function
@@ -156,70 +538,15 @@
           # XXX: escaping?
           (make-string (slurp a-str)))))))
 
-(def mal-atom
+(def mal-count
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (make-string "atom requires 1 argument")))
-      (make-atom (in asts 0)))))
-
-(defn atom?*
-  [ast]
-  (= (ast :tag) :atom))
-
-(def mal-atom?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "atom? requires 1 argument")))
-      (if (atom?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(defn deref*
-  [ast]
-  (if (not (atom?* ast))
-    (throw* (make-string (string "Expected atom, got: " (ast :tag))))
-    (ast :content)))
-
-(def mal-deref
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "deref requires 1 argument")))
+        (throw* (make-string "count requires 1 argument")))
       (let [ast (in asts 0)]
-        (deref* ast)))))
-
-(defn reset!*
-  [atom-ast val-ast]
-  (put atom-ast
-       :content val-ast)
-  val-ast)
-
-(def mal-reset!
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 2)
-        (throw* (make-string "reset! requires 2 arguments")))
-      (let [atom-ast (in asts 0)
-            val-ast (in asts 1)]
-        (reset!* atom-ast val-ast)))))
-
-(def mal-swap!
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 2)
-        (throw* (make-string "swap! requires at least 2 arguments")))
-      (let [atom-ast (in asts 0)
-            fn-ast (in asts 1)
-            args-asts (slice asts 2)
-            inner-ast (deref* atom-ast)]
-        (reset!* atom-ast
-                 ((fn-ast :content) [inner-ast ;args-asts]))))))
-
-(defn cons*
-  [head-ast tail-ast]
-  [head-ast ;(tail-ast :content)])
+        (if (nil?* ast)
+          (make-number 0)
+          (make-number (length (ast :content))))))))
 
 (def mal-cons
   (make-function
@@ -230,26 +557,10 @@
             tail-ast (in asts 1)]
         (make-list (cons* head-ast tail-ast))))))
 
-(defn concat*
-  [& list-asts]
-  (reduce (fn [acc list-ast]
-            [;acc ;(list-ast :content)])
-          []
-          list-asts))
-
 (def mal-concat
   (make-function
     (fn [asts]
       (make-list (concat* ;asts)))))
-
-(defn nth*
-  [coll-ast num-ast]
-  (let [elts (coll-ast :content)
-        n-elts (length elts)
-        i (num-ast :content)]
-    (if (< i n-elts)
-      (in elts i)
-      (throw* (make-string (string "Index out of range: " i))))))
 
 (def mal-nth
   (make-function
@@ -260,13 +571,6 @@
             num-ast (in asts 1)]
         (nth* coll-ast num-ast)))))
 
-(defn first*
-  [coll-or-nil-ast]
-  (if (or (nil?* coll-or-nil-ast)
-          (empty?* coll-or-nil-ast))
-    (make-nil)
-    (in (coll-or-nil-ast :content) 0)))
-
 (def mal-first
   (make-function
     (fn [asts]
@@ -275,13 +579,6 @@
       (let [coll-or-nil-ast (in asts 0)]
         (first* coll-or-nil-ast)))))
 
-(defn rest*
-  [coll-or-nil-ast]
-  (if (or (nil?* coll-or-nil-ast)
-          (empty?* coll-or-nil-ast))
-    (make-list [])
-    (make-list (slice (coll-or-nil-ast :content) 1))))
-
 (def mal-rest
   (make-function
     (fn [asts]
@@ -289,179 +586,6 @@
         (throw* (make-string "rest requires 1 argument")))
       (let [coll-or-nil-ast (in asts 0)]
         (rest* coll-or-nil-ast)))))
-
-(def mal-throw
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "throw requires 1 argument")))
-      (throw* (in asts 0)))))
-
-# (apply F A B [C D]) is equivalent to (F A B C D)
-(def mal-apply
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "apply requires at least 1 argument")))
-      (let [the-fn ((in asts 0) :content)] # e.g. F
-        (if (= (length asts) 1)
-          (the-fn [])
-          (let [last-asts ((get (slice asts -2) 0) :content) # e.g. [C D]
-                args-asts (slice asts 1 -2)] # e.g. [A B]
-            (the-fn [;args-asts ;last-asts])))))))
-
-(def mal-map
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 2)
-        (throw* (make-string "map requires at least 2 arguments")))
-      (let [the-fn ((in asts 0) :content)
-            coll ((in asts 1) :content)]
-        (make-list (map |(the-fn [$])
-                        coll))))))
-
-(def mal-vec
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "vec requires 1 argument")))
-      (let [ast (in asts 0)]
-        (cond
-          (vector?* ast)
-          ast
-          ##
-          (list?* ast)
-          (make-vector (ast :content))
-          ##
-          (nil?* ast)
-          (make-vector ())
-          ##
-          (throw* (make-string "vec requires a vector, list, or nil")))))))
-
-(defn true?*
-  [ast]
-  (and (= :boolean (ast :tag))
-       (= "true" (ast :content))))
-
-(def mal-true?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "true? requires 1 argument")))
-      (if (true?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(defn false?*
-  [ast]
-  (and (= :boolean (ast :tag))
-       (= "false" (ast :content))))
-
-(def mal-false?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "false? requires 1 argument")))
-      (if (false?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(defn symbol?*
-  [ast]
-  (= :symbol (ast :tag)))
-
-(def mal-symbol?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "symbol? requires 1 argument")))
-      (if (symbol?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(def mal-symbol
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "symbol requires 1 argument")))
-      (make-symbol ((in asts 0) :content)))))
-
-(defn keyword?*
-  [ast]
-  (= (ast :tag) :keyword))
-
-(defn string?*
-  [ast]
-  (= (ast :tag) :string))
-
-(def mal-keyword
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "keyword requires 1 argument")))
-      (let [arg-ast (in asts 0)]
-        (cond
-          (keyword?* arg-ast)
-          arg-ast
-          ##
-          (string?* arg-ast)
-          (make-keyword (string ":" (arg-ast :content)))
-          ##
-          (throw* (make-string "Expected string")))))))
-
-(def mal-keyword?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "keyword? requires 1 argument")))
-      (if (keyword?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(def mal-string?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "string? requires 1 argument")))
-      (if (string?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(def mal-vector
-  (make-function
-    (fn [asts]
-      (make-vector asts))))
-
-(def mal-sequential?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "sequential? requires 1 argument")))
-      (if (or (list?* (in asts 0))
-              (vector?* (in asts 0)))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(def mal-hash-map
-  (make-function
-    (fn [asts]
-      (when (= 1 (% (length asts) 2))
-        (throw* (make-string
-                  "hash-map requires an even number of arguments")))
-      (make-hash-map asts))))
-
-(defn hash-map?*
-  [ast]
-  (= (ast :tag) :hash-map))
-
-(def mal-map?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "map? requires 1 argument")))
-      (if (hash-map?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
 
 (def mal-assoc
   (make-function
@@ -517,24 +641,6 @@
               val-ast
               (make-nil))))))))
 
-(def mal-contains?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 2)
-        (throw* (make-string "contains? requires 2 arguments")))
-      (let [head-ast (in asts 0)]
-        (when (not (or (hash-map?* head-ast)
-                       (nil?* head-ast)))
-          (throw* (make-string
-                    "contains? first argument should be a hash-map or nil")))
-        (if (nil?* head-ast)
-          (make-nil)
-          (let [item-struct (head-ast :content)
-                key-ast (in asts 1)]
-            (if-let [val-ast (get item-struct key-ast)]
-              (make-boolean true)
-              (make-boolean false))))))))
-
 (def mal-keys
   (make-function
     (fn [asts]
@@ -564,122 +670,6 @@
           (make-nil)
           (let [item-struct (head-ast :content)]
             (make-list (values item-struct))))))))
-
-# XXX: likely this could be simpler
-(defn equals?*
-  [ast-1 ast-2]
-  (let [tag-1 (ast-1 :tag)
-        tag-2 (ast-2 :tag)]
-    (if (and (not= tag-1 tag-2)
-             # XXX: not elegant
-             (not (and (= tag-1 :list) (= tag-2 :vector)))
-             (not (and (= tag-2 :list) (= tag-1 :vector))))
-      false
-      (let [val-1 (ast-1 :content)
-            val-2 (ast-2 :content)]
-        # XXX: when not a collection...
-        (if (and (not (list?* ast-1))
-                 (not (vector?* ast-1))
-                 (not (hash-map?* ast-1)))
-          (= val-1 val-2)
-          (if (not= (length val-1) (length val-2))
-            false
-            (if (and (not (hash-map?* ast-1))
-                     (not (hash-map?* ast-2)))
-              (do
-                (var found-unequal false)
-                (each [v1 v2] (partition 2 (interleave val-1 val-2))
-                      (when (not (equals?* v1 v2))
-                        (set found-unequal true)
-                        (break)))
-                (not found-unequal))
-              (if (or (not (hash-map?* ast-1))
-                      (not (hash-map?* ast-2)))
-                false
-                (do
-                  (var found-unequal false)
-                  (each [k1 k2] (partition 2 (interleave (keys val-1)
-                                                         (keys val-2)))
-                        (when (not (equals?* k1 k2))
-                          (set found-unequal true)
-                          (break))
-                        (when (not (equals?* (val-1 k1) (val-2 k2)))
-                          (set found-unequal true)
-                          (break)))
-                  (not found-unequal))))))))))
-
-(def mal-=
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 2)
-        (throw* (make-string "= requires 2 arguments")))
-      (let [ast-1 (in asts 0)
-            ast-2 (in asts 1)]
-        (if (equals?* ast-1 ast-2)
-          (make-boolean true)
-          (make-boolean false))))))
-
-(def mal-readline
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "readline requires 1 argument")))
-      (let [prompt ((in asts 0) :content)
-            buf @""]
-        (file/write stdout prompt)
-        (file/flush stdout)
-        (file/read stdin :line buf)
-        (if (< 0 (length buf))
-          (make-string (string/trimr buf))
-          (make-nil))))))
-
-(defn number?*
-  [ast]
-  (= (ast :tag) :number))
-
-(def mal-number?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "number? requires 1 argument")))
-      (if (number?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
-
-(defn fn?*
-  [ast]
-  (= (ast :tag) :function))
-
-(def mal-fn?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "fn? requires 1 argument")))
-      (let [target-ast (in asts 0)]
-        (if (and (fn?* target-ast)
-                 (not (target-ast :is-macro)))
-          (make-boolean true)
-          (make-boolean false))))))
-
-(defn macro?*
-  [ast]
-  (and (fn?* ast)
-       (ast :is-macro)))
-
-(def mal-macro?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "macro? requires 1 argument")))
-      (let [the-ast (in asts 0)]
-        (if (macro?* the-ast)
-          (make-boolean true)
-          (make-boolean false))))))
-
-(def mal-time-ms
-  (make-function
-    (fn [asts]
-      (make-number (os/clock)))))
 
 (def mal-conj
   (make-function
@@ -729,6 +719,29 @@
           ##
           (throw* (make-string "Expected list, vector, string, or nil")))))))
 
+(def mal-map
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "map requires at least 2 arguments")))
+      (let [the-fn ((in asts 0) :content)
+            coll ((in asts 1) :content)]
+        (make-list (map |(the-fn [$])
+                        coll))))))
+
+# (apply F A B [C D]) is equivalent to (F A B C D)
+(def mal-apply
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "apply requires at least 1 argument")))
+      (let [the-fn ((in asts 0) :content)] # e.g. F
+        (if (= (length asts) 1)
+          (the-fn [])
+          (let [last-asts ((get (slice asts -2) 0) :content) # e.g. [C D]
+                args-asts (slice asts 1 -2)] # e.g. [A B]
+            (the-fn [;args-asts ;last-asts])))))))
+
 (def mal-meta
   (make-function
     (fn [asts]
@@ -741,10 +754,6 @@
                 (fn?* head-ast))
           ((in asts 0) :meta)
           (make-nil))))))
-
-(defn spawn-function
-  [fn-ast overrides]
-  (merge fn-ast overrides))
 
 (def mal-with-meta
   (make-function
@@ -768,40 +777,31 @@
           ##
           (throw* (make-string "Expected list, vector, hash-map, or fn")))))))
 
-(defn janet-eval*
-  [janet-val]
-  (case (type janet-val)
-    :nil
-    (make-nil)
-    ##
-    :boolean
-    (make-boolean janet-val)
-    ##
-    :number # XXX: there may be some incompatibilities
-    (make-number janet-val)
-    ##
-    :string
-    (make-string janet-val)
-    ##
-    :keyword # XXX: there may be some incompatibilities
-    (make-keyword (string ":" janet-val))
-    ##
-    :symbol # XXX: there may be some incompatibilities
-    (make-symbol (string janet-val))
-    ##
-    :tuple
-    (make-list (map janet-eval* janet-val))
-    ##
-    :array
-    (make-list (map janet-eval* janet-val))
-    ##
-    :struct
-    (make-hash-map (struct ;(map janet-eval* (kvs janet-val))))
-    ##
-    :table
-    (make-hash-map (struct ;(map janet-eval* (kvs janet-val))))
-    ##
-    (throw* (make-string (string "Unsupported type: " (type janet-val))))))
+(def mal-throw
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "throw requires 1 argument")))
+      (throw* (in asts 0)))))
+
+(def mal-readline
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "readline requires 1 argument")))
+      (let [prompt ((in asts 0) :content)
+            buf @""]
+        (file/write stdout prompt)
+        (file/flush stdout)
+        (file/read stdin :line buf)
+        (if (< 0 (length buf))
+          (make-string (string/trimr buf))
+          (make-nil))))))
+
+(def mal-time-ms
+  (make-function
+    (fn [asts]
+      (make-number (os/clock)))))
 
 (def mal-janet-eval
   (make-function

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -245,48 +245,6 @@
     (fn [asts]
       (make-list (concat* ;asts)))))
 
-(defn starts-with
-  [ast name]
-  (when (and (list?* ast)
-             (not (is-empty?* ast)))
-    (let [head-ast (in (ast :content) 0)]
-      (and (= :symbol (head-ast :tag))
-           (= name (head-ast :content))))))
-
-(var quasiquote* nil)
-
-(defn qq-iter
-  [ast]
-  (if (is-empty?* ast)
-    (make-list ())
-    (let [elt (in (ast :content) 0)
-          acc (qq-iter (make-list (slice (ast :content) 1)))]
-      (if (starts-with elt "splice-unquote")
-        (make-list [(make-symbol "concat")
-                    (in (elt :content) 1)
-                    acc])
-        (make-list [(make-symbol "cons")
-                    (quasiquote* elt)
-                    acc])))))
-
-(varfn quasiquote*
-  [ast]
-  (cond
-    (starts-with ast "unquote")
-    (in (ast :content) 1)
-    ##
-    (list?* ast)
-    (qq-iter ast)
-    ##
-    (vector?* ast)
-    (make-list [(make-symbol "vec") (qq-iter ast)])
-    ##
-    (or (= :symbol (ast :tag))
-        (= :hash-map (ast :tag)))
-    (make-list [(make-symbol "quote") ast])
-    ##
-    ast))
-
 (defn nth*
   [coll-ast num-ast]
   (let [elts (coll-ast :content)

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -12,8 +12,8 @@
     (fn [asts]
       (let [ast-1 (in asts 0)
             ast-2 (in asts 1)]
-        (make-number (string (op (scan-number (ast-1 :content))
-                                 (scan-number (ast-2 :content)))))))))
+        (make-number (op (ast-1 :content)
+                         (ast-2 :content)))))))
 
 (def create-list
   (make-function
@@ -68,8 +68,8 @@
       (let [ast (in asts 0)]
         (let [tag (ast :tag)]
           (if (= tag :nil)
-            (make-number "0")
-            (make-number (string (length (ast :content))))))))))
+            (make-number 0)
+            (make-number (length (ast :content)))))))))
 
 
 (defn cmp-fn
@@ -78,8 +78,8 @@
     (fn [asts]
       (let [ast-1 (in asts 0)
             ast-2 (in asts 1)]
-        (let [val-1 (scan-number (ast-1 :content))
-              val-2 (scan-number (ast-2 :content))]
+        (let [val-1 (ast-1 :content)
+              val-2 (ast-2 :content)]
           (if (op val-1 val-2)
             (make-boolean true)
             (make-boolean false)))))))
@@ -223,8 +223,8 @@
 
 (defn starts-with
   [ast name]
-  (when (and (not (is-empty?* ast))
-             (list?* ast))
+  (when (and (list?* ast)
+             (not (is-empty?* ast)))
     (let [head-ast (in (ast :content) 0)]
       (and (= :symbol (head-ast :tag))
            (= name (head-ast :content))))))
@@ -267,7 +267,7 @@
   [coll-ast num-ast]
   (let [elts (coll-ast :content)
         n-elts (length elts)
-        i (scan-number (num-ast :content))]
+        i (num-ast :content)]
     (if (< i n-elts)
       (in elts i)
       (throw* (make-string (string "Index out of range: " i))))))
@@ -603,9 +603,7 @@
 (def time-ms
   (make-function
     (fn [asts]
-      # XXX: hack to get test to pass :(
-      (os/sleep 1)
-      (make-number (string (os/time))))))
+      (make-number (os/clock)))))
 
 (def conj
   (make-function

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -687,6 +687,9 @@
       (let [coll-ast (in asts 0)
             item-asts (slice asts 1)]
         (cond
+          (nil?* coll-ast)
+          (make-list [;(reverse item-asts)])
+          ##
           (list?* coll-ast)
           (make-list [;(reverse item-asts) ;(coll-ast :content)])
           ##

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -800,12 +800,15 @@
     (fn [asts]
       (when (< (length asts) 1)
         (throw* (make-string "janet-eval requires 1 argument")))
-      (let [str-ast (in asts 0)
-            res (try
-                  (eval-string (str-ast :content)) # XXX: escaping?
-                  ([err]
-                   (throw* (make-string (string "Eval failed: " err)))))]
-        (janet-eval* res)))))
+      (let [head-ast (in asts 0)]
+        (when (not (string?* head-ast))
+          (throw* (make-string
+                    "janet-eval first argument should be a string")))
+        (let [res (try
+                    (eval-string (head-ast :content)) # XXX: escaping?
+                    ([err]
+                     (throw* (make-string (string "Eval failed: " err)))))]
+          (janet-eval* res))))))
 
 ##
 

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -732,7 +732,13 @@
     (fn [asts]
       (when (< (length asts) 1)
         (throw* (make-string "meta requires 1 argument")))
-      ((in asts 0) :meta))))
+      (let [head-ast (in asts 0)]
+        (if (or (list?* head-ast)
+                (vector?* head-ast)
+                (hash-map?* head-ast)
+                (fn?* head-ast))
+          ((in asts 0) :meta)
+          (make-nil))))))
 
 (defn spawn-function
   [fn-ast overrides]

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -14,7 +14,7 @@
         (op ;(map |($ :content)
                   asts))))))
 
-(def create-list
+(def mal-list
   (make-function
     (fn [asts]
       (make-list asts))))
@@ -36,7 +36,7 @@
   [ast]
   (= (ast :tag) :vector))
 
-(def create-vector
+(def mal-vec
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -60,20 +60,20 @@
         (make-boolean true)
         (make-boolean false)))))
 
-(defn is-empty?*
+(defn empty?*
   [ast]
   (empty? (ast :content)))
 
-(def is-empty?
+(def mal-empty?
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
         (throw* (make-string "empty? requires 1 argument")))
-      (if (is-empty?* (in asts 0))
+      (if (empty?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
 
-(def count-elts
+(def mal-count
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -92,7 +92,7 @@
         (make-boolean true)
         (make-boolean false)))))
 
-(def pr-str
+(def mal-pr-str
   (make-function
     (fn [asts]
       (def buf @"")
@@ -104,7 +104,7 @@
         (buffer/popn buf 1))
       (make-string (string buf)))))
 
-(def str
+(def mal-str
   (make-function
     (fn [asts]
       (def buf @"")
@@ -113,7 +113,7 @@
               (buffer/push-string buf (printer/pr_str ast false))))
       (make-string (string buf)))))
 
-(def prn
+(def mal-prn
   (make-function
     (fn [asts]
       (def buf @"")
@@ -126,7 +126,7 @@
       (print (string buf))
       (make-nil))))
 
-(def println
+(def mal-println
   (make-function
     (fn [asts]
       (def buf @"")
@@ -139,7 +139,7 @@
       (print (string buf))
       (make-nil))))
 
-(def read-string
+(def mal-read-string
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -159,7 +159,7 @@
           # XXX: escaping?
           (make-string (slurp a-str)))))))
 
-(def create-atom
+(def mal-atom
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -185,7 +185,7 @@
     (throw* (make-string (string "Expected atom, got: " (ast :tag))))
     (ast :content)))
 
-(def deref
+(def mal-deref
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -199,7 +199,7 @@
        :content val-ast)
   val-ast)
 
-(def reset!
+(def mal-reset!
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
@@ -208,7 +208,7 @@
             val-ast (in asts 1)]
         (reset!* atom-ast val-ast)))))
 
-(def swap!
+(def mal-swap!
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
@@ -224,7 +224,7 @@
   [head-ast tail-ast]
   [head-ast ;(tail-ast :content)])
 
-(def cons
+(def mal-cons
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
@@ -240,7 +240,7 @@
           []
           list-asts))
 
-(def concat
+(def mal-concat
   (make-function
     (fn [asts]
       (make-list (concat* ;asts)))))
@@ -254,7 +254,7 @@
       (in elts i)
       (throw* (make-string (string "Index out of range: " i))))))
 
-(def nth
+(def mal-nth
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
@@ -266,7 +266,7 @@
 (defn first*
   [coll-or-nil-ast]
   (if (or (= (coll-or-nil-ast :tag) :nil)
-          (is-empty?* coll-or-nil-ast))
+          (empty?* coll-or-nil-ast))
     (make-nil)
     (in (coll-or-nil-ast :content) 0)))
 
@@ -281,11 +281,11 @@
 (defn rest*
   [coll-or-nil-ast]
   (if (or (= (coll-or-nil-ast :tag) :nil)
-          (is-empty?* coll-or-nil-ast))
+          (empty?* coll-or-nil-ast))
     (make-list [])
     (make-list (slice (coll-or-nil-ast :content) 1))))
 
-(def rest
+(def mal-rest
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -293,7 +293,7 @@
       (let [coll-or-nil-ast (in asts 0)]
         (rest* coll-or-nil-ast)))))
 
-(def throw
+(def mal-throw
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -377,7 +377,7 @@
         (make-boolean true)
         (make-boolean false)))))
 
-(def create-symbol
+(def mal-symbol
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -392,7 +392,7 @@
   [ast]
   (= (ast :tag) :string))
 
-(def create-keyword
+(def mal-keyword
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -425,7 +425,7 @@
         (make-boolean true)
         (make-boolean false)))))
 
-(def create-vector-from-items
+(def mal-vector
   (make-function
     (fn [asts]
       (make-vector asts))))
@@ -440,7 +440,7 @@
         (make-boolean true)
         (make-boolean false)))))
 
-(def create-hash-map
+(def mal-hash-map
   (make-function
     (fn [asts]
       (when (= 1 (% (length asts) 2))
@@ -461,7 +461,7 @@
         (make-boolean true)
         (make-boolean false)))))
 
-(def assoc
+(def mal-assoc
   (make-function
     (fn [asts]
       (when (< (length asts) 3)
@@ -479,7 +479,7 @@
                   (put item-table key-ast val-ast))
             (make-hash-map (table/to-struct item-table))))))))
 
-(def dissoc
+(def mal-dissoc
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
@@ -515,7 +515,7 @@
               val-ast
               (make-nil))))))))
 
-(def contains?
+(def mal-contains?
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
@@ -606,7 +606,7 @@
                           (break)))
                   (not found-unequal))))))))))
 
-(def equals?
+(def mal-=
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
@@ -617,7 +617,7 @@
           (make-boolean true)
           (make-boolean false))))))
 
-(def readline
+(def mal-readline
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -674,12 +674,12 @@
           (make-boolean true)
           (make-boolean false))))))
 
-(def time-ms
+(def mal-time-ms
   (make-function
     (fn [asts]
       (make-number (os/clock)))))
 
-(def conj
+(def mal-conj
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
@@ -706,17 +706,17 @@
       (let [arg-ast (in asts 0)]
         (cond
           (list?* arg-ast)
-          (if (is-empty?* arg-ast)
+          (if (empty?* arg-ast)
             (make-nil)
             arg-ast)
           ##
           (vector?* arg-ast)
-          (if (is-empty?* arg-ast)
+          (if (empty?* arg-ast)
             (make-nil)
             (make-list (arg-ast :content)))
           ##
           (string?* arg-ast)
-          (if (is-empty?* arg-ast)
+          (if (empty?* arg-ast)
             (make-nil)
             (let [str-asts (map |(make-string (string/from-bytes $))
                                 (arg-ast :content))]
@@ -727,7 +727,7 @@
           ##
           (throw* (make-string "Expected list, vector, string, or nil")))))))
 
-(def meta
+(def mal-meta
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -738,7 +738,7 @@
   [fn-ast overrides]
   (merge fn-ast overrides))
 
-(def with-meta
+(def mal-with-meta
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
@@ -795,7 +795,7 @@
     ##
     (throw* (make-string (string "Unsupported type: " (type janet-val))))))
 
-(def janet-eval
+(def mal-janet-eval
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
@@ -816,71 +816,71 @@
         (throw* (make-string "type requires 1 argument")))
       (make-keyword ((in asts 0) :tag)))))
 
-(def unimplemented throw)
+(def unimplemented mal-throw)
 
 (def ns
   {(make-symbol "+") (arith-fn +)
    (make-symbol "-") (arith-fn -)
    (make-symbol "*") (arith-fn *)
    (make-symbol "/") (arith-fn /)
-   (make-symbol "list") create-list
+   (make-symbol "list") mal-list
    (make-symbol "list?") mal-list?
-   (make-symbol "vec") create-vector
+   (make-symbol "vec") mal-vec
    (make-symbol "vector?") mal-vector?
-   (make-symbol "empty?") is-empty?
-   (make-symbol "count") count-elts
-   (make-symbol "=") equals?
+   (make-symbol "empty?") mal-empty?
+   (make-symbol "count") mal-count
+   (make-symbol "=") mal-=
    (make-symbol "<") (cmp-fn <)
    (make-symbol "<=") (cmp-fn <=)
    (make-symbol ">") (cmp-fn >)
    (make-symbol ">=") (cmp-fn >=)
-   (make-symbol "pr-str") pr-str
-   (make-symbol "str") str
-   (make-symbol "prn") prn
-   (make-symbol "println") println
-   (make-symbol "read-string") read-string
+   (make-symbol "pr-str") mal-pr-str
+   (make-symbol "str") mal-str
+   (make-symbol "prn") mal-prn
+   (make-symbol "println") mal-println
+   (make-symbol "read-string") mal-read-string
    (make-symbol "slurp") mal-slurp
-   (make-symbol "atom") create-atom
+   (make-symbol "atom") mal-atom
    (make-symbol "atom?") mal-atom?
-   (make-symbol "deref") deref
-   (make-symbol "reset!") reset!
-   (make-symbol "swap!") swap!
-   (make-symbol "cons") cons
-   (make-symbol "concat") concat
-   (make-symbol "nth") nth
+   (make-symbol "deref") mal-deref
+   (make-symbol "reset!") mal-reset!
+   (make-symbol "swap!") mal-swap!
+   (make-symbol "cons") mal-cons
+   (make-symbol "concat") mal-concat
+   (make-symbol "nth") mal-nth
    (make-symbol "first") mal-first
-   (make-symbol "rest") rest
-   (make-symbol "throw") throw
+   (make-symbol "rest") mal-rest
+   (make-symbol "throw") mal-throw
    (make-symbol "apply") mal-apply
    (make-symbol "map") mal-map
    (make-symbol "nil?") mal-nil?
    (make-symbol "true?") mal-true?
    (make-symbol "false?") mal-false?
    (make-symbol "symbol?") mal-symbol?
-   (make-symbol "symbol") create-symbol
-   (make-symbol "keyword") create-keyword
+   (make-symbol "symbol") mal-symbol
+   (make-symbol "keyword") mal-keyword
    (make-symbol "keyword?") mal-keyword?
-   (make-symbol "vector") create-vector-from-items
+   (make-symbol "vector") mal-vector
    (make-symbol "sequential?") mal-sequential?
-   (make-symbol "hash-map") create-hash-map
+   (make-symbol "hash-map") mal-hash-map
    (make-symbol "map?") mal-map?
-   (make-symbol "assoc") assoc
-   (make-symbol "dissoc") dissoc
+   (make-symbol "assoc") mal-assoc
+   (make-symbol "dissoc") mal-dissoc
    (make-symbol "get") mal-get
-   (make-symbol "contains?") contains?
+   (make-symbol "contains?") mal-contains?
    (make-symbol "keys") mal-keys
    (make-symbol "vals") mal-vals
-   (make-symbol "readline") readline
-   (make-symbol "time-ms") time-ms
-   (make-symbol "meta") meta
-   (make-symbol "with-meta") with-meta
+   (make-symbol "readline") mal-readline
+   (make-symbol "time-ms") mal-time-ms
+   (make-symbol "meta") mal-meta
+   (make-symbol "with-meta") mal-with-meta
    (make-symbol "fn?") mal-fn?
    (make-symbol "string?") mal-string?
    (make-symbol "number?") mal-number?
-   (make-symbol "conj") conj
+   (make-symbol "conj") mal-conj
    (make-symbol "seq") mal-seq
    (make-symbol "macro?") mal-macro?
-   (make-symbol "janet-eval") janet-eval
+   (make-symbol "janet-eval") mal-janet-eval
    ##
    (make-symbol "type") mal-type
 })

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -10,10 +10,9 @@
   [op]
   (make-function
     (fn [asts]
-      (let [ast-1 (in asts 0)
-            ast-2 (in asts 1)]
-        (make-number (op (ast-1 :content)
-                         (ast-2 :content)))))))
+      (make-number
+        (op ;(map |($ :content)
+                  asts))))))
 
 (def create-list
   (make-function

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -1,15 +1,12 @@
 (import ./types :as t)
+(import ./utils :as u)
 (import ./printer)
 (import ./reader)
-
-(defn throw*
-  [ast]
-  (error ast))
 
 (defn deref*
   [ast]
   (if (not (t/atom?* ast))
-    (throw* (t/make-string (string "Expected atom, got: " (t/get-type ast))))
+    (u/throw* (t/make-string (string "Expected atom, got: " (t/get-type ast))))
     (t/get-value ast)))
 
 (defn reset!*
@@ -35,7 +32,7 @@
         i (t/get-value num-ast)]
     (if (< i n-elts)
       (in elts i)
-      (throw* (t/make-string (string "Index out of range: " i))))))
+      (u/throw* (t/make-string (string "Index out of range: " i))))))
 
 (defn first*
   [coll-or-nil-ast]
@@ -84,7 +81,7 @@
     :table
     (t/make-hash-map (struct ;(map janet-eval* (kvs janet-val))))
     ##
-    (throw* (t/make-string (string "Unsupported type: " (type janet-val))))))
+    (u/throw* (t/make-string (string "Unsupported type: " (type janet-val))))))
 
 (defn arith-fn
   [op]
@@ -106,14 +103,14 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "symbol requires 1 argument")))
+        (u/throw* (t/make-string "symbol requires 1 argument")))
       (t/make-symbol (t/get-value (in asts 0))))))
 
 (def mal-keyword
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "keyword requires 1 argument")))
+        (u/throw* (t/make-string "keyword requires 1 argument")))
       (let [arg-ast (in asts 0)]
         (cond
           (t/keyword?* arg-ast)
@@ -122,7 +119,7 @@
           (t/string?* arg-ast)
           (t/make-keyword (string ":" (t/get-value arg-ast)))
           ##
-          (throw* (t/make-string "Expected string")))))))
+          (u/throw* (t/make-string "Expected string")))))))
 
 (def mal-list
   (t/make-function
@@ -138,7 +135,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "vec requires 1 argument")))
+        (u/throw* (t/make-string "vec requires 1 argument")))
       (let [ast (in asts 0)]
         (cond
           (t/vector?* ast)
@@ -150,28 +147,28 @@
           (t/nil?* ast)
           (t/make-vector ())
           ##
-          (throw* (t/make-string "vec requires a vector, list, or nil")))))))
+          (u/throw* (t/make-string "vec requires a vector, list, or nil")))))))
 
 (def mal-hash-map
   (t/make-function
     (fn [asts]
       (when (= 1 (% (length asts) 2))
-        (throw* (t/make-string
-                  "hash-map requires an even number of arguments")))
+        (u/throw* (t/make-string
+                    "hash-map requires an even number of arguments")))
       (t/make-hash-map asts))))
 
 (def mal-atom
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "atom requires 1 argument")))
+        (u/throw* (t/make-string "atom requires 1 argument")))
       (t/make-atom (in asts 0)))))
 
 (def mal-nil?
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "nil? requires 1 argument")))
+        (u/throw* (t/make-string "nil? requires 1 argument")))
       (if (t/nil?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -180,7 +177,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "true? requires 1 argument")))
+        (u/throw* (t/make-string "true? requires 1 argument")))
       (if (t/true?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -189,7 +186,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "false? requires 1 argument")))
+        (u/throw* (t/make-string "false? requires 1 argument")))
       (if (t/false?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -198,7 +195,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "number? requires 1 argument")))
+        (u/throw* (t/make-string "number? requires 1 argument")))
       (if (t/number?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -207,7 +204,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "symbol? requires 1 argument")))
+        (u/throw* (t/make-string "symbol? requires 1 argument")))
       (if (t/symbol?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -216,7 +213,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "keyword? requires 1 argument")))
+        (u/throw* (t/make-string "keyword? requires 1 argument")))
       (if (t/keyword?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -225,7 +222,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "string? requires 1 argument")))
+        (u/throw* (t/make-string "string? requires 1 argument")))
       (if (t/string?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -234,7 +231,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "list? requires 1 argument")))
+        (u/throw* (t/make-string "list? requires 1 argument")))
       (if (t/list?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -243,7 +240,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "vector? requires 1 argument")))
+        (u/throw* (t/make-string "vector? requires 1 argument")))
       (if (t/vector?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -252,7 +249,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "map? requires 1 argument")))
+        (u/throw* (t/make-string "map? requires 1 argument")))
       (if (t/hash-map?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -261,7 +258,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "fn? requires 1 argument")))
+        (u/throw* (t/make-string "fn? requires 1 argument")))
       (let [target-ast (in asts 0)]
         (if (and (t/fn?* target-ast)
                  (not (t/get-is-macro target-ast)))
@@ -272,7 +269,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "macro? requires 1 argument")))
+        (u/throw* (t/make-string "macro? requires 1 argument")))
       (let [the-ast (in asts 0)]
         (if (t/macro?* the-ast)
           t/mal-true
@@ -282,7 +279,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "atom? requires 1 argument")))
+        (u/throw* (t/make-string "atom? requires 1 argument")))
       (if (t/atom?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -291,7 +288,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "sequential? requires 1 argument")))
+        (u/throw* (t/make-string "sequential? requires 1 argument")))
       (if (or (t/list?* (in asts 0))
               (t/vector?* (in asts 0)))
         t/mal-true
@@ -301,7 +298,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "= requires 2 arguments")))
+        (u/throw* (t/make-string "= requires 2 arguments")))
       (let [ast-1 (in asts 0)
             ast-2 (in asts 1)]
         (if (t/equals?* ast-1 ast-2)
@@ -312,7 +309,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "empty? requires 1 argument")))
+        (u/throw* (t/make-string "empty? requires 1 argument")))
       (if (t/empty?* (in asts 0))
         t/mal-true
         t/mal-false))))
@@ -321,12 +318,12 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "contains? requires 2 arguments")))
+        (u/throw* (t/make-string "contains? requires 2 arguments")))
       (let [head-ast (in asts 0)]
         (when (not (or (t/hash-map?* head-ast)
                        (t/nil?* head-ast)))
-          (throw* (t/make-string
-                    "contains? first argument should be a hash-map or nil")))
+          (u/throw* (t/make-string
+                      "contains? first argument should be a hash-map or nil")))
         (if (t/nil?* head-ast)
           t/mal-nil
           (let [item-struct (t/get-value head-ast)
@@ -339,7 +336,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "deref requires 1 argument")))
+        (u/throw* (t/make-string "deref requires 1 argument")))
       (let [ast (in asts 0)]
         (deref* ast)))))
 
@@ -347,7 +344,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "reset! requires 2 arguments")))
+        (u/throw* (t/make-string "reset! requires 2 arguments")))
       (let [atom-ast (in asts 0)
             val-ast (in asts 1)]
         (reset!* atom-ast val-ast)))))
@@ -356,7 +353,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "swap! requires at least 2 arguments")))
+        (u/throw* (t/make-string "swap! requires at least 2 arguments")))
       (let [atom-ast (in asts 0)
             fn-ast (in asts 1)
             args-asts (slice asts 2)
@@ -415,19 +412,19 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "read-string requires 1 argument")))
+        (u/throw* (t/make-string "read-string requires 1 argument")))
       (if-let [res (reader/read_str (t/get-value (in asts 0)))]
         res
-        (throw* (t/make-string "No code content"))))))
+        (u/throw* (t/make-string "No code content"))))))
 
 (def mal-slurp
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "slurp requires 1 argument")))
+        (u/throw* (t/make-string "slurp requires 1 argument")))
       (let [a-str (t/get-value (in asts 0))]
         (if (not (os/stat a-str))
-          (throw* (string "File not found: " a-str))
+          (u/throw* (string "File not found: " a-str))
           # XXX: escaping?
           (t/make-string (slurp a-str)))))))
 
@@ -435,7 +432,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "count requires 1 argument")))
+        (u/throw* (t/make-string "count requires 1 argument")))
       (let [ast (in asts 0)]
         (if (t/nil?* ast)
           (t/make-number 0)
@@ -445,7 +442,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "cons requires 2 arguments")))
+        (u/throw* (t/make-string "cons requires 2 arguments")))
       (let [head-ast (in asts 0)
             tail-ast (in asts 1)]
         (t/make-list (cons* head-ast tail-ast))))))
@@ -459,7 +456,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "nth requires 2 arguments")))
+        (u/throw* (t/make-string "nth requires 2 arguments")))
       (let [coll-ast (in asts 0)
             num-ast (in asts 1)]
         (nth* coll-ast num-ast)))))
@@ -468,7 +465,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "first requires 1 argument")))
+        (u/throw* (t/make-string "first requires 1 argument")))
       (let [coll-or-nil-ast (in asts 0)]
         (first* coll-or-nil-ast)))))
 
@@ -476,7 +473,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "rest requires 1 argument")))
+        (u/throw* (t/make-string "rest requires 1 argument")))
       (let [coll-or-nil-ast (in asts 0)]
         (rest* coll-or-nil-ast)))))
 
@@ -484,12 +481,12 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 3)
-        (throw* (t/make-string "assoc requires at least 3 arguments")))
+        (u/throw* (t/make-string "assoc requires at least 3 arguments")))
       (let [head-ast (in asts 0)]
         (when (not (or (t/hash-map?* head-ast)
                        (t/nil?* head-ast)))
-          (throw* (t/make-string
-                    "assoc first argument should be a hash-map or nil")))
+          (u/throw* (t/make-string
+                      "assoc first argument should be a hash-map or nil")))
         (if (t/nil?* head-ast)
           t/mal-nil
           (let [item-table (table ;(kvs (t/get-value head-ast)))
@@ -502,12 +499,12 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "dissoc requires at least 2 arguments")))
+        (u/throw* (t/make-string "dissoc requires at least 2 arguments")))
       (let [head-ast (in asts 0)]
         (when (not (or (t/hash-map?* head-ast)
                        (t/nil?* head-ast)))
-          (throw* (t/make-string
-                    "dissoc first argument should be a hash-map or nil")))
+          (u/throw* (t/make-string
+                      "dissoc first argument should be a hash-map or nil")))
         (if (t/nil?* head-ast)
           t/mal-nil
           (let [item-table (table ;(kvs (t/get-value head-ast)))
@@ -520,12 +517,12 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "get requires 2 arguments")))
+        (u/throw* (t/make-string "get requires 2 arguments")))
       (let [head-ast (in asts 0)]
         (when (not (or (t/hash-map?* head-ast)
                        (t/nil?* head-ast)))
-          (throw* (t/make-string
-                    "get first argument should be a hash-map or nil")))
+          (u/throw* (t/make-string
+                      "get first argument should be a hash-map or nil")))
         (if (t/nil?* head-ast)
           t/mal-nil
           (let [item-struct (t/get-value head-ast)
@@ -538,12 +535,12 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "keys requires 1 argument")))
+        (u/throw* (t/make-string "keys requires 1 argument")))
       (let [head-ast (in asts 0)]
         (when (not (or (t/hash-map?* head-ast)
                        (t/nil?* head-ast)))
-          (throw* (t/make-string
-                    "keys first argument should be a hash-map or nil")))
+          (u/throw* (t/make-string
+                      "keys first argument should be a hash-map or nil")))
         (if (t/nil?* head-ast)
           t/mal-nil
           (let [item-struct (t/get-value head-ast)]
@@ -553,12 +550,12 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "vals requires 1 argument")))
+        (u/throw* (t/make-string "vals requires 1 argument")))
       (let [head-ast (in asts 0)]
         (when (not (or (t/hash-map?* head-ast)
                        (t/nil?* head-ast)))
-          (throw* (t/make-string
-                    "vals first argument should be a hash-map or nil")))
+          (u/throw* (t/make-string
+                      "vals first argument should be a hash-map or nil")))
         (if (t/nil?* head-ast)
           t/mal-nil
           (let [item-struct (t/get-value head-ast)]
@@ -568,7 +565,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "conj requires at least 2 arguments")))
+        (u/throw* (t/make-string "conj requires at least 2 arguments")))
       (let [coll-ast (in asts 0)
             item-asts (slice asts 1)]
         (cond
@@ -581,13 +578,13 @@
           (t/vector?* coll-ast)
           (t/make-vector [;(t/get-value coll-ast) ;item-asts])
           ##
-          (throw* (t/make-string "Expected list or vector")))))))
+          (u/throw* (t/make-string "Expected list or vector")))))))
 
 (def mal-seq
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "seq requires 1 argument")))
+        (u/throw* (t/make-string "seq requires 1 argument")))
       (let [arg-ast (in asts 0)]
         (cond
           (t/list?* arg-ast)
@@ -610,13 +607,13 @@
           (t/nil?* arg-ast)
           arg-ast
           ##
-          (throw* (t/make-string "Expected list, vector, string, or nil")))))))
+          (u/throw* (t/make-string "Expected list, vector, string, or nil")))))))
 
 (def mal-map
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "map requires at least 2 arguments")))
+        (u/throw* (t/make-string "map requires at least 2 arguments")))
       (let [the-fn (t/get-value (in asts 0))
             coll (t/get-value (in asts 1))]
         (t/make-list (map |(the-fn [$])
@@ -627,7 +624,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "apply requires at least 1 argument")))
+        (u/throw* (t/make-string "apply requires at least 1 argument")))
       (let [the-fn (t/get-value (in asts 0))] # e.g. F
         (if (= (length asts) 1)
           (the-fn [])
@@ -639,7 +636,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "meta requires 1 argument")))
+        (u/throw* (t/make-string "meta requires 1 argument")))
       (let [head-ast (in asts 0)]
         (if (or (t/list?* head-ast)
                 (t/vector?* head-ast)
@@ -652,7 +649,7 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (t/make-string "with-meta requires 2 arguments")))
+        (u/throw* (t/make-string "with-meta requires 2 arguments")))
       (let [target-ast (in asts 0)
             meta-ast (in asts 1)]
         (cond
@@ -668,20 +665,20 @@
           (t/fn?* target-ast)
           (t/clone-with-meta target-ast meta-ast)
           ##
-          (throw* (t/make-string "Expected list, vector, hash-map, or fn")))))))
+          (u/throw* (t/make-string "Expected list, vector, hash-map, or fn")))))))
 
 (def mal-throw
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "throw requires 1 argument")))
-      (throw* (in asts 0)))))
+        (u/throw* (t/make-string "throw requires 1 argument")))
+      (u/throw* (in asts 0)))))
 
 (def mal-readline
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "readline requires 1 argument")))
+        (u/throw* (t/make-string "readline requires 1 argument")))
       (let [prompt (t/get-value (in asts 0))
             buf @""]
         (file/write stdout prompt)
@@ -700,15 +697,15 @@
   (t/make-function
     (fn [asts]
       (when (< (length asts) 1)
-        (throw* (t/make-string "janet-eval requires 1 argument")))
+        (u/throw* (t/make-string "janet-eval requires 1 argument")))
       (let [head-ast (in asts 0)]
         (when (not (t/string?* head-ast))
-          (throw* (t/make-string
-                    "janet-eval first argument should be a string")))
+          (u/throw* (t/make-string
+                      "janet-eval first argument should be a string")))
         (let [res (try
                     (eval-string (t/get-value head-ast)) # XXX: escaping?
                     ([err]
-                     (throw* (t/make-string (string "Eval failed: " err)))))]
+                     (u/throw* (t/make-string (string "Eval failed: " err)))))]
           (janet-eval* res))))))
 
 (def unimplemented mal-throw)

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -734,13 +734,9 @@
         (throw* (make-string "meta requires 1 argument")))
       ((in asts 0) :meta))))
 
-(defn copy-function
-  [fn-ast meta-ast]
-  (let [fn-attr (fn-ast :content)
-        is-macro-attr (fn-ast :is-macro)
-        env-attr (fn-ast :env)]
-    (make-function fn-attr
-                   meta-ast is-macro-attr nil nil env-attr)))
+(defn spawn-function
+  [fn-ast overrides]
+  (merge fn-ast overrides))
 
 (def with-meta
   (make-function
@@ -760,7 +756,7 @@
           (make-hash-map (target-ast :content) meta-ast)
           ##
           (fn?* target-ast)
-          (copy-function target-ast meta-ast)
+          (spawn-function target-ast {:meta meta-ast})
           ##
           (throw* (make-string "Expected list, vector, hash-map, or fn")))))))
 

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -314,12 +314,12 @@
 (def mal-apply
   (make-function
     (fn [asts]
-      (assert (< 1 (length asts))
-              "apply requires at least 2 arguments")
-      (let [the-fn ((in asts 0) :content) # r.g. F
-            last-asts ((get (slice asts -2) 0) :content) # e.g. [C D]
-            args-asts (slice asts 1 -2)] # e.g. [A B]
-        (the-fn [;args-asts ;last-asts])))))
+      (let [the-fn ((in asts 0) :content)] # e.g. F
+        (if (= (length asts) 1)
+          (the-fn [])
+          (let [last-asts ((get (slice asts -2) 0) :content) # e.g. [C D]
+                args-asts (slice asts 1 -2)] # e.g. [A B]
+            (the-fn [;args-asts ;last-asts])))))))
 
 (def mal-map
   (make-function

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -691,7 +691,8 @@
 (def mal-time-ms
   (t/make-function
     (fn [asts]
-      (t/make-number (os/clock)))))
+      (t/make-number
+        (math/floor (* 1000 (os/clock)))))))
 
 (def mal-janet-eval
   (t/make-function

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -2,6 +2,10 @@
 (import ./printer)
 (import ./reader)
 
+(defn throw*
+  [ast]
+  (error ast))
+
 (defn arith-fn
   [op]
   (make-function
@@ -16,18 +20,18 @@
     (fn [asts]
       (make-list asts))))
 
-(defn is-list?*
+(defn mal-list?*
   [ast]
   (= (ast :tag) :list))
 
-(def is-list?
+(def mal-list?
   (make-function
     (fn [asts]
-      (if (is-list?* (in asts 0))
+      (if (mal-list?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
 
-(defn is-vector?*
+(defn mal-vector?*
   [ast]
   (= (ast :tag) :vector))
 
@@ -35,14 +39,14 @@
   (make-function
     (fn [asts]
       (let [ast (in asts 0)]
-        (if (is-vector?* ast)
+        (if (mal-vector?* ast)
           ast
           (make-vector (ast :content)))))))
 
-(def is-vector?
+(def mal-vector?
   (make-function
     (fn [asts]
-      (if (is-vector?* (in asts 0))
+      (if (mal-vector?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
 
@@ -67,39 +71,6 @@
             (make-number "0")
             (make-number (string (length (ast :content))))))))))
 
-(defn equals?*
-  [ast-1 ast-2]
-  (let [tag-1 (ast-1 :tag)
-        tag-2 (ast-2 :tag)]
-    (if (and (not= tag-1 tag-2)
-             # XXX: not elegant
-             (not (and (= tag-1 :list) (= tag-2 :vector)))
-             (not (and (= tag-2 :list) (= tag-1 :vector))))
-      false
-      (let [val-1 (ast-1 :content)
-            val-2 (ast-2 :content)]
-        # XXX: when not a collection...
-        (if (and (not (is-list?* ast-1))
-                 (not (is-vector?* ast-1)))
-          (= val-1 val-2)
-          (if (not= (length val-1) (length val-2))
-            false
-            (do
-              (var found-unequal false)
-              (each [v1 v2] (partition 2 (interleave val-1 val-2))
-                    (when (not (equals?* v1 v2))
-                      (set found-unequal true)
-                      (break)))
-              (not found-unequal))))))))
-
-(def equals?
-  (make-function
-    (fn [asts]
-      (let [ast-1 (in asts 0)
-            ast-2 (in asts 1)]
-        (if (equals?* ast-1 ast-2)
-          (make-boolean true)
-          (make-boolean false))))))
 
 (defn cmp-fn
   [op]
@@ -170,7 +141,7 @@
     (fn [asts]
       (let [a-str ((in asts 0) :content)]
         (if (not (os/stat a-str))
-          (error (string "File not found: " a-str))
+          (throw* (string "File not found: " a-str))
           # XXX: escaping?
           (make-string (slurp a-str)))))))
 
@@ -179,21 +150,21 @@
     (fn [asts]
       (make-atom (in asts 0)))))
 
-(defn atom?*
+(defn mal-atom?*
   [ast]
   (= (ast :tag) :atom))
 
-(def atom?
+(def mal-atom?
   (make-function
     (fn [asts]
-      (if (atom?* (in asts 0))
+      (if (mal-atom?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
 
 (defn deref*
   [ast]
-  (if (not (atom?* ast))
-    (error (string "Expected atom, got: " (ast :tag)))
+  (if (not (mal-atom?* ast))
+    (throw* (make-string (string "Expected atom, got: " (ast :tag))))
     (ast :content)))
 
 (def deref
@@ -251,7 +222,7 @@
 (defn starts-with
   [ast name]
   (when (and (not (is-empty?* ast))
-             (is-list?* ast))
+             (mal-list?* ast))
     (let [head-ast (in (ast :content) 0)]
       (and (= :symbol (head-ast :tag))
            (= name (head-ast :content))))))
@@ -278,10 +249,10 @@
     (starts-with ast "unquote")
     (in (ast :content) 1)
     ##
-    (is-list?* ast)
+    (mal-list?* ast)
     (qq-iter ast)
     ##
-    (is-vector?* ast)
+    (mal-vector?* ast)
     (make-list [(make-symbol "vec") (qq-iter ast)])
     ##
     (or (= :symbol (ast :tag))
@@ -297,7 +268,7 @@
         i (scan-number (num-ast :content))]
     (if (< i n-elts)
       (in elts i)
-      (error (string "Index out of range: " i)))))
+      (throw* (make-string (string "Index out of range: " i))))))
 
 (def nth
   (make-function
@@ -332,15 +303,254 @@
       (let [coll-or-nil-ast (in asts 0)]
         (rest* coll-or-nil-ast)))))
 
+(def throw
+  (make-function
+    (fn [asts]
+      (throw* (in asts 0)))))
+
+# (apply F A B [C D]) is equivalent to (F A B C D)
+(def mal-apply
+  (make-function
+    (fn [asts]
+      (assert (< 1 (length asts))
+              "apply requires at least 2 arguments")
+      (let [the-fn ((in asts 0) :content) # r.g. F
+            last-asts ((get (slice asts -2) 0) :content) # e.g. [C D]
+            args-asts (slice asts 1 -2)] # e.g. [A B]
+        (the-fn [;args-asts ;last-asts])))))
+
+(def mal-map
+  (make-function
+    (fn [asts]
+      (assert (< 1 (length asts))
+              "map requires at least 2 arguments")
+      (let [the-fn ((in asts 0) :content)
+            coll ((in asts 1) :content)]
+        (make-list (map |(the-fn [$])
+                        coll))))))
+
+(defn nil?*
+  [ast]
+  (= :nil (ast :tag)))
+
+(def mal-nil?
+  (make-function
+    (fn [asts]
+      (if (nil?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(defn true?*
+  [ast]
+  (and (= :boolean (ast :tag))
+       (= "true" (ast :content))))
+
+(def mal-true?
+  (make-function
+    (fn [asts]
+      (if (true?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(defn false?*
+  [ast]
+  (and (= :boolean (ast :tag))
+       (= "false" (ast :content))))
+
+(def mal-false?
+  (make-function
+    (fn [asts]
+      (if (false?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(defn symbol?*
+  [ast]
+  (= :symbol (ast :tag)))
+
+(def mal-symbol?
+  (make-function
+    (fn [asts]
+      (if (symbol?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def mal-type
+  (make-function
+    (fn [asts]
+      (make-keyword ((in asts 0) :tag)))))
+
+(def create-symbol
+  (make-function
+    (fn [asts]
+      (make-symbol ((in asts 0) :content)))))
+
+(defn mal-keyword?*
+  [ast]
+  (= (ast :tag) :keyword))
+
+(defn mal-string?*
+  [ast]
+  (= (ast :tag) :string))
+
+(def create-keyword
+  (make-function
+    (fn [asts]
+      (let [arg-ast (in asts 0)]
+        (cond
+          (mal-keyword?* arg-ast)
+          arg-ast
+          ##
+          (mal-string?* arg-ast)
+          (make-keyword (string ":" (arg-ast :content)))
+          ##
+          (throw* (make-string "Expected string")))))))
+
+(def mal-keyword?
+  (make-function
+    (fn [asts]
+      (if (mal-keyword?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def create-vector-from-items
+  (make-function
+    (fn [asts]
+      (make-vector asts))))
+
+(def mal-sequential?
+  (make-function
+    (fn [asts]
+      (if (or (mal-list?* (in asts 0))
+              (mal-vector?* (in asts 0)))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def create-hash-map
+  (make-function
+    (fn [asts]
+      (make-hash-map asts))))
+
+(defn mal-hash-map?*
+  [ast]
+  (= (ast :tag) :hash-map))
+
+(def mal-map?
+  (make-function
+    (fn [asts]
+      (if (mal-hash-map?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
+(def assoc
+  (make-function
+    (fn [asts]
+      (let [item-table (table ;(kvs ((in asts 0) :content)))
+            kv-asts (slice asts 1 -1)]
+        (each [key-ast val-ast] (partition 2 kv-asts)
+          (put item-table key-ast val-ast))
+        (make-hash-map (table/to-struct item-table))))))
+
+(def dissoc
+  (make-function
+    (fn [asts]
+      (let [item-table (table ;(kvs ((in asts 0) :content)))
+            key-asts (slice asts 1 -1)]
+        (each key-ast key-asts
+              (put item-table key-ast nil))
+        (make-hash-map (table/to-struct item-table))))))
+
+(def mal-get
+  (make-function
+    (fn [asts]
+      (let [item-struct ((in asts 0) :content)
+            key-ast (in asts 1)]
+        (if-let [val-ast (get item-struct key-ast)]
+          val-ast
+          (make-nil))))))
+
+(def contains?
+  (make-function
+    (fn [asts]
+      (let [item-struct ((in asts 0) :content)
+            key-ast (in asts 1)]
+        (if-let [val-ast (get item-struct key-ast)]
+          (make-boolean true)
+          (make-boolean false))))))
+
+(def mal-keys
+  (make-function
+    (fn [asts]
+      (let [item-struct ((in asts 0) :content)]
+        (make-list (keys item-struct))))))
+
+(def mal-vals
+  (make-function
+    (fn [asts]
+      (let [item-struct ((in asts 0) :content)]
+        (make-list (values item-struct))))))
+
+# XXX: likely this could be simpler
+(defn equals?*
+  [ast-1 ast-2]
+  (let [tag-1 (ast-1 :tag)
+        tag-2 (ast-2 :tag)]
+    (if (and (not= tag-1 tag-2)
+             # XXX: not elegant
+             (not (and (= tag-1 :list) (= tag-2 :vector)))
+             (not (and (= tag-2 :list) (= tag-1 :vector))))
+      false
+      (let [val-1 (ast-1 :content)
+            val-2 (ast-2 :content)]
+        # XXX: when not a collection...
+        (if (and (not (mal-list?* ast-1))
+                 (not (mal-vector?* ast-1))
+                 (not (mal-hash-map?* ast-1)))
+          (= val-1 val-2)
+          (if (not= (length val-1) (length val-2))
+            false
+            (if (and (not (mal-hash-map?* ast-1))
+                     (not (mal-hash-map?* ast-2)))
+              (do
+                (var found-unequal false)
+                (each [v1 v2] (partition 2 (interleave val-1 val-2))
+                      (when (not (equals?* v1 v2))
+                        (set found-unequal true)
+                        (break)))
+                (not found-unequal))
+              (if (or (not (mal-hash-map?* ast-1))
+                      (not (mal-hash-map?* ast-2)))
+                false
+                (do
+                  (var found-unequal false)
+                  (each [k1 k2] (partition 2 (interleave (keys val-1)
+                                                         (keys val-2)))
+                        (when (not (equals?* k1 k2))
+                          (set found-unequal true)
+                          (break))
+                        (when (not (equals?* (val-1 k1) (val-2 k2)))
+                          (set found-unequal true)
+                          (break)))
+                  (not found-unequal))))))))))
+
+(def equals?
+  (make-function
+    (fn [asts]
+      (let [ast-1 (in asts 0)
+            ast-2 (in asts 1)]
+        (if (equals?* ast-1 ast-2)
+          (make-boolean true)
+          (make-boolean false))))))
+
 (def ns
   {(make-symbol "+") (arith-fn +)
    (make-symbol "-") (arith-fn -)
    (make-symbol "*") (arith-fn *)
    (make-symbol "/") (arith-fn /)
    (make-symbol "list") create-list
-   (make-symbol "list?") is-list?
+   (make-symbol "list?") mal-list?
    (make-symbol "vec") create-vector
-   (make-symbol "vector?") is-vector?
+   (make-symbol "vector?") mal-vector?
    (make-symbol "empty?") is-empty?
    (make-symbol "count") count-elts
    (make-symbol "=") equals?
@@ -355,7 +565,7 @@
    (make-symbol "read-string") read-string
    (make-symbol "slurp") mal-slurp
    (make-symbol "atom") create-atom
-   (make-symbol "atom?") atom?
+   (make-symbol "atom?") mal-atom?
    (make-symbol "deref") deref
    (make-symbol "reset!") reset!
    (make-symbol "swap!") swap!
@@ -364,4 +574,26 @@
    (make-symbol "nth") nth
    (make-symbol "first") mal-first
    (make-symbol "rest") rest
+   (make-symbol "throw") throw
+   (make-symbol "apply") mal-apply
+   (make-symbol "map") mal-map
+   (make-symbol "nil?") mal-nil?
+   (make-symbol "true?") mal-true?
+   (make-symbol "false?") mal-false?
+   (make-symbol "symbol?") mal-symbol?
+   (make-symbol "symbol") create-symbol
+   (make-symbol "keyword") create-keyword
+   (make-symbol "keyword?") mal-keyword?
+   (make-symbol "vector") create-vector-from-items
+   (make-symbol "sequential?") mal-sequential?
+   (make-symbol "hash-map") create-hash-map
+   (make-symbol "map?") mal-map?
+   (make-symbol "assoc") assoc
+   (make-symbol "dissoc") dissoc
+   (make-symbol "get") mal-get
+   (make-symbol "contains?") contains?
+   (make-symbol "keys") mal-keys
+   (make-symbol "vals") mal-vals
+   ##
+   (make-symbol "type") mal-type
 })

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -613,7 +613,7 @@
   (make-function
     (fn [asts]
       (when (< (length asts) 2)
-        (throw* (make-string "equals? requires 2 arguments")))
+        (throw* (make-string "= requires 2 arguments")))
       (let [ast-1 (in asts 0)
             ast-2 (in asts 1)]
         (if (equals?* ast-1 ast-2)

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -70,18 +70,13 @@
             (make-number 0)
             (make-number (length (ast :content)))))))))
 
-
 (defn cmp-fn
   [op]
   (make-function
     (fn [asts]
-      (let [ast-1 (in asts 0)
-            ast-2 (in asts 1)]
-        (let [val-1 (ast-1 :content)
-              val-2 (ast-2 :content)]
-          (if (op val-1 val-2)
-            (make-boolean true)
-            (make-boolean false)))))))
+      (if (op ;(map |($ :content) asts))
+        (make-boolean true)
+        (make-boolean false)))))
 
 (def pr-str
   (make-function

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -26,6 +26,8 @@
 (def mal-list?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "list? requires 1 argument")))
       (if (list?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -37,14 +39,23 @@
 (def create-vector
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "vec requires 1 argument")))
       (let [ast (in asts 0)]
-        (if (vector?* ast)
+        (cond
+          (vector?* ast)
           ast
-          (make-vector (ast :content)))))))
+          ##
+          (list?* ast)
+          (make-vector (ast :content))
+          ##
+          (throw* (make-string "vec requires a vector or list")))))))
 
 (def mal-vector?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "vector? requires 1 argument")))
       (if (vector?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -56,19 +67,22 @@
 (def is-empty?
   (make-function
     (fn [asts]
-      (let [ast (in asts 0)]
-        (if (is-empty?* ast)
-          (make-boolean true)
-          (make-boolean false))))))
+      (when (< (length asts) 1)
+        (throw* (make-string "empty? requires 1 argument")))
+      (if (is-empty?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
 
 (def count-elts
   (make-function
     (fn [asts]
-      (let [ast (in asts 0)]
-        (let [tag (ast :tag)]
-          (if (= tag :nil)
-            (make-number 0)
-            (make-number (length (ast :content)))))))))
+      (when (< (length asts) 1)
+        (throw* (make-string "count requires 1 argument")))
+      (let [ast (in asts 0)
+            tag (ast :tag)]
+        (if (= tag :nil)
+          (make-number 0)
+          (make-number (length (ast :content))))))))
 
 (defn cmp-fn
   [op]
@@ -128,13 +142,17 @@
 (def read-string
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "read-string requires 1 argument")))
       (if-let [res (reader/read_str ((in asts 0) :content))]
         res
-        (throw* (make-string "Blank Line"))))))
+        (throw* (make-string "No code content"))))))
 
 (def mal-slurp
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "slurp requires 1 argument")))
       (let [a-str ((in asts 0) :content)]
         (if (not (os/stat a-str))
           (throw* (string "File not found: " a-str))
@@ -144,6 +162,8 @@
 (def create-atom
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "atom requires 1 argument")))
       (make-atom (in asts 0)))))
 
 (defn atom?*
@@ -153,6 +173,8 @@
 (def mal-atom?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "atom? requires 1 argument")))
       (if (atom?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -166,6 +188,8 @@
 (def deref
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "deref requires 1 argument")))
       (let [ast (in asts 0)]
         (deref* ast)))))
 
@@ -178,6 +202,8 @@
 (def reset!
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "reset! requires 2 arguments")))
       (let [atom-ast (in asts 0)
             val-ast (in asts 1)]
         (reset!* atom-ast val-ast)))))
@@ -185,6 +211,8 @@
 (def swap!
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "swap! requires at least 2 arguments")))
       (let [atom-ast (in asts 0)
             fn-ast (in asts 1)
             args-asts (slice asts 2)
@@ -199,6 +227,8 @@
 (def cons
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "cons requires 2 arguments")))
       (let [head-ast (in asts 0)
             tail-ast (in asts 1)]
         (make-list (cons* head-ast tail-ast))))))
@@ -269,6 +299,8 @@
 (def nth
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "nth requires 2 arguments")))
       (let [coll-ast (in asts 0)
             num-ast (in asts 1)]
         (nth* coll-ast num-ast)))))
@@ -283,6 +315,8 @@
 (def mal-first
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "first requires 1 argument")))
       (let [coll-or-nil-ast (in asts 0)]
         (first* coll-or-nil-ast)))))
 
@@ -296,18 +330,24 @@
 (def rest
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "rest requires 1 argument")))
       (let [coll-or-nil-ast (in asts 0)]
         (rest* coll-or-nil-ast)))))
 
 (def throw
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "throw requires 1 argument")))
       (throw* (in asts 0)))))
 
 # (apply F A B [C D]) is equivalent to (F A B C D)
 (def mal-apply
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "apply requires at least 1 argument")))
       (let [the-fn ((in asts 0) :content)] # e.g. F
         (if (= (length asts) 1)
           (the-fn [])
@@ -332,6 +372,8 @@
 (def mal-nil?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "nil? requires 1 argument")))
       (if (nil?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -344,6 +386,8 @@
 (def mal-true?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "true? requires 1 argument")))
       (if (true?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -356,6 +400,8 @@
 (def mal-false?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "false? requires 1 argument")))
       (if (false?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -367,18 +413,17 @@
 (def mal-symbol?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "symbol? requires 1 argument")))
       (if (symbol?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
 
-(def mal-type
-  (make-function
-    (fn [asts]
-      (make-keyword ((in asts 0) :tag)))))
-
 (def create-symbol
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "symbol requires 1 argument")))
       (make-symbol ((in asts 0) :content)))))
 
 (defn keyword?*
@@ -392,6 +437,8 @@
 (def create-keyword
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "keyword requires 1 argument")))
       (let [arg-ast (in asts 0)]
         (cond
           (keyword?* arg-ast)
@@ -405,6 +452,8 @@
 (def mal-keyword?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "keyword? requires 1 argument")))
       (if (keyword?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -412,6 +461,8 @@
 (def mal-string?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "string? requires 1 argument")))
       (if (string?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -424,6 +475,8 @@
 (def mal-sequential?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "sequential? requires 1 argument")))
       (if (or (list?* (in asts 0))
               (vector?* (in asts 0)))
         (make-boolean true)
@@ -441,6 +494,8 @@
 (def mal-map?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "map? requires 1 argument")))
       (if (hash-map?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -448,6 +503,8 @@
 (def assoc
   (make-function
     (fn [asts]
+      (when (< (length asts) 3)
+        (throw* (make-string "assoc requires at least 3 arguments")))
       (let [item-table (table ;(kvs ((in asts 0) :content)))
             kv-asts (slice asts 1 -1)]
         (each [key-ast val-ast] (partition 2 kv-asts)
@@ -457,6 +514,8 @@
 (def dissoc
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "dissoc requires at least 2 arguments")))
       (let [item-table (table ;(kvs ((in asts 0) :content)))
             key-asts (slice asts 1 -1)]
         (each key-ast key-asts
@@ -466,6 +525,8 @@
 (def mal-get
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "get requires 2 arguments")))
       (let [item-struct ((in asts 0) :content)
             key-ast (in asts 1)]
         (if-let [val-ast (get item-struct key-ast)]
@@ -475,6 +536,8 @@
 (def contains?
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "contains? requires 2 arguments")))
       (let [item-struct ((in asts 0) :content)
             key-ast (in asts 1)]
         (if-let [val-ast (get item-struct key-ast)]
@@ -484,12 +547,16 @@
 (def mal-keys
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "keys requires 1 argument")))
       (let [item-struct ((in asts 0) :content)]
         (make-list (keys item-struct))))))
 
 (def mal-vals
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "vals requires 1 argument")))
       (let [item-struct ((in asts 0) :content)]
         (make-list (values item-struct))))))
 
@@ -539,6 +606,8 @@
 (def equals?
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "equals? requires 2 arguments")))
       (let [ast-1 (in asts 0)
             ast-2 (in asts 1)]
         (if (equals?* ast-1 ast-2)
@@ -548,6 +617,8 @@
 (def readline
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "readline requires 1 argument")))
       (let [prompt ((in asts 0) :content)
             buf @""]
         (file/write stdout prompt)
@@ -564,6 +635,8 @@
 (def mal-number?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "number? requires 1 argument")))
       (if (number?* (in asts 0))
         (make-boolean true)
         (make-boolean false)))))
@@ -575,6 +648,8 @@
 (def mal-fn?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "fn? requires 1 argument")))
       (let [target-ast (in asts 0)]
         (if (and (fn?* target-ast)
                  (not (target-ast :is-macro)))
@@ -589,6 +664,8 @@
 (def mal-macro?
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "macro? requires 1 argument")))
       (let [the-ast (in asts 0)]
         (if (macro?* the-ast)
           (make-boolean true)
@@ -602,6 +679,8 @@
 (def conj
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "conj requires at least 2 arguments")))
       (let [coll-ast (in asts 0)
             item-asts (slice asts 1)]
         (cond
@@ -616,6 +695,8 @@
 (def mal-seq
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "seq requires 1 argument")))
       (let [arg-ast (in asts 0)]
         (cond
           (list?* arg-ast)
@@ -643,6 +724,8 @@
 (def meta
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "meta requires 1 argument")))
       ((in asts 0) :meta))))
 
 (defn copy-function
@@ -656,6 +739,8 @@
 (def with-meta
   (make-function
     (fn [asts]
+      (when (< (length asts) 2)
+        (throw* (make-string "with-meta requires 2 arguments")))
       (let [target-ast (in asts 0)
             meta-ast (in asts 1)]
         (cond
@@ -711,12 +796,23 @@
 (def janet-eval
   (make-function
     (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "janet-eval requires 1 argument")))
       (let [str-ast (in asts 0)
             res (try
                   (eval-string (str-ast :content)) # XXX: escaping?
                   ([err]
                    (throw* (make-string (string "Eval failed: " err)))))]
         (janet-eval* res)))))
+
+##
+
+(def mal-type
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "type requires 1 argument")))
+      (make-keyword ((in asts 0) :tag)))))
 
 (def unimplemented throw)
 

--- a/impls/janet/core.janet
+++ b/impls/janet/core.janet
@@ -58,14 +58,26 @@
         (make-boolean true)
         (make-boolean false)))))
 
+(defn nil?*
+  [ast]
+  (= :nil (ast :tag)))
+
+(def mal-nil?
+  (make-function
+    (fn [asts]
+      (when (< (length asts) 1)
+        (throw* (make-string "nil? requires 1 argument")))
+      (if (nil?* (in asts 0))
+        (make-boolean true)
+        (make-boolean false)))))
+
 (def mal-count
   (make-function
     (fn [asts]
       (when (< (length asts) 1)
         (throw* (make-string "count requires 1 argument")))
-      (let [ast (in asts 0)
-            tag (ast :tag)]
-        (if (= tag :nil)
+      (let [ast (in asts 0)]
+        (if (nil?* ast)
           (make-number 0)
           (make-number (length (ast :content))))))))
 
@@ -250,7 +262,7 @@
 
 (defn first*
   [coll-or-nil-ast]
-  (if (or (= (coll-or-nil-ast :tag) :nil)
+  (if (or (nil?* coll-or-nil-ast)
           (empty?* coll-or-nil-ast))
     (make-nil)
     (in (coll-or-nil-ast :content) 0)))
@@ -265,7 +277,7 @@
 
 (defn rest*
   [coll-or-nil-ast]
-  (if (or (= (coll-or-nil-ast :tag) :nil)
+  (if (or (nil?* coll-or-nil-ast)
           (empty?* coll-or-nil-ast))
     (make-list [])
     (make-list (slice (coll-or-nil-ast :content) 1))))
@@ -307,19 +319,6 @@
             coll ((in asts 1) :content)]
         (make-list (map |(the-fn [$])
                         coll))))))
-
-(defn nil?*
-  [ast]
-  (= :nil (ast :tag)))
-
-(def mal-nil?
-  (make-function
-    (fn [asts]
-      (when (< (length asts) 1)
-        (throw* (make-string "nil? requires 1 argument")))
-      (if (nil?* (in asts 0))
-        (make-boolean true)
-        (make-boolean false)))))
 
 (def mal-vec
   (make-function

--- a/impls/janet/env.janet
+++ b/impls/janet/env.janet
@@ -10,7 +10,7 @@
   (while (and (not found-amp)
               (< idx n-binds))
     (def c-bind (in binds idx))
-    (when (= (c-bind :content) "&")
+    (when (= (get-value c-bind) "&")
       (set found-amp true)
       (break))
     (++ idx))
@@ -45,4 +45,4 @@
   (if-let [goal-env (env-find env sym)]
     (get-in goal-env [:data sym])
     # XXX: would like to use throw* from core
-    (error (make-string (string "'" (sym :content) "'" " not found" )))))
+    (error (make-string (string "'" (get-value sym) "'" " not found" )))))

--- a/impls/janet/env.janet
+++ b/impls/janet/env.janet
@@ -1,6 +1,36 @@
+(import ./types :prefix "")
+
+# based on janet's take-until
+(defn split-before-and-where
+  "Split ind before first position matching pred, and report on where.
+   If there was no split, report index as nil."
+  [pred ind]
+  (def use-str (bytes? ind))
+  (def f (if use-str string/slice tuple/slice))
+  (def len (length ind))
+  (def i (find-index pred ind))
+  (def end (if (nil? i) len i))
+  [(f ind 0 end) (f ind end) i])
+
+# XXX: probably could be simplified
 (defn make-env
-  [&opt outer]
-  @{:data @{}
+  [&opt outer binds exprs]
+  (default binds [])
+  (default exprs [])
+  (def [new-binds split-idx]
+    (let [[normal-binds args i]
+          (split-before-and-where (fn [sym-ast]
+                                    (= (sym-ast :content) "&"))
+                                   binds)]
+      (if i
+        [(array/concat (array ;normal-binds) (in args 1)) i]
+        [normal-binds nil])))
+  (def new-exprs
+    (if split-idx
+      (array/concat (array ;(slice exprs 0 split-idx))
+                    (array (make-list (slice exprs split-idx))))
+      exprs))
+  @{:data (zipcoll new-binds new-exprs)
     :outer outer})
 
 (defn env-set

--- a/impls/janet/env.janet
+++ b/impls/janet/env.janet
@@ -24,6 +24,7 @@
       (array/concat (array ;(slice exprs 0 idx))
                     (array (make-list (slice exprs idx))))
       exprs))
+  # XXX: would length mismatches of new-binds / new-exprs ever be an issue?
   @{:data (zipcoll new-binds new-exprs)
     :outer outer})
 

--- a/impls/janet/env.janet
+++ b/impls/janet/env.janet
@@ -1,4 +1,5 @@
-(import ./types :prefix "")
+(import ./types :as t)
+(import ./utils :as u)
 
 (defn make-env
   [&opt outer binds exprs]
@@ -10,7 +11,7 @@
   (while (and (not found-amp)
               (< idx n-binds))
     (def c-bind (in binds idx))
-    (when (= (get-value c-bind) "&")
+    (when (= (t/get-value c-bind) "&")
       (set found-amp true)
       (break))
     (++ idx))
@@ -22,7 +23,7 @@
   (def new-exprs
     (if found-amp
       (array/concat (array ;(slice exprs 0 idx))
-                    (array (make-list (slice exprs idx))))
+                    (array (t/make-list (slice exprs idx))))
       exprs))
   # XXX: would length mismatches of new-binds / new-exprs ever be an issue?
   @{:data (zipcoll new-binds new-exprs)
@@ -44,5 +45,6 @@
   [env sym]
   (if-let [goal-env (env-find env sym)]
     (get-in goal-env [:data sym])
-    # XXX: would like to use throw* from core
-    (error (make-string (string "'" (get-value sym) "'" " not found" )))))
+    (u/throw*
+      (t/make-string
+        (string "'" (t/get-value sym) "'" " not found" )))))

--- a/impls/janet/env.janet
+++ b/impls/janet/env.janet
@@ -49,4 +49,5 @@
   [env sym]
   (if-let [goal-env (env-find env sym)]
     (get-in goal-env [:data sym])
-    (error (string (sym :content) " not found." ))))
+    # XXX: would like to use throw* from core
+    (error (make-string (string "'" (sym :content) "'" " not found" )))))

--- a/impls/janet/env.janet
+++ b/impls/janet/env.janet
@@ -1,0 +1,22 @@
+(defn make-env
+  [&opt outer]
+  @{:data @{}
+    :outer outer})
+
+(defn env-set
+  [env sym value]
+  (put-in env [:data sym]
+              value))
+
+(defn env-find
+  [env sym]
+  (if (get-in env [:data sym])
+    env
+    (when-let [outer (get env :outer)]
+      (env-find outer sym))))
+
+(defn env-get
+  [env sym]
+  (if-let [goal-env (env-find env sym)]
+    (get-in goal-env [:data sym])
+    (error (string (sym :content) " not found." ))))

--- a/impls/janet/printer.janet
+++ b/impls/janet/printer.janet
@@ -61,7 +61,13 @@
       (buffer/push-string buf "]"))
     #
     :function
-    (buffer/push-string buf "#<function>")))
+    (buffer/push-string buf "#<function>")
+    #
+    :atom
+    (do
+      (buffer/push-string buf "(atom ")
+      (code* (ast :content) buf print_readably)
+      (buffer/push-string buf ")"))))
 
 (comment
 

--- a/impls/janet/printer.janet
+++ b/impls/janet/printer.janet
@@ -16,7 +16,7 @@
     :keyword
     (buffer/push-string buf (ast :content))
     :number
-    (buffer/push-string buf (ast :content))
+    (buffer/push-string buf (string (ast :content)))
     :string
     (if print_readably
       (buffer/push-string buf (string "\""
@@ -80,7 +80,7 @@
 
   (let [buf @""]
     (code* {:tag :number
-            :content "1"}
+            :content 1}
       buf))
   # => @"1"
 
@@ -95,7 +95,7 @@
 (comment
 
   (pr_str {:tag :number
-           :content "1"}
+           :content 1}
     false)
   # => @"1"
 

--- a/impls/janet/printer.janet
+++ b/impls/janet/printer.janet
@@ -1,0 +1,86 @@
+(defn escape
+  [a-str]
+  (->> (buffer a-str)
+       (peg/replace-all "\\" "\\\\")
+       (peg/replace-all "\"" "\\\"")
+       (peg/replace-all "\n" "\\n")
+       string))
+
+(defn code*
+  [ast buf print_readably]
+  (case (ast :tag)
+    :boolean
+    (buffer/push-string buf (ast :content))
+    :nil
+    (buffer/push-string buf (ast :content))
+    :keyword
+    (buffer/push-string buf (ast :content))
+    :number
+    (buffer/push-string buf (ast :content))
+    :string
+    (if print_readably
+      (buffer/push-string buf (string "\""
+                                      (escape (ast :content))
+                                      "\""))
+      (buffer/push-string buf (ast :content)))
+    :symbol
+    (buffer/push-string buf (ast :content))
+    #
+    :list
+    (do
+      (buffer/push-string buf "(")
+      (var remove false)
+      (each elt (ast :content)
+            (code* elt buf print_readably)
+            (buffer/push-string buf " ")
+            (set remove true))
+      (when remove
+        (buffer/popn buf 1))
+      (buffer/push-string buf ")"))
+    :hash-map
+    (do
+      (buffer/push-string buf "{")
+      (var remove false)
+      (each elt (ast :content)
+            (code* elt buf print_readably)
+            (buffer/push-string buf " ")
+            (set remove true))
+      (when remove
+        (buffer/popn buf 1))
+      (buffer/push-string buf "}"))
+    :vector
+    (do
+      (buffer/push-string buf "[")
+      (var remove false)
+      (each elt (ast :content)
+            (code* elt buf print_readably)
+            (buffer/push-string buf " ")
+            (set remove true))
+      (when remove
+        (buffer/popn buf 1))
+      (buffer/push-string buf "]"))))
+
+(comment
+
+  (let [buf @""]
+    (code* {:tag :number
+            :content "1"}
+      buf))
+  # => @"1"
+
+  )
+
+(defn pr_str
+  [ast print_readably]
+  (let [buf @""]
+    (code* ast buf print_readably)
+    buf))
+
+(comment
+
+  (pr_str {:tag :number
+           :content "1"}
+    false)
+  # => @"1"
+
+  )

--- a/impls/janet/printer.janet
+++ b/impls/janet/printer.janet
@@ -73,7 +73,7 @@
     #
     :exception
     (do
-      (buffer/push-string buf "Exception ")
+      (buffer/push-string buf "Error: ")
       (code* (ast :content) buf print_readably))))
 
 (comment

--- a/impls/janet/printer.janet
+++ b/impls/janet/printer.janet
@@ -41,8 +41,10 @@
     (do
       (buffer/push-string buf "{")
       (var remove false)
-      (each elt (ast :content)
-            (code* elt buf print_readably)
+      (eachp [k v] (ast :content)
+            (code* k buf print_readably)
+            (buffer/push-string buf " ")
+            (code* v buf print_readably)
             (buffer/push-string buf " ")
             (set remove true))
       (when remove
@@ -67,7 +69,12 @@
     (do
       (buffer/push-string buf "(atom ")
       (code* (ast :content) buf print_readably)
-      (buffer/push-string buf ")"))))
+      (buffer/push-string buf ")"))
+    #
+    :exception
+    (do
+      (buffer/push-string buf "Exception ")
+      (code* (ast :content) buf print_readably))))
 
 (comment
 

--- a/impls/janet/printer.janet
+++ b/impls/janet/printer.janet
@@ -58,7 +58,10 @@
             (set remove true))
       (when remove
         (buffer/popn buf 1))
-      (buffer/push-string buf "]"))))
+      (buffer/push-string buf "]"))
+    #
+    :function
+    (buffer/push-string buf "#<function>")))
 
 (comment
 

--- a/impls/janet/reader.janet
+++ b/impls/janet/reader.janet
@@ -211,7 +211,15 @@
 
 (defn read_str
   [code-str]
-  (let [[parsed _] (peg/match enlive-grammar code-str)]
+  (let [[parsed _]
+        (try
+          (peg/match enlive-grammar code-str)
+          ([err]
+           # XXX
+           [{:tag :exception
+             :content {:tag :string
+                       :content err}}
+            "peg/match exception"]))]
     (when (= (type parsed) :struct)
       parsed)))
 

--- a/impls/janet/reader.janet
+++ b/impls/janet/reader.janet
@@ -1,3 +1,6 @@
+(import ./types :as t)
+(import ./utils :as u)
+
 (def grammar
   ~{:main (capture (some :input))
     :input (choice :gap :form)
@@ -281,13 +284,10 @@
         (try
           (peg/match enlive-grammar code-str)
           ([err]
-           # XXX
-           [{:tag :exception
-             :content {:tag :string
-                       :content err}}
-            "peg/match exception"]))]
-    (when (= (type parsed) :struct)
-      parsed)))
+           (u/throw* (t/make-string err))))]
+    (if (= (type parsed) :struct)
+      parsed
+      (u/throw* t/mal-nil))))
 
 (comment
 

--- a/impls/janet/reader.janet
+++ b/impls/janet/reader.janet
@@ -1,0 +1,216 @@
+(def grammar
+  ~{:main (capture (some :input))
+    :input (choice :gap :form)
+    :gap (choice :ws :comment)
+    :ws (set " \f\n\r\t,")
+    :comment (sequence ";"
+                       (any (if-not (set "\r\n")
+                                    1)))
+    :form (choice :boolean :nil :number :keyword :symbol
+                  :string :list :vector :hash-map
+                  :deref :quasiquote :quote :splice-unquote :unquote
+                  :with-meta)
+    :name-char (if-not (set " \f\n\r\t,[]{}()'`~^@\"`;")
+                       1)
+    :boolean (choice "false" "true")
+    :nil "nil"
+    :number (drop (cmt
+                   (capture (some :name-char))
+                   ,scan-number))
+    :keyword (sequence ":"
+                       (any :name-char))
+    :symbol (some :name-char)
+    :string (sequence "\""
+                      (any (if-not (set "\"\\")
+                                   1))
+                      (any (sequence "\\"
+                                     1
+                                     (any (if-not (set "\"\\")
+                                                  1))))
+                      (choice "\""
+                              (error (constant "unbalanced \""))))
+    :hash-map (sequence "{"
+                        (any :input)
+                        (choice "}"
+                                (error (constant "unbalanced }"))))
+    :list (sequence "("
+                    (any :input)
+                    (choice ")"
+                            (error (constant "unbalanced )"))))
+    :vector (sequence "["
+                      (any :input)
+                      (choice "]"
+                              (error (constant "unbalanced ]"))))
+    :deref (sequence "@" :form)
+    :quasiquote (sequence "`" :form)
+    :quote (sequence "'" :form)
+    :splice-unquote (sequence "~@" :form)
+    :unquote (sequence "~" :form)
+    :with-meta (sequence "^" :form (some :gap) :form)
+    }
+  )
+
+(comment
+
+  (peg/match grammar " ")
+  # => @[" "]
+
+  (peg/match grammar "; hello")
+  # => @["; hello"]
+
+  (peg/match grammar "true")
+  # => @["true"]
+
+  (peg/match grammar "false")
+  # => @["false"]
+
+  (peg/match grammar "nil")
+  # => @["nil"]
+
+  (peg/match grammar "18")
+  # => @["18"]
+
+  (peg/match grammar "sym")
+  # => @["sym"]
+
+  (peg/match grammar ":alpha")
+  # => @[":alpha"]
+
+  (peg/match grammar "\"a string\"")
+  # => @["\"a string\""]
+
+  (peg/match grammar "(+ 1 2)")
+  # => @["(+ 1 2)"]
+
+  (peg/match grammar "[:a :b :c]")
+  # => @["[:a :b :c]"]
+
+  (peg/match grammar "{:a 1 :b 2}")
+  # => @{"{:a 1 :b 2}"]
+
+  )
+
+(defn unescape
+  [a-str]
+  (->> a-str
+       (peg/replace-all "\\\\" "\u029e") # XXX: a hack?
+       (peg/replace-all "\\\"" "\"")
+       (peg/replace-all "\\n" "\n")
+       (peg/replace-all "\u029e" "\\")
+       string))
+
+(def enlive-grammar
+  (let [cg (table ;(kvs grammar))]
+    (each kwd [# :comment # XX: don't capture comments
+               :boolean :keyword :nil :number
+               :symbol
+               # :ws # XXX: dont' capture whitespace
+              ]
+          (put cg kwd
+               ~(cmt (capture ,(in cg kwd))
+                     ,|{:tag (keyword kwd)
+                        :content $})))
+    (put cg :string
+            ~(cmt (capture ,(in cg :string))
+                  ,|{:tag :string
+                     # discard surrounding double quotes
+                     :content (unescape (slice $ 1 -2))}))
+    (each kwd [:deref :quasiquote :quote :splice-unquote :unquote]
+          (put cg kwd
+               ~(cmt (capture ,(in cg kwd))
+                     ,|{:tag :list
+                        :content [{:tag :symbol
+                                   :content (string kwd)}
+                                  ;(slice $& 0 -2)]})))
+    (each kwd [:hash-map :list :vector]
+          (put cg kwd
+               (tuple # array needs to be converted
+                 ;(put (array ;(in cg kwd))
+                       2 ~(cmt (capture ,(get-in cg [kwd 2]))
+                               ,|{:tag (keyword kwd)
+                                  :content (slice $& 0 -2)})))))
+    (put cg :with-meta
+            ~(cmt (capture ,(in cg :with-meta))
+                  ,|{:tag :list
+                     :content [{:tag :symbol
+                                :content "with-meta"}
+                               (get $& 1)
+                               (get $& 0)]}))
+    # tried using a table with a peg but had a problem, so use a struct
+    (table/to-struct cg)))
+
+(comment
+
+  (peg/match enlive-grammar "nil")
+
+  (peg/match enlive-grammar "true")
+
+  (peg/match enlive-grammar ":hi")
+
+  (peg/match enlive-grammar "sym")
+
+  (peg/match enlive-grammar "'a")
+
+  (peg/match enlive-grammar "@a")
+
+  (peg/match enlive-grammar "`a")
+
+  (peg/match enlive-grammar "~a")
+
+  (peg/match enlive-grammar "~@a")
+
+  (peg/match enlive-grammar "(a b c)")
+  ``
+  '@[{:content ({:content "a"
+                 :tag :symbol}
+                {:content "b"
+                 :tag :symbol}
+                {:content "c"
+                 :tag :symbol})
+      :tag :list} "(a b c)"]
+  ``
+
+  (peg/match enlive-grammar "(a [:x :y] c)")
+
+  (peg/match enlive-grammar "^{:a 1} [:x :y]")
+  ``
+  '@[{:content ({:content ({:content ":x"
+                            :tag :keyword}
+                           {:content ":y"
+                            :tag :keyword})
+                 :tag :vector}
+                {:content ({:content ":a"
+                            :tag :keyword}
+                           {:content "1"
+                            :tag :number})
+                 :tag :hash-map})
+      :tag :with-meta} "^{:a 1} [:x :y]"]
+  ``
+
+  (peg/match enlive-grammar ";; hi")
+
+  (peg/match enlive-grammar "[:x ;; hi\n :y]")
+
+  (peg/match enlive-grammar "  7  ")
+
+  (peg/match enlive-grammar "  abc  ")
+
+  (peg/match enlive-grammar "  \nabc  ")
+
+  )
+
+(defn read_str
+  [code-str]
+  (let [[parsed _] (peg/match enlive-grammar code-str)]
+    (when (= (type parsed) :struct)
+      parsed)))
+
+(comment
+
+  (read_str "(+ 1 2)")
+
+  (read_str ";; hello")
+
+  (read_str "\"1\"")
+
+  )

--- a/impls/janet/run
+++ b/impls/janet/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec janet $(dirname $0)/${STEP:-stepA_mal}.janet "${@}"

--- a/impls/janet/step0_repl.janet
+++ b/impls/janet/step0_repl.janet
@@ -1,0 +1,31 @@
+(defn READ
+  [code-str]
+  code-str)
+
+(defn EVAL
+  [ast]
+  ast)
+
+(defn PRINT
+  [value]
+  value)
+
+(defn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str))))
+
+# getline gives problems
+(defn getstdin [prompt buf]
+  (file/write stdout prompt)
+  (file/flush stdout)
+  (file/read stdin :line buf))
+
+(defn main
+  [& args]
+  (var buf nil)
+  (while true
+    (set buf @"")
+    (getstdin "user> " buf)
+    (if (< 0 (length buf))
+      (prin (rep buf))
+      (break))))

--- a/impls/janet/step0_repl.janet
+++ b/impls/janet/step0_repl.janet
@@ -7,8 +7,8 @@
   ast)
 
 (defn PRINT
-  [value]
-  value)
+  [ast]
+  ast)
 
 (defn rep
   [code-str]

--- a/impls/janet/step1_read_print.janet
+++ b/impls/janet/step1_read_print.janet
@@ -1,0 +1,39 @@
+(import ./reader :prefix "")
+(import ./printer :prefix "")
+
+(defn READ
+  [code-str]
+  (read_str code-str))
+
+(defn EVAL
+  [ast]
+  ast)
+
+(defn PRINT
+  [value]
+  (pr_str value true))
+
+(defn rep
+  [code-str]
+  (let [ds (READ code-str)]
+    (when ds
+      (PRINT (EVAL ds)))))
+
+# getline gives problems
+(defn getstdin [prompt buf]
+  (file/write stdout prompt)
+  (file/flush stdout)
+  (file/read stdin :line buf))
+
+(defn main
+  [& args]
+  (var buf nil)
+  (while true
+    (set buf @"")
+    (getstdin "user> " buf)
+    (if (= 0 (length buf))
+      (break)
+      (try
+        (print (rep buf))
+        ([err]
+         (print err))))))

--- a/impls/janet/step1_read_print.janet
+++ b/impls/janet/step1_read_print.janet
@@ -1,9 +1,9 @@
-(import ./reader :prefix "")
-(import ./printer :prefix "")
+(import ./reader)
+(import ./printer)
 
 (defn READ
   [code-str]
-  (read_str code-str))
+  (reader/read_str code-str))
 
 (defn EVAL
   [ast]
@@ -11,7 +11,7 @@
 
 (defn PRINT
   [value]
-  (pr_str value true))
+  (printer/pr_str value true))
 
 (defn rep
   [code-str]

--- a/impls/janet/step1_read_print.janet
+++ b/impls/janet/step1_read_print.janet
@@ -1,5 +1,6 @@
 (import ./reader)
 (import ./printer)
+(import ./types :as t)
 
 (defn READ
   [code-str]
@@ -15,15 +16,24 @@
 
 (defn rep
   [code-str]
-  (let [ds (READ code-str)]
-    (when ds
-      (PRINT (EVAL ds)))))
+  (PRINT (EVAL (READ code-str))))
 
 # getline gives problems
 (defn getstdin [prompt buf]
   (file/write stdout prompt)
   (file/flush stdout)
   (file/read stdin :line buf))
+
+(defn handle-error
+  [err]
+  (cond
+    (t/nil?* err)
+    (print)
+    ##
+    (string? err)
+    (print err)
+    ##
+    (print (string "Error: " (PRINT err)))))
 
 (defn main
   [& args]
@@ -36,4 +46,4 @@
       (try
         (print (rep buf))
         ([err]
-         (print err))))))
+         (handle-error err))))))

--- a/impls/janet/step2_eval.janet
+++ b/impls/janet/step2_eval.janet
@@ -10,8 +10,8 @@
   [op]
   (fn [ast-1 ast-2]
     {:tag :number
-     :content (string (op (scan-number (ast-1 :content))
-                          (scan-number (ast-2 :content))))}))
+     :content (op (ast-1 :content)
+                  (ast-2 :content))}))
 
 (def repl_env
   {"+" (arith-fn +)

--- a/impls/janet/step2_eval.janet
+++ b/impls/janet/step2_eval.janet
@@ -62,16 +62,24 @@
 
 (defn rep
   [code-str]
-  (let [ds (READ code-str)]
-    (when ds
-      (PRINT
-        (EVAL ds repl_env)))))
+  (PRINT (EVAL (READ code-str) repl_env)))
 
 # getline gives problems
 (defn getstdin [prompt buf]
   (file/write stdout prompt)
   (file/flush stdout)
   (file/read stdin :line buf))
+
+(defn handle-error
+  [err]
+  (cond
+    (t/nil?* err)
+    (print)
+    ##
+    (string? err)
+    (print err)
+    ##
+    (print (string "Error: " (PRINT err)))))
 
 (defn main
   [& args]
@@ -84,4 +92,4 @@
       (try
         (print (rep buf))
         ([err]
-         (print err))))))
+         (handle-error err))))))

--- a/impls/janet/step2_eval.janet
+++ b/impls/janet/step2_eval.janet
@@ -1,5 +1,6 @@
 (import ./reader :prefix "")
 (import ./printer :prefix "")
+(import ./types :prefix "")
 
 (defn READ
   [code-str]
@@ -28,7 +29,7 @@
           val (env name)]
       (if val
         val
-        (error (string "unbound symbol: " name))))
+        (error (make-string (string "unbound symbol: " name)))))
     #
     :hash-map
     {:tag :hash-map

--- a/impls/janet/step2_eval.janet
+++ b/impls/janet/step2_eval.janet
@@ -32,8 +32,8 @@
     #
     :hash-map
     {:tag :hash-map
-     :content (map |(EVAL $0 env)
-                   (ast :content))}
+     :content (struct ;(map |(EVAL $0 env)
+                            (kvs (ast :content))))}
     #
     :list
     {:tag :list

--- a/impls/janet/step2_eval.janet
+++ b/impls/janet/step2_eval.janet
@@ -1,0 +1,92 @@
+(import ./reader :prefix "")
+(import ./printer :prefix "")
+
+(defn READ
+  [code-str]
+  (read_str code-str))
+
+(defn arith-fn
+  [op]
+  (fn [ast-1 ast-2]
+    {:tag :number
+     :content (string (op (scan-number (ast-1 :content))
+                          (scan-number (ast-2 :content))))}))
+
+(def repl_env
+  {"+" (arith-fn +)
+   "-" (arith-fn -)
+   "*" (arith-fn *)
+   "/" (arith-fn /)})
+
+(var EVAL nil)
+
+(defn eval_ast
+  [ast env]
+  (case (ast :tag)
+    :symbol
+    (let [name (ast :content)
+          val (env name)]
+      (if val
+        val
+        (error (string "unbound symbol: " name))))
+    #
+    :hash-map
+    {:tag :hash-map
+     :content (map |(EVAL $0 env)
+                   (ast :content))}
+    #
+    :list
+    {:tag :list
+     :content (map |(EVAL $0 env)
+                   (ast :content))}
+    #
+    :vector
+    {:tag :vector
+     :content (map |(EVAL $0 env)
+                   (ast :content))}
+    #
+    ast))
+
+(varfn EVAL
+  [ast env]
+  (cond
+    (not= :list (ast :tag))
+    (eval_ast ast env)
+    #
+    (empty? (ast :content))
+    ast
+    #
+    (let [eval-list ((eval_ast ast env) :content)
+          head (first eval-list)
+          tail (drop 1 eval-list)]
+      (apply head tail))))
+
+(defn PRINT
+  [value]
+  (pr_str value true))
+
+(defn rep
+  [code-str]
+  (let [ds (READ code-str)]
+    (when ds
+      (PRINT
+        (EVAL ds repl_env)))))
+
+# getline gives problems
+(defn getstdin [prompt buf]
+  (file/write stdout prompt)
+  (file/flush stdout)
+  (file/read stdin :line buf))
+
+(defn main
+  [& args]
+  (var buf nil)
+  (while true
+    (set buf @"")
+    (getstdin "user> " buf)
+    (if (= 0 (length buf))
+      (break)
+      (try
+        (print (rep buf))
+        ([err]
+         (print err))))))

--- a/impls/janet/step3_env.janet
+++ b/impls/janet/step3_env.janet
@@ -81,19 +81,24 @@
 
 (defn rep
   [code-str]
-  (let [ds (READ code-str)]
-    (when ds
-      (PRINT
-        (try
-          (EVAL ds repl_env)
-          ([err]
-           (t/make-exception err)))))))
+  (PRINT (EVAL (READ code-str) repl_env)))
 
 # getline gives problems
 (defn getstdin [prompt buf]
   (file/write stdout prompt)
   (file/flush stdout)
   (file/read stdin :line buf))
+
+(defn handle-error
+  [err]
+  (cond
+    (t/nil?* err)
+    (print)
+    ##
+    (string? err)
+    (print err)
+    ##
+    (print (string "Error: " (PRINT err)))))
 
 (defn main
   [& args]
@@ -106,4 +111,4 @@
       (try
         (print (rep buf))
         ([err]
-         (print err))))))
+         (handle-error err))))))

--- a/impls/janet/step3_env.janet
+++ b/impls/janet/step3_env.janet
@@ -10,8 +10,8 @@
 (defn arith-fn
   [op]
   (fn [ast-1 ast-2]
-    (make-number (string (op (scan-number (ast-1 :content))
-                             (scan-number (ast-2 :content)))))))
+    (make-number (op (ast-1 :content)
+                     (ast-2 :content)))))
 
 (def repl_env
   (let [env (make-env)]

--- a/impls/janet/step3_env.janet
+++ b/impls/janet/step3_env.janet
@@ -1,0 +1,106 @@
+(import ./reader :prefix "")
+(import ./printer :prefix "")
+(import ./types :prefix "")
+(import ./env :prefix "")
+
+(defn READ
+  [code-str]
+  (read_str code-str))
+
+(defn arith-fn
+  [op]
+  (fn [ast-1 ast-2]
+    (make-number (string (op (scan-number (ast-1 :content))
+                             (scan-number (ast-2 :content)))))))
+
+(def repl_env
+  (let [env (make-env)]
+    (env-set env (make-symbol "+") (arith-fn +))
+    (env-set env (make-symbol "-") (arith-fn -))
+    (env-set env (make-symbol "*") (arith-fn *))
+    (env-set env (make-symbol "/") (arith-fn /))
+    env))
+
+(var EVAL nil)
+
+(defn eval_ast
+  [ast env]
+  (case (ast :tag)
+    :symbol
+    (env-get env ast)
+    #
+    :hash-map
+    (make-hash-map (map |(EVAL $0 env)
+                        (ast :content)))
+    #
+    :list
+    (make-list (map |(EVAL $0 env)
+                    (ast :content)))
+    #
+    :vector
+    (make-vector (map |(EVAL $0 env)
+                      (ast :content)))
+    #
+    ast))
+
+(varfn EVAL
+  [ast env]
+  (cond
+    (not= :list (ast :tag))
+    (eval_ast ast env)
+    #
+    (empty? (ast :content))
+    ast
+    #
+    (let [ast-head (first (ast :content))
+          head-name (ast-head :content)]
+      (case head-name
+        "def!"
+        (let [def-name (in (ast :content) 1)
+              def-val (EVAL (in (ast :content) 2) env)]
+          (env-set env
+                   def-name def-val)
+          def-val)
+        #
+        "let*"
+        (let [new-env (make-env env)
+              bindings ((in (ast :content) 1) :content)]
+          (each [let-name let-val] (partition 2 bindings)
+                (env-set new-env
+                         let-name (EVAL let-val new-env)))
+          (EVAL (in (ast :content) 2) new-env))
+        #
+        (let [eval-list ((eval_ast ast env) :content)
+              head (first eval-list)
+              tail (drop 1 eval-list)]
+          (apply head tail))))))
+
+(defn PRINT
+  [value]
+  (pr_str value true))
+
+(defn rep
+  [code-str]
+  (let [ds (READ code-str)]
+    (when ds
+      (PRINT
+        (EVAL ds repl_env)))))
+
+# getline gives problems
+(defn getstdin [prompt buf]
+  (file/write stdout prompt)
+  (file/flush stdout)
+  (file/read stdin :line buf))
+
+(defn main
+  [& args]
+  (var buf nil)
+  (while true
+    (set buf @"")
+    (getstdin "user> " buf)
+    (if (= 0 (length buf))
+      (break)
+      (try
+        (print (rep buf))
+        ([err]
+         (print err))))))

--- a/impls/janet/step3_env.janet
+++ b/impls/janet/step3_env.janet
@@ -30,8 +30,8 @@
     (env-get env ast)
     #
     :hash-map
-    (make-hash-map (map |(EVAL $0 env)
-                        (ast :content)))
+    (make-hash-map (struct ;(map |(EVAL $0 env)
+                                 (kvs (ast :content)))))
     #
     :list
     (make-list (map |(EVAL $0 env)
@@ -84,7 +84,10 @@
   (let [ds (READ code-str)]
     (when ds
       (PRINT
-        (EVAL ds repl_env)))))
+        (try
+          (EVAL ds repl_env)
+          ([err]
+           (make-exception err)))))))
 
 # getline gives problems
 (defn getstdin [prompt buf]

--- a/impls/janet/step4_if_fn_do.janet
+++ b/impls/janet/step4_if_fn_do.janet
@@ -1,0 +1,126 @@
+(import ./reader)
+(import ./printer :prefix "")
+(import ./types :prefix "")
+(import ./env :prefix "")
+(import ./core)
+
+(def repl_env
+  (let [env (make-env)]
+    (eachp [k v] core/ns
+      (env-set env k v))
+    env))
+
+(defn READ
+  [code-str]
+  (reader/read_str code-str))
+
+(var EVAL nil)
+
+(defn eval_ast
+  [ast env]
+  (case (ast :tag)
+    :symbol
+    (env-get env ast)
+    #
+    :hash-map
+    (make-hash-map (map |(EVAL $0 env)
+                        (ast :content)))
+    #
+    :list
+    (make-list (map |(EVAL $0 env)
+                    (ast :content)))
+    #
+    :vector
+    (make-vector (map |(EVAL $0 env)
+                      (ast :content)))
+    #
+    ast))
+
+(varfn EVAL
+  [ast env]
+  (cond
+    (not= :list (ast :tag))
+    (eval_ast ast env)
+    #
+    (empty? (ast :content))
+    ast
+    #
+    (let [ast-head (in (ast :content) 0)
+          head-name (ast-head :content)]
+      (case head-name
+        "def!"
+        (let [def-name (in (ast :content) 1)
+              def-val (EVAL (in (ast :content) 2) env)]
+          (env-set env
+                   def-name def-val)
+          def-val)
+        #
+        "let*"
+        (let [new-env (make-env env)
+              bindings ((in (ast :content) 1) :content)]
+          (each [let-name let-val] (partition 2 bindings)
+                (env-set new-env
+                         let-name (EVAL let-val new-env)))
+          (EVAL (in (ast :content) 2) new-env))
+        #
+        "do"
+        (let [do-body-forms (drop 1 (ast :content))
+              res-ast (eval_ast (make-list do-body-forms) env)]
+          (last (res-ast :content)))
+        #
+        "if"
+        (let [cond-res (EVAL (in (ast :content) 1) env)
+              cond-type (cond-res :tag)
+              cond-val (cond-res :content)]
+          (if (or (= cond-type :nil)
+                  (and (= cond-type :boolean)
+                       (= cond-val "false")))
+            (if-let [else-ast (get (ast :content) 3)]
+              (EVAL else-ast env)
+              (make-nil))
+            (EVAL (in (ast :content) 2) env)))
+        #
+        "fn*"
+        (let [args ((in (ast :content) 1) :content)
+              body (in (ast :content) 2)]
+          (make-function (fn [params]
+                           (EVAL body
+                                 (make-env env args params)))))
+        #
+        (let [eval-list ((eval_ast ast env) :content)
+              head (first eval-list)
+              tail (drop 1 eval-list)]
+          ((head :content) tail))
+        ))))
+
+(defn PRINT
+  [ast]
+  (pr_str ast true))
+
+(defn rep
+  [code-str]
+  (let [ds (READ code-str)]
+    (when ds
+      (PRINT
+        (EVAL ds repl_env)))))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+# getline gives problems
+(defn getstdin [prompt buf]
+  (file/write stdout prompt)
+  (file/flush stdout)
+  (file/read stdin :line buf))
+
+(defn main
+  [& args]
+  (var buf nil)
+  (while true
+    (set buf @"")
+    (getstdin "user> " buf)
+    (if (= 0 (length buf))
+      (break)
+      (try
+        (print (rep buf))
+        ([err]
+         (print err))))))

--- a/impls/janet/step4_if_fn_do.janet
+++ b/impls/janet/step4_if_fn_do.janet
@@ -1,13 +1,13 @@
 (import ./reader)
-(import ./printer :prefix "")
-(import ./types :prefix "")
-(import ./env :prefix "")
+(import ./printer)
+(import ./types :as t)
+(import ./env :as e)
 (import ./core)
 
 (def repl_env
-  (let [env (make-env)]
+  (let [env (e/make-env)]
     (eachp [k v] core/ns
-      (env-set env k v))
+      (e/env-set env k v))
     env))
 
 (defn READ
@@ -18,91 +18,90 @@
 
 (defn eval_ast
   [ast env]
-  (case (ast :tag)
-    :symbol
-    (env-get env ast)
+  (cond
+    (t/symbol?* ast)
+    (e/env-get env ast)
     #
-    :hash-map
-    (make-hash-map (struct ;(map |(EVAL $0 env)
-                                 (kvs (ast :content)))))
+    (t/hash-map?* ast)
+    (t/make-hash-map (struct ;(map |(EVAL $0 env)
+                                   (kvs (t/get-value ast)))))
     #
-    :list
-    (make-list (map |(EVAL $0 env)
-                    (ast :content)))
+    (t/list?* ast)
+    (t/make-list (map |(EVAL $0 env)
+                      (t/get-value ast)))
     #
-    :vector
-    (make-vector (map |(EVAL $0 env)
-                      (ast :content)))
+    (t/vector?* ast)
+    (t/make-vector (map |(EVAL $0 env)
+                        (t/get-value ast)))
     #
     ast))
 
 (varfn EVAL
   [ast env]
   (cond
-    (not= :list (ast :tag))
+    (not (t/list?* ast))
     (eval_ast ast env)
     #
-    (empty? (ast :content))
+    (t/empty?* ast)
     ast
     #
-    (let [ast-head (in (ast :content) 0)
-          head-name (ast-head :content)]
+    (let [ast-head (first (t/get-value ast))
+          head-name (t/get-value ast-head)]
       (case head-name
         "def!"
-        (let [def-name (in (ast :content) 1)
-              def-val (EVAL (in (ast :content) 2) env)]
-          (env-set env
-                   def-name def-val)
+        (let [def-name (in (t/get-value ast) 1)
+              def-val (EVAL (in (t/get-value ast) 2) env)]
+          (e/env-set env
+                     def-name def-val)
           def-val)
         #
         "let*"
-        (let [new-env (make-env env)
-              bindings ((in (ast :content) 1) :content)]
+        (let [new-env (e/make-env env)
+              bindings (t/get-value (in (t/get-value ast) 1))]
           (each [let-name let-val] (partition 2 bindings)
-                (env-set new-env
-                         let-name (EVAL let-val new-env)))
-          (EVAL (in (ast :content) 2) new-env))
+                (e/env-set new-env
+                           let-name (EVAL let-val new-env)))
+          (EVAL (in (t/get-value ast) 2) new-env))
         #
         "do"
-        (let [do-body-forms (drop 1 (ast :content))
-              res-ast (eval_ast (make-list do-body-forms) env)]
-          (last (res-ast :content)))
+        (let [do-body-forms (drop 1 (t/get-value ast))
+              res-ast (eval_ast (t/make-list do-body-forms) env)]
+          (last (t/get-value res-ast)))
         #
         "if"
-        (let [cond-res (EVAL (in (ast :content) 1) env)
-              cond-type (cond-res :tag)
-              cond-val (cond-res :content)]
-          (if (or (= cond-type :nil)
-                  (and (= cond-type :boolean)
-                       (= cond-val "false")))
-            (if-let [else-ast (get (ast :content) 3)]
+        (let [cond-res (EVAL (in (t/get-value ast) 1) env)]
+          (if (or (t/nil?* cond-res)
+                  (t/false?* cond-res))
+            (if-let [else-ast (get (t/get-value ast) 3)]
               (EVAL else-ast env)
-              (make-nil))
-            (EVAL (in (ast :content) 2) env)))
+              t/mal-nil)
+            (EVAL (in (t/get-value ast) 2) env)))
         #
         "fn*"
-        (let [args ((in (ast :content) 1) :content)
-              body (in (ast :content) 2)]
-          (make-function (fn [params]
-                           (EVAL body
-                                 (make-env env args params)))))
+        (let [args (t/get-value (in (t/get-value ast) 1))
+              body (in (t/get-value ast) 2)]
+          (t/make-function (fn [params]
+                             (EVAL body
+                                   (e/make-env env args params)))))
         #
-        (let [eval-list ((eval_ast ast env) :content)
-              head (first eval-list)
-              tail (drop 1 eval-list)]
-          ((head :content) tail))
-        ))))
+        (let [eval-list (t/get-value (eval_ast ast env))
+              f (first eval-list)
+              args (drop 1 eval-list)]
+          ((t/get-value f) args))))))
 
 (defn PRINT
   [ast]
-  (pr_str ast true))
+  (printer/pr_str ast true))
 
 (defn rep
   [code-str]
   (let [ds (READ code-str)]
     (when ds
       (PRINT
-        (EVAL ds repl_env)))))
+        (try
+          (EVAL ds repl_env)
+          ([err]
+           (t/make-exception err)))))))
 
 (rep "(def! not (fn* (a) (if a false true)))")
 

--- a/impls/janet/step4_if_fn_do.janet
+++ b/impls/janet/step4_if_fn_do.janet
@@ -23,8 +23,8 @@
     (env-get env ast)
     #
     :hash-map
-    (make-hash-map (map |(EVAL $0 env)
-                        (ast :content)))
+    (make-hash-map (struct ;(map |(EVAL $0 env)
+                                 (kvs (ast :content)))))
     #
     :list
     (make-list (map |(EVAL $0 env)

--- a/impls/janet/step4_if_fn_do.janet
+++ b/impls/janet/step4_if_fn_do.janet
@@ -95,13 +95,7 @@
 
 (defn rep
   [code-str]
-  (let [ds (READ code-str)]
-    (when ds
-      (PRINT
-        (try
-          (EVAL ds repl_env)
-          ([err]
-           (t/make-exception err)))))))
+  (PRINT (EVAL (READ code-str) repl_env)))
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
@@ -110,6 +104,17 @@
   (file/write stdout prompt)
   (file/flush stdout)
   (file/read stdin :line buf))
+
+(defn handle-error
+  [err]
+  (cond
+    (t/nil?* err)
+    (print)
+    ##
+    (string? err)
+    (print err)
+    ##
+    (print (string "Error: " (PRINT err)))))
 
 (defn main
   [& args]
@@ -122,4 +127,4 @@
       (try
         (print (rep buf))
         ([err]
-         (print err))))))
+         (handle-error err))))))

--- a/impls/janet/step5_tco.janet
+++ b/impls/janet/step5_tco.janet
@@ -98,6 +98,7 @@
                       (make-function (fn [args]
                                        (EVAL body
                                          (make-env env params args)))
+                                     nil false
                                      body params env)))
             ##
             (let [eval-list ((eval_ast ast env) :content)

--- a/impls/janet/step5_tco.janet
+++ b/impls/janet/step5_tco.janet
@@ -1,0 +1,143 @@
+(import ./reader)
+(import ./printer :prefix "")
+(import ./types :prefix "")
+(import ./env :prefix "")
+(import ./core)
+
+(def repl_env
+  (let [env (make-env)]
+    (eachp [k v] core/ns
+      (env-set env k v))
+    env))
+
+(defn READ
+  [code-str]
+  (reader/read_str code-str))
+
+(var EVAL nil)
+
+(defn eval_ast
+  [ast env]
+  (case (ast :tag)
+    :symbol
+    (env-get env ast)
+    #
+    :hash-map
+    (make-hash-map (map |(EVAL $0 env)
+                        (ast :content)))
+    #
+    :list
+    (make-list (map |(EVAL $0 env)
+                    (ast :content)))
+    #
+    :vector
+    (make-vector (map |(EVAL $0 env)
+                      (ast :content)))
+    #
+    ast))
+
+(varfn EVAL
+  [ast-param env-param]
+  (var ast ast-param)
+  (var env env-param)
+  (label result
+    (while true
+      (cond
+        (not= :list (ast :tag))
+        (return result (eval_ast ast env))
+        ##
+        (empty? (ast :content))
+        (return result ast)
+        ##
+        (let [ast-head (in (ast :content) 0)
+              head-name (ast-head :content)]
+          (case head-name
+            "def!"
+            (let [def-name (in (ast :content) 1)
+                  def-val (EVAL (in (ast :content) 2) env)]
+              (env-set env
+                       def-name def-val)
+              (return result def-val))
+            ##
+            "let*"
+            (let [new-env (make-env env)
+                  bindings ((in (ast :content) 1) :content)]
+              (each [let-name let-val] (partition 2 bindings)
+                    (env-set new-env
+                             let-name (EVAL let-val new-env)))
+              ## tco
+              (set ast (in (ast :content) 2))
+              (set env new-env))
+            ##
+            "do"
+            (let [most-do-body-forms (slice (ast :content) 1 -2)
+                  last-body-form (last (ast :content))
+                  res-ast (eval_ast (make-list most-do-body-forms) env)]
+              ## tco
+              (set ast last-body-form))
+            ##
+            "if"
+            (let [cond-res (EVAL (in (ast :content) 1) env)
+                  cond-type (cond-res :tag)
+                  cond-val (cond-res :content)]
+              (if (or (= cond-type :nil)
+                      (and (= cond-type :boolean)
+                           (= cond-val "false")))
+                (if-let [else-ast (get (ast :content) 3)]
+                  ## tco
+                  (set ast else-ast)
+                  (return result (make-nil)))
+                ## tco
+                (set ast (in (ast :content) 2))))
+            ##
+            "fn*"
+            (let [params ((in (ast :content) 1) :content)
+                  body (in (ast :content) 2)]
+              ## tco
+              (return result
+                      (make-function (fn [args]
+                                       (EVAL body
+                                         (make-env env params args)))
+                                     body params env)))
+            ##
+            (let [eval-list ((eval_ast ast env) :content)
+                  f (first eval-list)
+                  args (drop 1 eval-list)]
+              (if-let [body (f :ast)] ## tco
+                (do
+                  (set ast body)
+                  (set env (make-env (f :env) (f :params) args)))
+                (return result
+                        ((f :content) args))))))))))
+
+(defn PRINT
+  [ast]
+  (pr_str ast true))
+
+(defn rep
+  [code-str]
+  (let [ds (READ code-str)]
+    (when ds
+      (PRINT
+        (EVAL ds repl_env)))))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+# getline gives problems
+(defn getstdin [prompt buf]
+  (file/write stdout prompt)
+  (file/flush stdout)
+  (file/read stdin :line buf))
+
+(defn main
+  [& args]
+  (var buf nil)
+  (while true
+    (set buf @"")
+    (getstdin "user> " buf)
+    (if (= 0 (length buf))
+      (break)
+      (try
+        (print (rep buf))
+        ([err]
+         (print err))))))

--- a/impls/janet/step5_tco.janet
+++ b/impls/janet/step5_tco.janet
@@ -23,8 +23,8 @@
     (env-get env ast)
     #
     :hash-map
-    (make-hash-map (map |(EVAL $0 env)
-                        (ast :content)))
+    (make-hash-map (struct ;(map |(EVAL $0 env)
+                                 (kvs (ast :content)))))
     #
     :list
     (make-list (map |(EVAL $0 env)

--- a/impls/janet/step5_tco.janet
+++ b/impls/janet/step5_tco.janet
@@ -114,10 +114,7 @@
 
 (defn rep
   [code-str]
-  (let [ds (READ code-str)]
-    (when ds
-      (PRINT
-        (EVAL ds repl_env)))))
+  (PRINT (EVAL (READ code-str) repl_env)))
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
@@ -126,6 +123,17 @@
   (file/write stdout prompt)
   (file/flush stdout)
   (file/read stdin :line buf))
+
+(defn handle-error
+  [err]
+  (cond
+    (t/nil?* err)
+    (print)
+    ##
+    (string? err)
+    (print err)
+    ##
+    (print (string "Error: " (PRINT err)))))
 
 (defn main
   [& args]
@@ -138,4 +146,4 @@
       (try
         (print (rep buf))
         ([err]
-         (print err))))))
+         (handle-error err))))))

--- a/impls/janet/step6_file.janet
+++ b/impls/janet/step6_file.janet
@@ -1,0 +1,168 @@
+(import ./reader)
+(import ./printer :prefix "")
+(import ./types :prefix "")
+(import ./env :prefix "")
+(import ./core)
+
+(def repl_env
+  (let [env (make-env)]
+    (eachp [k v] core/ns
+      (env-set env k v))
+    env))
+
+(defn READ
+  [code-str]
+  (reader/read_str code-str))
+
+(var EVAL nil)
+
+(defn eval_ast
+  [ast env]
+  (case (ast :tag)
+    :symbol
+    (env-get env ast)
+    #
+    :hash-map
+    (make-hash-map (map |(EVAL $0 env)
+                        (ast :content)))
+    #
+    :list
+    (make-list (map |(EVAL $0 env)
+                    (ast :content)))
+    #
+    :vector
+    (make-vector (map |(EVAL $0 env)
+                      (ast :content)))
+    #
+    ast))
+
+(varfn EVAL
+  [ast-param env-param]
+  (var ast ast-param)
+  (var env env-param)
+  (label result
+    (while true
+      (cond
+        (not= :list (ast :tag))
+        (return result (eval_ast ast env))
+        ##
+        (empty? (ast :content))
+        (return result ast)
+        ##
+        (let [ast-head (in (ast :content) 0)
+              head-name (ast-head :content)]
+          (case head-name
+            "def!"
+            (let [def-name (in (ast :content) 1)
+                  def-val (EVAL (in (ast :content) 2) env)]
+              (env-set env
+                       def-name def-val)
+              (return result def-val))
+            ##
+            "let*"
+            (let [new-env (make-env env)
+                  bindings ((in (ast :content) 1) :content)]
+              (each [let-name let-val] (partition 2 bindings)
+                    (env-set new-env
+                             let-name (EVAL let-val new-env)))
+              ## tco
+              (set ast (in (ast :content) 2))
+              (set env new-env))
+            ##
+            "do"
+            (let [most-do-body-forms (slice (ast :content) 1 -2)
+                  last-body-form (last (ast :content))
+                  res-ast (eval_ast (make-list most-do-body-forms) env)]
+              ## tco
+              (set ast last-body-form))
+            ##
+            "if"
+            (let [cond-res (EVAL (in (ast :content) 1) env)
+                  cond-type (cond-res :tag)
+                  cond-val (cond-res :content)]
+              (if (or (= cond-type :nil)
+                      (and (= cond-type :boolean)
+                           (= cond-val "false")))
+                (if-let [else-ast (get (ast :content) 3)]
+                  ## tco
+                  (set ast else-ast)
+                  (return result (make-nil)))
+                ## tco
+                (set ast (in (ast :content) 2))))
+            ##
+            "fn*"
+            (let [params ((in (ast :content) 1) :content)
+                  body (in (ast :content) 2)]
+              ## tco
+              (return result
+                      (make-function (fn [args]
+                                       (EVAL body
+                                         (make-env env params args)))
+                                     body params env)))
+            ##
+            (let [eval-list ((eval_ast ast env) :content)
+                  f (first eval-list)
+                  args (drop 1 eval-list)]
+              (if-let [body (f :ast)] ## tco
+                (do
+                  (set ast body)
+                  (set env (make-env (f :env) (f :params) args)))
+                (return result
+                        ((f :content) args))))))))))
+
+(defn PRINT
+  [ast]
+  (pr_str ast true))
+
+(defn rep
+  [code-str]
+  (let [ds (READ code-str)]
+    (when ds
+      (PRINT
+        (EVAL ds repl_env)))))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(env-set repl_env
+         (make-symbol "eval")
+         (make-function (fn [asts]
+                          (EVAL (in asts 0) repl_env))))
+
+(rep ```
+  (def! load-file
+        (fn* (fpath)
+          (eval
+            (read-string (str "(do "
+                                (slurp fpath) "\n"
+                                "nil)")))))
+```)
+
+# getline gives problems
+(defn getstdin [prompt buf]
+  (file/write stdout prompt)
+  (file/flush stdout)
+  (file/read stdin :line buf))
+
+(defn main
+  [& args]
+  (let [args-len (length args)
+        argv (if (<= 2 args-len)
+               (drop 2 args)
+               ())]
+    (env-set repl_env
+             (make-symbol "*ARGV*")
+             (make-list (map make-string argv)))
+    (if (< 1 args-len)
+      (rep
+        (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+      (do
+        (var buf nil)
+        (while true
+          (set buf @"")
+          (getstdin "user> " buf)
+          (if (= 0 (length buf))
+            (break)
+            (try
+              (print (rep buf))
+              ([err]
+               (print err)))))))))

--- a/impls/janet/step6_file.janet
+++ b/impls/janet/step6_file.janet
@@ -98,6 +98,7 @@
                       (make-function (fn [args]
                                        (EVAL body
                                          (make-env env params args)))
+                                     nil false
                                      body params env)))
             ##
             (let [eval-list ((eval_ast ast env) :content)

--- a/impls/janet/step6_file.janet
+++ b/impls/janet/step6_file.janet
@@ -114,10 +114,7 @@
 
 (defn rep
   [code-str]
-  (let [ds (READ code-str)]
-    (when ds
-      (PRINT
-        (EVAL ds repl_env)))))
+  (PRINT (EVAL (READ code-str) repl_env)))
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
@@ -141,6 +138,17 @@
   (file/flush stdout)
   (file/read stdin :line buf))
 
+(defn handle-error
+  [err]
+  (cond
+    (t/nil?* err)
+    (print)
+    ##
+    (string? err)
+    (print err)
+    ##
+    (print (string "Error: " (PRINT err)))))
+
 (defn main
   [& args]
   (let [args-len (length args)
@@ -151,8 +159,11 @@
                (t/make-symbol "*ARGV*")
                (t/make-list (map t/make-string argv)))
     (if (< 1 args-len)
-      (rep
-        (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+      (try
+        (rep
+          (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+        ([err]
+         (handle-error err)))
       (do
         (var buf nil)
         (while true
@@ -163,4 +174,4 @@
             (try
               (print (rep buf))
               ([err]
-               (print err)))))))))
+               (handle-error err)))))))))

--- a/impls/janet/step6_file.janet
+++ b/impls/janet/step6_file.janet
@@ -23,8 +23,8 @@
     (env-get env ast)
     #
     :hash-map
-    (make-hash-map (map |(EVAL $0 env)
-                        (ast :content)))
+    (make-hash-map (struct ;(map |(EVAL $0 env)
+                                 (kvs (ast :content)))))
     #
     :list
     (make-list (map |(EVAL $0 env)

--- a/impls/janet/step6_file.janet
+++ b/impls/janet/step6_file.janet
@@ -1,13 +1,13 @@
 (import ./reader)
-(import ./printer :prefix "")
-(import ./types :prefix "")
-(import ./env :prefix "")
+(import ./printer)
+(import ./types :as t)
+(import ./env :as e)
 (import ./core)
 
 (def repl_env
-  (let [env (make-env)]
+  (let [env (e/make-env)]
     (eachp [k v] core/ns
-      (env-set env k v))
+      (e/env-set env k v))
     env))
 
 (defn READ
@@ -18,21 +18,21 @@
 
 (defn eval_ast
   [ast env]
-  (case (ast :tag)
-    :symbol
-    (env-get env ast)
+  (cond
+    (t/symbol?* ast)
+    (e/env-get env ast)
     #
-    :hash-map
-    (make-hash-map (struct ;(map |(EVAL $0 env)
-                                 (kvs (ast :content)))))
+    (t/hash-map?* ast)
+    (t/make-hash-map (struct ;(map |(EVAL $0 env)
+                                   (kvs (t/get-value ast)))))
     #
-    :list
-    (make-list (map |(EVAL $0 env)
-                    (ast :content)))
+    (t/list?* ast)
+    (t/make-list (map |(EVAL $0 env)
+                      (t/get-value ast)))
     #
-    :vector
-    (make-vector (map |(EVAL $0 env)
-                      (ast :content)))
+    (t/vector?* ast)
+    (t/make-vector (map |(EVAL $0 env)
+                        (t/get-value ast)))
     #
     ast))
 
@@ -43,77 +43,74 @@
   (label result
     (while true
       (cond
-        (not= :list (ast :tag))
+        (not (t/list?* ast))
         (return result (eval_ast ast env))
         ##
-        (empty? (ast :content))
+        (t/empty?* ast)
         (return result ast)
         ##
-        (let [ast-head (in (ast :content) 0)
-              head-name (ast-head :content)]
+        (let [ast-head (first (t/get-value ast))
+              head-name (t/get-value ast-head)]
           (case head-name
             "def!"
-            (let [def-name (in (ast :content) 1)
-                  def-val (EVAL (in (ast :content) 2) env)]
-              (env-set env
-                       def-name def-val)
+            (let [def-name (in (t/get-value ast) 1)
+                  def-val (EVAL (in (t/get-value ast) 2) env)]
+              (e/env-set env
+                         def-name def-val)
               (return result def-val))
             ##
             "let*"
-            (let [new-env (make-env env)
-                  bindings ((in (ast :content) 1) :content)]
+            (let [new-env (e/make-env env)
+                  bindings (t/get-value (in (t/get-value ast) 1))]
               (each [let-name let-val] (partition 2 bindings)
-                    (env-set new-env
-                             let-name (EVAL let-val new-env)))
+                    (e/env-set new-env
+                               let-name (EVAL let-val new-env)))
               ## tco
-              (set ast (in (ast :content) 2))
+              (set ast (in (t/get-value ast) 2))
               (set env new-env))
             ##
             "do"
-            (let [most-do-body-forms (slice (ast :content) 1 -2)
-                  last-body-form (last (ast :content))
-                  res-ast (eval_ast (make-list most-do-body-forms) env)]
+            (let [most-do-body-forms (slice (t/get-value ast) 1 -2)
+                  last-body-form (last (t/get-value ast))
+                  res-ast (eval_ast (t/make-list most-do-body-forms) env)]
               ## tco
               (set ast last-body-form))
             ##
             "if"
-            (let [cond-res (EVAL (in (ast :content) 1) env)
-                  cond-type (cond-res :tag)
-                  cond-val (cond-res :content)]
-              (if (or (= cond-type :nil)
-                      (and (= cond-type :boolean)
-                           (= cond-val "false")))
-                (if-let [else-ast (get (ast :content) 3)]
+            (let [cond-res (EVAL (in (t/get-value ast) 1) env)]
+              (if (or (t/nil?* cond-res)
+                      (t/false?* cond-res))
+                (if-let [else-ast (get (t/get-value ast) 3)]
                   ## tco
                   (set ast else-ast)
-                  (return result (make-nil)))
+                  (return result t/mal-nil))
                 ## tco
-                (set ast (in (ast :content) 2))))
+                (set ast (in (t/get-value ast) 2))))
             ##
             "fn*"
-            (let [params ((in (ast :content) 1) :content)
-                  body (in (ast :content) 2)]
+            (let [params (t/get-value (in (t/get-value ast) 1))
+                  body (in (t/get-value ast) 2)]
               ## tco
               (return result
-                      (make-function (fn [args]
-                                       (EVAL body
-                                         (make-env env params args)))
-                                     nil false
-                                     body params env)))
+                      (t/make-function (fn [args]
+                                         (EVAL body
+                                           (e/make-env env params args)))
+                                       nil false
+                                       body params env)))
             ##
-            (let [eval-list ((eval_ast ast env) :content)
+            (let [eval-list (t/get-value (eval_ast ast env))
                   f (first eval-list)
                   args (drop 1 eval-list)]
-              (if-let [body (f :ast)] ## tco
+              (if-let [body (t/get-ast f)] ## tco
                 (do
                   (set ast body)
-                  (set env (make-env (f :env) (f :params) args)))
+                  (set env (e/make-env (t/get-env f) (t/get-params f) args)))
                 (return result
-                        ((f :content) args))))))))))
+                        ((t/get-value f) args))))))))))
 
 (defn PRINT
   [ast]
-  (pr_str ast true))
+  (printer/pr_str ast true))
 
 (defn rep
   [code-str]
@@ -124,19 +121,19 @@
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
-(env-set repl_env
-         (make-symbol "eval")
-         (make-function (fn [asts]
-                          (EVAL (in asts 0) repl_env))))
+(e/env-set repl_env
+           (t/make-symbol "eval")
+           (t/make-function (fn [asts]
+                              (EVAL (in asts 0) repl_env))))
 
-(rep ```
+(rep ``
   (def! load-file
         (fn* (fpath)
           (eval
             (read-string (str "(do "
                                 (slurp fpath) "\n"
                                 "nil)")))))
-```)
+``)
 
 # getline gives problems
 (defn getstdin [prompt buf]
@@ -150,9 +147,9 @@
         argv (if (<= 2 args-len)
                (drop 2 args)
                ())]
-    (env-set repl_env
-             (make-symbol "*ARGV*")
-             (make-list (map make-string argv)))
+    (e/env-set repl_env
+               (t/make-symbol "*ARGV*")
+               (t/make-list (map t/make-string argv)))
     (if (< 1 args-len)
       (rep
         (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?

--- a/impls/janet/step7_quote.janet
+++ b/impls/janet/step7_quote.janet
@@ -1,0 +1,179 @@
+(import ./reader)
+(import ./printer :prefix "")
+(import ./types :prefix "")
+(import ./env :prefix "")
+(import ./core)
+
+(def repl_env
+  (let [env (make-env)]
+    (eachp [k v] core/ns
+      (env-set env k v))
+    env))
+
+(defn READ
+  [code-str]
+  (reader/read_str code-str))
+
+(var EVAL nil)
+
+(defn eval_ast
+  [ast env]
+  (case (ast :tag)
+    :symbol
+    (env-get env ast)
+    #
+    :hash-map
+    (make-hash-map (map |(EVAL $0 env)
+                        (ast :content)))
+    #
+    :list
+    (make-list (map |(EVAL $0 env)
+                    (ast :content)))
+    #
+    :vector
+    (make-vector (map |(EVAL $0 env)
+                      (ast :content)))
+    #
+    ast))
+
+(varfn EVAL
+  [ast-param env-param]
+  (var ast ast-param)
+  (var env env-param)
+  (label result
+    (while true
+      (cond
+        (not= :list (ast :tag))
+        (return result (eval_ast ast env))
+        ##
+        (empty? (ast :content))
+        (return result ast)
+        ##
+        (let [ast-head (in (ast :content) 0)
+              head-name (ast-head :content)]
+          (case head-name
+            "def!"
+            (let [def-name (in (ast :content) 1)
+                  def-val (EVAL (in (ast :content) 2) env)]
+              (env-set env
+                       def-name def-val)
+              (return result def-val))
+            ##
+            "let*"
+            (let [new-env (make-env env)
+                  bindings ((in (ast :content) 1) :content)]
+              (each [let-name let-val] (partition 2 bindings)
+                    (env-set new-env
+                             let-name (EVAL let-val new-env)))
+              ## tco
+              (set ast (in (ast :content) 2))
+              (set env new-env))
+            ##
+            "quote"
+            (return result (in (ast :content) 1))
+            ##
+            "quasiquoteexpand"
+            ## tco
+            (return result (core/quasiquote* (in (ast :content) 1)))
+            ##
+            "quasiquote"
+            ## tco
+            (set ast (core/quasiquote* (in (ast :content) 1)))
+            ##
+            "do"
+            (let [most-do-body-forms (slice (ast :content) 1 -2)
+                  last-body-form (last (ast :content))
+                  res-ast (eval_ast (make-list most-do-body-forms) env)]
+              ## tco
+              (set ast last-body-form))
+            ##
+            "if"
+            (let [cond-res (EVAL (in (ast :content) 1) env)
+                  cond-type (cond-res :tag)
+                  cond-val (cond-res :content)]
+              (if (or (= cond-type :nil)
+                      (and (= cond-type :boolean)
+                           (= cond-val "false")))
+                (if-let [else-ast (get (ast :content) 3)]
+                  ## tco
+                  (set ast else-ast)
+                  (return result (make-nil)))
+                ## tco
+                (set ast (in (ast :content) 2))))
+            ##
+            "fn*"
+            (let [params ((in (ast :content) 1) :content)
+                  body (in (ast :content) 2)]
+              ## tco
+              (return result
+                      (make-function (fn [args]
+                                       (EVAL body
+                                         (make-env env params args)))
+                                     body params env)))
+            ##
+            (let [eval-list ((eval_ast ast env) :content)
+                  f (first eval-list)
+                  args (drop 1 eval-list)]
+              (if-let [body (f :ast)] ## tco
+                (do
+                  (set ast body)
+                  (set env (make-env (f :env) (f :params) args)))
+                (return result
+                        ((f :content) args))))))))))
+
+(defn PRINT
+  [ast]
+  (pr_str ast true))
+
+(defn rep
+  [code-str]
+  (let [ds (READ code-str)]
+    (when ds
+      (PRINT
+        (EVAL ds repl_env)))))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(env-set repl_env
+         (make-symbol "eval")
+         (make-function (fn [asts]
+                          (EVAL (in asts 0) repl_env))))
+
+(rep ```
+  (def! load-file
+        (fn* (fpath)
+          (eval
+            (read-string (str "(do "
+                                (slurp fpath) "\n"
+                                "nil)")))))
+```)
+
+# getline gives problems
+(defn getstdin [prompt buf]
+  (file/write stdout prompt)
+  (file/flush stdout)
+  (file/read stdin :line buf))
+
+(defn main
+  [& args]
+  (let [args-len (length args)
+        argv (if (<= 2 args-len)
+               (drop 2 args)
+               ())]
+    (env-set repl_env
+             (make-symbol "*ARGV*")
+             (make-list (map make-string argv)))
+    (if (< 1 args-len)
+      (rep
+        (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+      (do
+        (var buf nil)
+        (while true
+          (set buf @"")
+          (getstdin "user> " buf)
+          (if (= 0 (length buf))
+            (break)
+            (try
+              (print (rep buf))
+              ([err]
+               (print err)))))))))

--- a/impls/janet/step7_quote.janet
+++ b/impls/janet/step7_quote.janet
@@ -23,8 +23,8 @@
     (env-get env ast)
     #
     :hash-map
-    (make-hash-map (map |(EVAL $0 env)
-                        (ast :content)))
+    (make-hash-map (struct ;(map |(EVAL $0 env)
+                                 (kvs (ast :content)))))
     #
     :list
     (make-list (map |(EVAL $0 env)

--- a/impls/janet/step7_quote.janet
+++ b/impls/janet/step7_quote.janet
@@ -167,10 +167,7 @@
 
 (defn rep
   [code-str]
-  (let [ds (READ code-str)]
-    (when ds
-      (PRINT
-        (EVAL ds repl_env)))))
+  (PRINT (EVAL (READ code-str) repl_env)))
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
@@ -194,6 +191,17 @@
   (file/flush stdout)
   (file/read stdin :line buf))
 
+(defn handle-error
+  [err]
+  (cond
+    (t/nil?* err)
+    (print)
+    ##
+    (string? err)
+    (print err)
+    ##
+    (print (string "Error: " (PRINT err)))))
+
 (defn main
   [& args]
   (let [args-len (length args)
@@ -204,8 +212,11 @@
                (t/make-symbol "*ARGV*")
                (t/make-list (map t/make-string argv)))
     (if (< 1 args-len)
-      (rep
-        (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+      (try
+        (rep
+          (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+        ([err]
+         (handle-error err)))
       (do
         (var buf nil)
         (while true
@@ -216,4 +227,4 @@
             (try
               (print (rep buf))
               ([err]
-               (print err)))))))))
+               (handle-error err)))))))))

--- a/impls/janet/step7_quote.janet
+++ b/impls/janet/step7_quote.janet
@@ -36,6 +36,48 @@
     #
     ast))
 
+(defn starts-with
+  [ast name]
+  (when (and (core/list?* ast)
+             (not (core/is-empty?* ast)))
+    (let [head-ast (in (ast :content) 0)]
+      (and (= :symbol (head-ast :tag))
+           (= name (head-ast :content))))))
+
+(var quasiquote* nil)
+
+(defn qq-iter
+  [ast]
+  (if (core/is-empty?* ast)
+    (make-list ())
+    (let [elt (in (ast :content) 0)
+          acc (qq-iter (make-list (slice (ast :content) 1)))]
+      (if (starts-with elt "splice-unquote")
+        (make-list [(make-symbol "concat")
+                    (in (elt :content) 1)
+                    acc])
+        (make-list [(make-symbol "cons")
+                    (quasiquote* elt)
+                    acc])))))
+
+(varfn quasiquote*
+  [ast]
+  (cond
+    (starts-with ast "unquote")
+    (in (ast :content) 1)
+    ##
+    (core/list?* ast)
+    (qq-iter ast)
+    ##
+    (core/vector?* ast)
+    (make-list [(make-symbol "vec") (qq-iter ast)])
+    ##
+    (or (= :symbol (ast :tag))
+        (= :hash-map (ast :tag)))
+    (make-list [(make-symbol "quote") ast])
+    ##
+    ast))
+
 (varfn EVAL
   [ast-param env-param]
   (var ast ast-param)
@@ -74,11 +116,11 @@
             ##
             "quasiquoteexpand"
             ## tco
-            (return result (core/quasiquote* (in (ast :content) 1)))
+            (return result (quasiquote* (in (ast :content) 1)))
             ##
             "quasiquote"
             ## tco
-            (set ast (core/quasiquote* (in (ast :content) 1)))
+            (set ast (quasiquote* (in (ast :content) 1)))
             ##
             "do"
             (let [most-do-body-forms (slice (ast :content) 1 -2)

--- a/impls/janet/step7_quote.janet
+++ b/impls/janet/step7_quote.janet
@@ -39,7 +39,7 @@
 (defn starts-with
   [ast name]
   (when (and (core/list?* ast)
-             (not (core/is-empty?* ast)))
+             (not (core/empty?* ast)))
     (let [head-ast (in (ast :content) 0)]
       (and (= :symbol (head-ast :tag))
            (= name (head-ast :content))))))
@@ -48,7 +48,7 @@
 
 (defn qq-iter
   [ast]
-  (if (core/is-empty?* ast)
+  (if (core/empty?* ast)
     (make-list ())
     (let [elt (in (ast :content) 0)
           acc (qq-iter (make-list (slice (ast :content) 1)))]

--- a/impls/janet/step7_quote.janet
+++ b/impls/janet/step7_quote.janet
@@ -1,13 +1,13 @@
 (import ./reader)
-(import ./printer :prefix "")
+(import ./printer)
 (import ./types :as t)
-(import ./env :prefix "")
+(import ./env :as e)
 (import ./core)
 
 (def repl_env
-  (let [env (make-env)]
+  (let [env (e/make-env)]
     (eachp [k v] core/ns
-      (env-set env k v))
+      (e/env-set env k v))
     env))
 
 (defn READ
@@ -18,21 +18,21 @@
 
 (defn eval_ast
   [ast env]
-  (case (ast :tag)
-    :symbol
-    (env-get env ast)
+  (cond
+    (t/symbol?* ast)
+    (e/env-get env ast)
     #
-    :hash-map
+    (t/hash-map?* ast)
     (t/make-hash-map (struct ;(map |(EVAL $0 env)
-                                   (kvs (ast :content)))))
+                                   (kvs (t/get-value ast)))))
     #
-    :list
+    (t/list?* ast)
     (t/make-list (map |(EVAL $0 env)
-                      (ast :content)))
+                      (t/get-value ast)))
     #
-    :vector
+    (t/vector?* ast)
     (t/make-vector (map |(EVAL $0 env)
-                        (ast :content)))
+                        (t/get-value ast)))
     #
     ast))
 
@@ -40,9 +40,9 @@
   [ast name]
   (when (and (t/list?* ast)
              (not (t/empty?* ast)))
-    (let [head-ast (in (ast :content) 0)]
-      (and (= :symbol (head-ast :tag))
-           (= name (head-ast :content))))))
+    (let [head-ast (in (t/get-value ast) 0)]
+      (and (t/symbol?* head-ast)
+           (= name (t/get-value head-ast))))))
 
 (var quasiquote* nil)
 
@@ -50,11 +50,11 @@
   [ast]
   (if (t/empty?* ast)
     (t/make-list ())
-    (let [elt (in (ast :content) 0)
-          acc (qq-iter (t/make-list (slice (ast :content) 1)))]
+    (let [elt (in (t/get-value ast) 0)
+          acc (qq-iter (t/make-list (slice (t/get-value ast) 1)))]
       (if (starts-with elt "splice-unquote")
         (t/make-list [(t/make-symbol "concat")
-                      (in (elt :content) 1)
+                      (in (t/get-value elt) 1)
                       acc])
         (t/make-list [(t/make-symbol "cons")
                       (quasiquote* elt)
@@ -64,7 +64,7 @@
   [ast]
   (cond
     (starts-with ast "unquote")
-    (in (ast :content) 1)
+    (in (t/get-value ast) 1)
     ##
     (t/list?* ast)
     (qq-iter ast)
@@ -72,8 +72,8 @@
     (t/vector?* ast)
     (t/make-list [(t/make-symbol "vec") (qq-iter ast)])
     ##
-    (or (= :symbol (ast :tag))
-        (= :hash-map (ast :tag)))
+    (or (t/symbol?* ast)
+        (t/hash-map?* ast))
     (t/make-list [(t/make-symbol "quote") ast])
     ##
     ast))
@@ -85,88 +85,85 @@
   (label result
     (while true
       (cond
-        (not= :list (ast :tag))
+        (not (t/list?* ast))
         (return result (eval_ast ast env))
         ##
-        (empty? (ast :content))
+        (t/empty?* ast)
         (return result ast)
         ##
-        (let [ast-head (in (ast :content) 0)
-              head-name (ast-head :content)]
+        (let [ast-head (first (t/get-value ast))
+              head-name (t/get-value ast-head)]
           (case head-name
             "def!"
-            (let [def-name (in (ast :content) 1)
-                  def-val (EVAL (in (ast :content) 2) env)]
-              (env-set env
-                       def-name def-val)
+            (let [def-name (in (t/get-value ast) 1)
+                  def-val (EVAL (in (t/get-value ast) 2) env)]
+              (e/env-set env
+                         def-name def-val)
               (return result def-val))
             ##
             "let*"
-            (let [new-env (make-env env)
-                  bindings ((in (ast :content) 1) :content)]
+            (let [new-env (e/make-env env)
+                  bindings (t/get-value (in (t/get-value ast) 1))]
               (each [let-name let-val] (partition 2 bindings)
-                    (env-set new-env
-                             let-name (EVAL let-val new-env)))
+                    (e/env-set new-env
+                               let-name (EVAL let-val new-env)))
               ## tco
-              (set ast (in (ast :content) 2))
+              (set ast (in (t/get-value ast) 2))
               (set env new-env))
             ##
             "quote"
-            (return result (in (ast :content) 1))
+            (return result (in (t/get-value ast) 1))
             ##
             "quasiquoteexpand"
             ## tco
-            (return result (quasiquote* (in (ast :content) 1)))
+            (return result (quasiquote* (in (t/get-value ast) 1)))
             ##
             "quasiquote"
             ## tco
-            (set ast (quasiquote* (in (ast :content) 1)))
+            (set ast (quasiquote* (in (t/get-value ast) 1)))
             ##
             "do"
-            (let [most-do-body-forms (slice (ast :content) 1 -2)
-                  last-body-form (last (ast :content))
+            (let [most-do-body-forms (slice (t/get-value ast) 1 -2)
+                  last-body-form (last (t/get-value ast))
                   res-ast (eval_ast (t/make-list most-do-body-forms) env)]
               ## tco
               (set ast last-body-form))
             ##
             "if"
-            (let [cond-res (EVAL (in (ast :content) 1) env)
-                  cond-type (cond-res :tag)
-                  cond-val (cond-res :content)]
-              (if (or (= cond-type :nil)
-                      (and (= cond-type :boolean)
-                           (= cond-val "false")))
-                (if-let [else-ast (get (ast :content) 3)]
+            (let [cond-res (EVAL (in (t/get-value ast) 1) env)]
+              (if (or (t/nil?* cond-res)
+                      (t/false?* cond-res))
+                (if-let [else-ast (get (t/get-value ast) 3)]
                   ## tco
                   (set ast else-ast)
                   (return result t/mal-nil))
                 ## tco
-                (set ast (in (ast :content) 2))))
+                (set ast (in (t/get-value ast) 2))))
             ##
             "fn*"
-            (let [params ((in (ast :content) 1) :content)
-                  body (in (ast :content) 2)]
+            (let [params (t/get-value (in (t/get-value ast) 1))
+                  body (in (t/get-value ast) 2)]
               ## tco
               (return result
                       (t/make-function (fn [args]
-                                       (EVAL body
-                                         (make-env env params args)))
-                                     nil false
-                                     body params env)))
+                                         (EVAL body
+                                           (e/make-env env params args)))
+                                       nil false
+                                       body params env)))
             ##
-            (let [eval-list ((eval_ast ast env) :content)
+            (let [eval-list (t/get-value (eval_ast ast env))
                   f (first eval-list)
                   args (drop 1 eval-list)]
-              (if-let [body (f :ast)] ## tco
+              (if-let [body (t/get-ast f)] ## tco
                 (do
                   (set ast body)
-                  (set env (make-env (f :env) (f :params) args)))
+                  (set env (e/make-env (t/get-env f) (t/get-params f) args)))
                 (return result
-                        ((f :content) args))))))))))
+                        ((t/get-value f) args))))))))))
 
 (defn PRINT
   [ast]
-  (pr_str ast true))
+  (printer/pr_str ast true))
 
 (defn rep
   [code-str]
@@ -177,19 +174,19 @@
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
-(env-set repl_env
-         (t/make-symbol "eval")
-         (t/make-function (fn [asts]
-                            (EVAL (in asts 0) repl_env))))
+(e/env-set repl_env
+           (t/make-symbol "eval")
+           (t/make-function (fn [asts]
+                              (EVAL (in asts 0) repl_env))))
 
-(rep ```
+(rep ``
   (def! load-file
         (fn* (fpath)
           (eval
             (read-string (str "(do "
                                 (slurp fpath) "\n"
                                 "nil)")))))
-```)
+``)
 
 # getline gives problems
 (defn getstdin [prompt buf]
@@ -203,9 +200,9 @@
         argv (if (<= 2 args-len)
                (drop 2 args)
                ())]
-    (env-set repl_env
-             (t/make-symbol "*ARGV*")
-             (t/make-list (map t/make-string argv)))
+    (e/env-set repl_env
+               (t/make-symbol "*ARGV*")
+               (t/make-list (map t/make-string argv)))
     (if (< 1 args-len)
       (rep
         (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?

--- a/impls/janet/step7_quote.janet
+++ b/impls/janet/step7_quote.janet
@@ -1,6 +1,6 @@
 (import ./reader)
 (import ./printer :prefix "")
-(import ./types :prefix "")
+(import ./types :as t)
 (import ./env :prefix "")
 (import ./core)
 
@@ -23,23 +23,23 @@
     (env-get env ast)
     #
     :hash-map
-    (make-hash-map (struct ;(map |(EVAL $0 env)
-                                 (kvs (ast :content)))))
+    (t/make-hash-map (struct ;(map |(EVAL $0 env)
+                                   (kvs (ast :content)))))
     #
     :list
-    (make-list (map |(EVAL $0 env)
-                    (ast :content)))
+    (t/make-list (map |(EVAL $0 env)
+                      (ast :content)))
     #
     :vector
-    (make-vector (map |(EVAL $0 env)
-                      (ast :content)))
+    (t/make-vector (map |(EVAL $0 env)
+                        (ast :content)))
     #
     ast))
 
 (defn starts-with
   [ast name]
-  (when (and (core/list?* ast)
-             (not (core/empty?* ast)))
+  (when (and (t/list?* ast)
+             (not (t/empty?* ast)))
     (let [head-ast (in (ast :content) 0)]
       (and (= :symbol (head-ast :tag))
            (= name (head-ast :content))))))
@@ -48,17 +48,17 @@
 
 (defn qq-iter
   [ast]
-  (if (core/empty?* ast)
-    (make-list ())
+  (if (t/empty?* ast)
+    (t/make-list ())
     (let [elt (in (ast :content) 0)
-          acc (qq-iter (make-list (slice (ast :content) 1)))]
+          acc (qq-iter (t/make-list (slice (ast :content) 1)))]
       (if (starts-with elt "splice-unquote")
-        (make-list [(make-symbol "concat")
-                    (in (elt :content) 1)
-                    acc])
-        (make-list [(make-symbol "cons")
-                    (quasiquote* elt)
-                    acc])))))
+        (t/make-list [(t/make-symbol "concat")
+                      (in (elt :content) 1)
+                      acc])
+        (t/make-list [(t/make-symbol "cons")
+                      (quasiquote* elt)
+                      acc])))))
 
 (varfn quasiquote*
   [ast]
@@ -66,15 +66,15 @@
     (starts-with ast "unquote")
     (in (ast :content) 1)
     ##
-    (core/list?* ast)
+    (t/list?* ast)
     (qq-iter ast)
     ##
-    (core/vector?* ast)
-    (make-list [(make-symbol "vec") (qq-iter ast)])
+    (t/vector?* ast)
+    (t/make-list [(t/make-symbol "vec") (qq-iter ast)])
     ##
     (or (= :symbol (ast :tag))
         (= :hash-map (ast :tag)))
-    (make-list [(make-symbol "quote") ast])
+    (t/make-list [(t/make-symbol "quote") ast])
     ##
     ast))
 
@@ -125,7 +125,7 @@
             "do"
             (let [most-do-body-forms (slice (ast :content) 1 -2)
                   last-body-form (last (ast :content))
-                  res-ast (eval_ast (make-list most-do-body-forms) env)]
+                  res-ast (eval_ast (t/make-list most-do-body-forms) env)]
               ## tco
               (set ast last-body-form))
             ##
@@ -139,7 +139,7 @@
                 (if-let [else-ast (get (ast :content) 3)]
                   ## tco
                   (set ast else-ast)
-                  (return result (make-nil)))
+                  (return result t/mal-nil))
                 ## tco
                 (set ast (in (ast :content) 2))))
             ##
@@ -148,7 +148,7 @@
                   body (in (ast :content) 2)]
               ## tco
               (return result
-                      (make-function (fn [args]
+                      (t/make-function (fn [args]
                                        (EVAL body
                                          (make-env env params args)))
                                      nil false
@@ -178,9 +178,9 @@
 (rep "(def! not (fn* (a) (if a false true)))")
 
 (env-set repl_env
-         (make-symbol "eval")
-         (make-function (fn [asts]
-                          (EVAL (in asts 0) repl_env))))
+         (t/make-symbol "eval")
+         (t/make-function (fn [asts]
+                            (EVAL (in asts 0) repl_env))))
 
 (rep ```
   (def! load-file
@@ -204,8 +204,8 @@
                (drop 2 args)
                ())]
     (env-set repl_env
-             (make-symbol "*ARGV*")
-             (make-list (map make-string argv)))
+             (t/make-symbol "*ARGV*")
+             (t/make-list (map t/make-string argv)))
     (if (< 1 args-len)
       (rep
         (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?

--- a/impls/janet/step7_quote.janet
+++ b/impls/janet/step7_quote.janet
@@ -109,6 +109,7 @@
                       (make-function (fn [args]
                                        (EVAL body
                                          (make-env env params args)))
+                                     nil false
                                      body params env)))
             ##
             (let [eval-list ((eval_ast ast env) :content)

--- a/impls/janet/step8_macros.janet
+++ b/impls/janet/step8_macros.janet
@@ -58,6 +58,48 @@
     #
     ast))
 
+(defn starts-with
+  [ast name]
+  (when (and (core/list?* ast)
+             (not (core/is-empty?* ast)))
+    (let [head-ast (in (ast :content) 0)]
+      (and (= :symbol (head-ast :tag))
+           (= name (head-ast :content))))))
+
+(var quasiquote* nil)
+
+(defn qq-iter
+  [ast]
+  (if (core/is-empty?* ast)
+    (make-list ())
+    (let [elt (in (ast :content) 0)
+          acc (qq-iter (make-list (slice (ast :content) 1)))]
+      (if (starts-with elt "splice-unquote")
+        (make-list [(make-symbol "concat")
+                    (in (elt :content) 1)
+                    acc])
+        (make-list [(make-symbol "cons")
+                    (quasiquote* elt)
+                    acc])))))
+
+(varfn quasiquote*
+  [ast]
+  (cond
+    (starts-with ast "unquote")
+    (in (ast :content) 1)
+    ##
+    (core/list?* ast)
+    (qq-iter ast)
+    ##
+    (core/vector?* ast)
+    (make-list [(make-symbol "vec") (qq-iter ast)])
+    ##
+    (or (= :symbol (ast :tag))
+        (= :hash-map (ast :tag)))
+    (make-list [(make-symbol "quote") ast])
+    ##
+    ast))
+
 (varfn EVAL
   [ast-param env-param]
   (var ast ast-param)
@@ -115,11 +157,11 @@
           ##
           "quasiquoteexpand"
           ## tco
-          (return result (core/quasiquote* (in (ast :content) 1)))
+          (return result (quasiquote* (in (ast :content) 1)))
           ##
           "quasiquote"
           ## tco
-          (set ast (core/quasiquote* (in (ast :content) 1)))
+          (set ast (quasiquote* (in (ast :content) 1)))
           ##
           "do"
           (let [most-do-body-forms (slice (ast :content) 1 -2)

--- a/impls/janet/step8_macros.janet
+++ b/impls/janet/step8_macros.janet
@@ -203,10 +203,7 @@
 
 (defn rep
   [code-str]
-  (let [ds (READ code-str)]
-    (when ds
-      (PRINT
-        (EVAL ds repl_env)))))
+  (PRINT (EVAL (READ code-str) repl_env)))
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
@@ -242,6 +239,17 @@
   (file/flush stdout)
   (file/read stdin :line buf))
 
+(defn handle-error
+  [err]
+  (cond
+    (t/nil?* err)
+    (print)
+    ##
+    (string? err)
+    (print err)
+    ##
+    (print (string "Error: " (PRINT err)))))
+
 (defn main
   [& args]
   (let [args-len (length args)
@@ -252,8 +260,11 @@
                (t/make-symbol "*ARGV*")
                (t/make-list (map t/make-string argv)))
     (if (< 1 args-len)
-      (rep
-        (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+      (try
+        (rep
+          (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+        ([err]
+         (handle-error err)))
       (do
         (var buf nil)
         (while true
@@ -264,4 +275,4 @@
             (try
               (print (rep buf))
               ([err]
-               (print err)))))))))
+               (handle-error err)))))))))

--- a/impls/janet/step8_macros.janet
+++ b/impls/janet/step8_macros.janet
@@ -124,7 +124,7 @@
           (let [def-name (in (ast :content) 1)
                 def-val (EVAL (in (ast :content) 2) env)]
             (env-set env
-              def-name def-val)
+                     def-name def-val)
             (return result def-val))
           ##
           "defmacro!"
@@ -147,7 +147,7 @@
                 bindings ((in (ast :content) 1) :content)]
             (each [let-name let-val] (partition 2 bindings)
                   (env-set new-env
-                    let-name (EVAL let-val new-env)))
+                           let-name (EVAL let-val new-env)))
             ## tco
             (set ast (in (ast :content) 2))
             (set env new-env))
@@ -175,8 +175,8 @@
                 cond-type (cond-res :tag)
                 cond-val (cond-res :content)]
             (if (or (= cond-type :nil)
-                  (and (= cond-type :boolean)
-                    (= cond-val "false")))
+                    (and (= cond-type :boolean)
+                         (= cond-val "false")))
               (if-let [else-ast (get (ast :content) 3)]
                 ## tco
                 (set ast else-ast)

--- a/impls/janet/step8_macros.janet
+++ b/impls/janet/step8_macros.janet
@@ -1,0 +1,229 @@
+(import ./reader)
+(import ./printer :prefix "")
+(import ./types :prefix "")
+(import ./env :prefix "")
+(import ./core)
+
+(def repl_env
+  (let [env (make-env)]
+    (eachp [k v] core/ns
+      (env-set env k v))
+    env))
+
+(defn READ
+  [code-str]
+  (reader/read_str code-str))
+
+(defn is_macro_call
+  [ast env]
+  (when (and (core/is-list?* ast)
+             (not (core/is-empty?* ast)))
+    (when-let [head-ast (in (ast :content) 0)]
+      (when (= :symbol (head-ast :tag))
+        (when (env-find env head-ast)
+          (let [target-ast (env-get env head-ast)]
+            (and (= :function (target-ast :tag))
+                 (target-ast :is-macro))))))))
+
+(defn macroexpand
+  [ast env]
+  (var ast-var ast)
+  (while (is_macro_call ast-var env)
+    (let [inner-asts (ast-var :content)
+          head-ast (in inner-asts 0)
+          macro-fn ((env-get env head-ast) :content)
+          args (drop 1 inner-asts)]
+      (set ast-var (macro-fn args))))
+  ast-var)
+
+(var EVAL nil)
+
+(defn eval_ast
+  [ast env]
+  (case (ast :tag)
+    :symbol
+    (env-get env ast)
+    #
+    :hash-map
+    (make-hash-map (map |(EVAL $0 env)
+                        (ast :content)))
+    #
+    :list
+    (make-list (map |(EVAL $0 env)
+                    (ast :content)))
+    #
+    :vector
+    (make-vector (map |(EVAL $0 env)
+                      (ast :content)))
+    #
+    ast))
+
+(varfn EVAL
+  [ast-param env-param]
+  (var ast ast-param)
+  (var env env-param)
+  (label result
+    (while true
+      (when (not= :list (ast :tag))
+        (return result (eval_ast ast env)))
+      ##
+      (set ast (macroexpand ast env))
+      ##
+      (when (not= :list (ast :tag))
+        (return result (eval_ast ast env)))
+      ##
+      (when (empty? (ast :content))
+        (return result ast))
+      ##
+      (let [ast-head (in (ast :content) 0)
+            head-name (ast-head :content)]
+        (case head-name
+          "def!"
+          (let [def-name (in (ast :content) 1)
+                def-val (EVAL (in (ast :content) 2) env)]
+            (env-set env
+              def-name def-val)
+            (return result def-val))
+          ##
+          "defmacro!"
+          (let [def-name (in (ast :content) 1)
+                def-val (EVAL (in (ast :content) 2) env)]
+            (put def-val
+              :is-macro true)
+            (env-set env
+              def-name def-val)
+            (return result def-val))
+          ##
+          "macroexpand"
+          (return result (macroexpand (in (ast :content) 1) env))
+          ##
+          "let*"
+          (let [new-env (make-env env)
+                bindings ((in (ast :content) 1) :content)]
+            (each [let-name let-val] (partition 2 bindings)
+                  (env-set new-env
+                    let-name (EVAL let-val new-env)))
+            ## tco
+            (set ast (in (ast :content) 2))
+            (set env new-env))
+          ##
+          "quote"
+          (return result (in (ast :content) 1))
+          ##
+          "quasiquoteexpand"
+          ## tco
+          (return result (core/quasiquote* (in (ast :content) 1)))
+          ##
+          "quasiquote"
+          ## tco
+          (set ast (core/quasiquote* (in (ast :content) 1)))
+          ##
+          "do"
+          (let [most-do-body-forms (slice (ast :content) 1 -2)
+                last-body-form (last (ast :content))
+                res-ast (eval_ast (make-list most-do-body-forms) env)]
+            ## tco
+            (set ast last-body-form))
+          ##
+          "if"
+          (let [cond-res (EVAL (in (ast :content) 1) env)
+                cond-type (cond-res :tag)
+                cond-val (cond-res :content)]
+            (if (or (= cond-type :nil)
+                  (and (= cond-type :boolean)
+                    (= cond-val "false")))
+              (if-let [else-ast (get (ast :content) 3)]
+                ## tco
+                (set ast else-ast)
+                (return result (make-nil)))
+              ## tco
+              (set ast (in (ast :content) 2))))
+          ##
+          "fn*"
+          (let [params ((in (ast :content) 1) :content)
+                body (in (ast :content) 2)]
+            ## tco
+            (return result
+              (make-function (fn [args]
+                               (EVAL body
+                                 (make-env env params args)))
+                body params env)))
+          ##
+          (let [eval-list ((eval_ast ast env) :content)
+                f (first eval-list)
+                args (drop 1 eval-list)]
+            (if-let [body (f :ast)] ## tco
+              (do
+                (set ast body)
+                (set env (make-env (f :env) (f :params) args)))
+              (return result
+                ((f :content) args)))))))))
+
+(defn PRINT
+  [ast]
+  (pr_str ast true))
+
+(defn rep
+  [code-str]
+  (let [ds (READ code-str)]
+    (when ds
+      (PRINT
+        (EVAL ds repl_env)))))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(env-set repl_env
+         (make-symbol "eval")
+         (make-function (fn [asts]
+                          (EVAL (in asts 0) repl_env))))
+
+(rep ``
+  (def! load-file
+        (fn* (fpath)
+          (eval
+            (read-string (str "(do "
+                                (slurp fpath) "\n"
+                                "nil)")))))
+``)
+
+(rep ``
+  (defmacro! cond
+    (fn* (& xs)
+      (if (> (count xs) 0)
+        (list 'if
+              (first xs)
+              (if (> (count xs) 1)
+                  (nth xs 1)
+                  (throw "odd number of forms to cond"))
+              (cons 'cond (rest (rest xs)))))))
+``)
+
+# getline gives problems
+(defn getstdin [prompt buf]
+  (file/write stdout prompt)
+  (file/flush stdout)
+  (file/read stdin :line buf))
+
+(defn main
+  [& args]
+  (let [args-len (length args)
+        argv (if (<= 2 args-len)
+               (drop 2 args)
+               ())]
+    (env-set repl_env
+             (make-symbol "*ARGV*")
+             (make-list (map make-string argv)))
+    (if (< 1 args-len)
+      (rep
+        (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+      (do
+        (var buf nil)
+        (while true
+          (set buf @"")
+          (getstdin "user> " buf)
+          (if (= 0 (length buf))
+            (break)
+            (try
+              (print (rep buf))
+              ([err]
+               (print err)))))))))

--- a/impls/janet/step8_macros.janet
+++ b/impls/janet/step8_macros.janet
@@ -17,7 +17,7 @@
 (defn is_macro_call
   [ast env]
   (when (and (core/list?* ast)
-             (not (core/is-empty?* ast)))
+             (not (core/empty?* ast)))
     (when-let [head-ast (in (ast :content) 0)]
       (when (= :symbol (head-ast :tag))
         (when (env-find env head-ast)
@@ -61,7 +61,7 @@
 (defn starts-with
   [ast name]
   (when (and (core/list?* ast)
-             (not (core/is-empty?* ast)))
+             (not (core/empty?* ast)))
     (let [head-ast (in (ast :content) 0)]
       (and (= :symbol (head-ast :tag))
            (= name (head-ast :content))))))
@@ -70,7 +70,7 @@
 
 (defn qq-iter
   [ast]
-  (if (core/is-empty?* ast)
+  (if (core/empty?* ast)
     (make-list ())
     (let [elt (in (ast :content) 0)
           acc (qq-iter (make-list (slice (ast :content) 1)))]

--- a/impls/janet/step9_try.janet
+++ b/impls/janet/step9_try.janet
@@ -124,7 +124,7 @@
           (let [def-name (in (ast :content) 1)
                 def-val (EVAL (in (ast :content) 2) env)]
             (env-set env
-              def-name def-val)
+                     def-name def-val)
             (return result def-val))
           ##
           "defmacro!"
@@ -147,7 +147,7 @@
                 bindings ((in (ast :content) 1) :content)]
             (each [let-name let-val] (partition 2 bindings)
                   (env-set new-env
-                    let-name (EVAL let-val new-env)))
+                           let-name (EVAL let-val new-env)))
             ## tco
             (set ast (in (ast :content) 2))
             (set env new-env))
@@ -194,8 +194,8 @@
                 cond-type (cond-res :tag)
                 cond-val (cond-res :content)]
             (if (or (= cond-type :nil)
-                  (and (= cond-type :boolean)
-                    (= cond-val "false")))
+                    (and (= cond-type :boolean)
+                         (= cond-val "false")))
               (if-let [else-ast (get (ast :content) 3)]
                 ## tco
                 (set ast else-ast)

--- a/impls/janet/step9_try.janet
+++ b/impls/janet/step9_try.janet
@@ -1,6 +1,6 @@
 (import ./reader)
 (import ./printer :prefix "")
-(import ./types :prefix "")
+(import ./types :as t)
 (import ./env :prefix "")
 (import ./core)
 
@@ -16,8 +16,8 @@
 
 (defn is_macro_call
   [ast env]
-  (when (and (core/list?* ast)
-             (not (core/empty?* ast)))
+  (when (and (t/list?* ast)
+             (not (t/empty?* ast)))
     (when-let [head-ast (in (ast :content) 0)]
       (when (= :symbol (head-ast :tag))
         (when (env-find env head-ast)
@@ -45,23 +45,23 @@
     (env-get env ast)
     #
     :hash-map
-    (make-hash-map (struct ;(map |(EVAL $0 env)
-                                 (kvs (ast :content)))))
+    (t/make-hash-map (struct ;(map |(EVAL $0 env)
+                                   (kvs (ast :content)))))
     #
     :list
-    (make-list (map |(EVAL $0 env)
-                    (ast :content)))
+    (t/make-list (map |(EVAL $0 env)
+                      (ast :content)))
     #
     :vector
-    (make-vector (map |(EVAL $0 env)
-                      (ast :content)))
+    (t/make-vector (map |(EVAL $0 env)
+                        (ast :content)))
     #
     ast))
 
 (defn starts-with
   [ast name]
-  (when (and (core/list?* ast)
-             (not (core/empty?* ast)))
+  (when (and (t/list?* ast)
+             (not (t/empty?* ast)))
     (let [head-ast (in (ast :content) 0)]
       (and (= :symbol (head-ast :tag))
            (= name (head-ast :content))))))
@@ -70,17 +70,17 @@
 
 (defn qq-iter
   [ast]
-  (if (core/empty?* ast)
-    (make-list ())
+  (if (t/empty?* ast)
+    (t/make-list ())
     (let [elt (in (ast :content) 0)
-          acc (qq-iter (make-list (slice (ast :content) 1)))]
+          acc (qq-iter (t/make-list (slice (ast :content) 1)))]
       (if (starts-with elt "splice-unquote")
-        (make-list [(make-symbol "concat")
-                    (in (elt :content) 1)
-                    acc])
-        (make-list [(make-symbol "cons")
-                    (quasiquote* elt)
-                    acc])))))
+        (t/make-list [(t/make-symbol "concat")
+                      (in (elt :content) 1)
+                      acc])
+        (t/make-list [(t/make-symbol "cons")
+                      (quasiquote* elt)
+                      acc])))))
 
 (varfn quasiquote*
   [ast]
@@ -88,15 +88,15 @@
     (starts-with ast "unquote")
     (in (ast :content) 1)
     ##
-    (core/list?* ast)
+    (t/list?* ast)
     (qq-iter ast)
     ##
-    (core/vector?* ast)
-    (make-list [(make-symbol "vec") (qq-iter ast)])
+    (t/vector?* ast)
+    (t/make-list [(t/make-symbol "vec") (qq-iter ast)])
     ##
     (or (= :symbol (ast :tag))
         (= :hash-map (ast :tag)))
-    (make-list [(make-symbol "quote") ast])
+    (t/make-list [(t/make-symbol "quote") ast])
     ##
     ast))
 
@@ -130,11 +130,11 @@
           "defmacro!"
           (let [def-name (in (ast :content) 1)
                 def-val (EVAL (in (ast :content) 2) env)
-                macro-ast (make-function (def-val :content)
-                                         (def-val :meta)
-                                         true
-                                         nil nil
-                                         (def-val :env))]
+                macro-ast (t/make-function (def-val :content)
+                                           (def-val :meta)
+                                           true
+                                           nil nil
+                                           (def-val :env))]
             (env-set env
                      def-name macro-ast)
             (return result macro-ast))
@@ -170,7 +170,7 @@
                   ([err]
                    (if-let [maybe-catch-ast (get (ast :content) 2)]
                      (if (not (starts-with maybe-catch-ast "catch*"))
-                       (make-exception err)
+                       (t/make-exception err)
                        (let [catch-asts (maybe-catch-ast :content)
                              # XXX: assert appropriate length?
                              catch-sym-ast (in catch-asts 1)
@@ -179,13 +179,13 @@
                          (EVAL catch-body-ast (make-env env
                                                         [catch-sym-ast]
                                                         [err]))))
-                     (make-exception err))))]
+                     (t/make-exception err))))]
             (return result res))
           ##
           "do"
           (let [most-do-body-forms (slice (ast :content) 1 -2)
                 last-body-form (last (ast :content))
-                res-ast (eval_ast (make-list most-do-body-forms) env)]
+                res-ast (eval_ast (t/make-list most-do-body-forms) env)]
             ## tco
             (set ast last-body-form))
           ##
@@ -199,7 +199,7 @@
               (if-let [else-ast (get (ast :content) 3)]
                 ## tco
                 (set ast else-ast)
-                (return result (make-nil)))
+                (return result t/mal-nil))
               ## tco
               (set ast (in (ast :content) 2))))
           ##
@@ -208,11 +208,11 @@
                 body (in (ast :content) 2)]
             ## tco
             (return result
-              (make-function (fn [args]
-                               (EVAL body
-                                 (make-env env params args)))
-                             nil false
-                             body params env)))
+              (t/make-function (fn [args]
+                                 (EVAL body
+                                   (make-env env params args)))
+                               nil false
+                               body params env)))
           ##
           (let [eval-list ((eval_ast ast env) :content)
                 f (first eval-list)
@@ -236,14 +236,14 @@
         (try
           (EVAL ds repl_env)
           ([err]
-           (make-exception err)))))))
+           (t/make-exception err)))))))
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
 (env-set repl_env
-         (make-symbol "eval")
-         (make-function (fn [asts]
-                          (EVAL (in asts 0) repl_env))))
+         (t/make-symbol "eval")
+         (t/make-function (fn [asts]
+                            (EVAL (in asts 0) repl_env))))
 
 (rep ``
   (def! load-file
@@ -279,8 +279,8 @@
                (drop 2 args)
                ())]
     (env-set repl_env
-             (make-symbol "*ARGV*")
-             (make-list (map make-string argv)))
+             (t/make-symbol "*ARGV*")
+             (t/make-list (map t/make-string argv)))
     (if (< 1 args-len)
       (rep
         (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?

--- a/impls/janet/step9_try.janet
+++ b/impls/janet/step9_try.janet
@@ -1,13 +1,13 @@
 (import ./reader)
-(import ./printer :prefix "")
+(import ./printer)
 (import ./types :as t)
-(import ./env :prefix "")
+(import ./env :as e)
 (import ./core)
 
 (def repl_env
-  (let [env (make-env)]
+  (let [env (e/make-env)]
     (eachp [k v] core/ns
-      (env-set env k v))
+      (e/env-set env k v))
     env))
 
 (defn READ
@@ -18,20 +18,19 @@
   [ast env]
   (when (and (t/list?* ast)
              (not (t/empty?* ast)))
-    (when-let [head-ast (in (ast :content) 0)]
-      (when (= :symbol (head-ast :tag))
-        (when (env-find env head-ast)
-          (let [target-ast (env-get env head-ast)]
-            (and (= :function (target-ast :tag))
-                 (target-ast :is-macro))))))))
+    (let [head-ast (in (t/get-value ast) 0)]
+      (when (and (t/symbol?* head-ast)
+                 (e/env-find env head-ast))
+        (let [target-ast (e/env-get env head-ast)]
+          (t/macro?* target-ast))))))
 
 (defn macroexpand
   [ast env]
   (var ast-var ast)
   (while (is_macro_call ast-var env)
-    (let [inner-asts (ast-var :content)
+    (let [inner-asts (t/get-value ast-var)
           head-ast (in inner-asts 0)
-          macro-fn ((env-get env head-ast) :content)
+          macro-fn (t/get-value (e/env-get env head-ast))
           args (drop 1 inner-asts)]
       (set ast-var (macro-fn args))))
   ast-var)
@@ -40,21 +39,21 @@
 
 (defn eval_ast
   [ast env]
-  (case (ast :tag)
-    :symbol
-    (env-get env ast)
+  (cond
+    (t/symbol?* ast)
+    (e/env-get env ast)
     #
-    :hash-map
+    (t/hash-map?* ast)
     (t/make-hash-map (struct ;(map |(EVAL $0 env)
-                                   (kvs (ast :content)))))
+                                   (kvs (t/get-value ast)))))
     #
-    :list
+    (t/list?* ast)
     (t/make-list (map |(EVAL $0 env)
-                      (ast :content)))
+                      (t/get-value ast)))
     #
-    :vector
+    (t/vector?* ast)
     (t/make-vector (map |(EVAL $0 env)
-                        (ast :content)))
+                        (t/get-value ast)))
     #
     ast))
 
@@ -62,9 +61,9 @@
   [ast name]
   (when (and (t/list?* ast)
              (not (t/empty?* ast)))
-    (let [head-ast (in (ast :content) 0)]
-      (and (= :symbol (head-ast :tag))
-           (= name (head-ast :content))))))
+    (let [head-ast (in (t/get-value ast) 0)]
+      (and (t/symbol?* head-ast)
+           (= name (t/get-value head-ast))))))
 
 (var quasiquote* nil)
 
@@ -72,11 +71,11 @@
   [ast]
   (if (t/empty?* ast)
     (t/make-list ())
-    (let [elt (in (ast :content) 0)
-          acc (qq-iter (t/make-list (slice (ast :content) 1)))]
+    (let [elt (in (t/get-value ast) 0)
+          acc (qq-iter (t/make-list (slice (t/get-value ast) 1)))]
       (if (starts-with elt "splice-unquote")
         (t/make-list [(t/make-symbol "concat")
-                      (in (elt :content) 1)
+                      (in (t/get-value elt) 1)
                       acc])
         (t/make-list [(t/make-symbol "cons")
                       (quasiquote* elt)
@@ -86,7 +85,7 @@
   [ast]
   (cond
     (starts-with ast "unquote")
-    (in (ast :content) 1)
+    (in (t/get-value ast) 1)
     ##
     (t/list?* ast)
     (qq-iter ast)
@@ -94,8 +93,8 @@
     (t/vector?* ast)
     (t/make-list [(t/make-symbol "vec") (qq-iter ast)])
     ##
-    (or (= :symbol (ast :tag))
-        (= :hash-map (ast :tag)))
+    (or (t/symbol?* ast)
+        (t/hash-map?* ast))
     (t/make-list [(t/make-symbol "quote") ast])
     ##
     ast))
@@ -106,127 +105,125 @@
   (var env env-param)
   (label result
     (while true
-      (when (not= :list (ast :tag))
+      (when (not (t/list?* ast))
         (return result (eval_ast ast env)))
       ##
       (set ast (macroexpand ast env))
       ##
-      (when (not= :list (ast :tag))
+      (when (not (t/list?* ast))
         (return result (eval_ast ast env)))
       ##
-      (when (empty? (ast :content))
+      (when (t/empty?* ast)
         (return result ast))
       ##
-      (let [ast-head (in (ast :content) 0)
-            head-name (ast-head :content)]
+      (let [ast-head (first (t/get-value ast))
+            head-name (t/get-value ast-head)]
         (case head-name
           "def!"
-          (let [def-name (in (ast :content) 1)
-                def-val (EVAL (in (ast :content) 2) env)]
-            (env-set env
-                     def-name def-val)
+          (let [def-name (in (t/get-value ast) 1)
+                def-val (EVAL (in (t/get-value ast) 2) env)]
+            (e/env-set env
+                       def-name def-val)
             (return result def-val))
           ##
           "defmacro!"
-          (let [def-name (in (ast :content) 1)
-                def-val (EVAL (in (ast :content) 2) env)
-                macro-ast (t/make-function (def-val :content)
-                                           (def-val :meta)
-                                           true
-                                           nil nil
-                                           (def-val :env))]
-            (env-set env
-                     def-name macro-ast)
+          (let [def-name (in (t/get-value ast) 1)
+                def-val (EVAL (in (t/get-value ast) 2) env)
+                macro-ast (t/macrofy def-val)]
+            (e/env-set env
+                       def-name macro-ast)
             (return result macro-ast))
           ##
           "macroexpand"
-          (return result (macroexpand (in (ast :content) 1) env))
+          (return result (macroexpand (in (t/get-value ast) 1) env))
           ##
           "let*"
-          (let [new-env (make-env env)
-                bindings ((in (ast :content) 1) :content)]
+          (let [new-env (e/make-env env)
+                bindings (t/get-value (in (t/get-value ast) 1))]
             (each [let-name let-val] (partition 2 bindings)
-                  (env-set new-env
-                           let-name (EVAL let-val new-env)))
+                  (e/env-set new-env
+                             let-name (EVAL let-val new-env)))
             ## tco
-            (set ast (in (ast :content) 2))
+            (set ast (in (t/get-value ast) 2))
             (set env new-env))
           ##
           "quote"
-          (return result (in (ast :content) 1))
+          (return result (in (t/get-value ast) 1))
           ##
           "quasiquoteexpand"
           ## tco
-          (return result (quasiquote* (in (ast :content) 1)))
+          (return result (quasiquote* (in (t/get-value ast) 1)))
           ##
           "quasiquote"
           ## tco
-          (set ast (quasiquote* (in (ast :content) 1)))
+          (set ast (quasiquote* (in (t/get-value ast) 1)))
           ##
           "try*"
           (let [res
                 (try
-                  (EVAL (in (ast :content) 1) env)
+                  (EVAL (in (t/get-value ast) 1) env)
                   ([err]
-                   (if-let [maybe-catch-ast (get (ast :content) 2)]
-                     (if (not (starts-with maybe-catch-ast "catch*"))
-                       (t/make-exception err)
-                       (let [catch-asts (maybe-catch-ast :content)
-                             # XXX: assert appropriate length?
-                             catch-sym-ast (in catch-asts 1)
-                             catch-body-ast (in catch-asts 2)]
-                         # XXX: what if this fails?
-                         (EVAL catch-body-ast (make-env env
-                                                        [catch-sym-ast]
-                                                        [err]))))
+                   (if-let [maybe-catch-ast (get (t/get-value ast) 2)]
+                     (if (starts-with maybe-catch-ast "catch*")
+                       (let [catch-asts (t/get-value maybe-catch-ast)]
+                         (if (>= (length catch-asts) 2)
+                           (let [catch-sym-ast (in catch-asts 1)
+                                 catch-body-ast (in catch-asts 2)]
+                             (EVAL catch-body-ast (e/make-env env
+                                                              [catch-sym-ast]
+                                                              [err])))
+                           (t/make-exception
+                             (t/make-string
+                               "catch* requires at least 2 arguments"))))
+                       (t/make-exception
+                         (t/make-string
+                           "Expected catch* form")))
+                     # XXX: is this appropriate?  show error message?
                      (t/make-exception err))))]
             (return result res))
           ##
           "do"
-          (let [most-do-body-forms (slice (ast :content) 1 -2)
-                last-body-form (last (ast :content))
+          (let [most-do-body-forms (slice (t/get-value ast) 1 -2)
+                last-body-form (last (t/get-value ast))
                 res-ast (eval_ast (t/make-list most-do-body-forms) env)]
             ## tco
             (set ast last-body-form))
           ##
           "if"
-          (let [cond-res (EVAL (in (ast :content) 1) env)
-                cond-type (cond-res :tag)
-                cond-val (cond-res :content)]
-            (if (or (= cond-type :nil)
-                    (and (= cond-type :boolean)
-                         (= cond-val "false")))
-              (if-let [else-ast (get (ast :content) 3)]
+          (let [cond-res (EVAL (in (t/get-value ast) 1) env)]
+            (if (or (t/nil?* cond-res)
+                    (t/false?* cond-res))
+              (if-let [else-ast (get (t/get-value ast) 3)]
                 ## tco
                 (set ast else-ast)
                 (return result t/mal-nil))
               ## tco
-              (set ast (in (ast :content) 2))))
+              (set ast (in (t/get-value ast) 2))))
           ##
           "fn*"
-          (let [params ((in (ast :content) 1) :content)
-                body (in (ast :content) 2)]
+          (let [params (t/get-value (in (t/get-value ast) 1))
+                body (in (t/get-value ast) 2)]
             ## tco
             (return result
               (t/make-function (fn [args]
                                  (EVAL body
-                                   (make-env env params args)))
+                                   (e/make-env env params args)))
                                nil false
                                body params env)))
           ##
-          (let [eval-list ((eval_ast ast env) :content)
+          (let [eval-list (t/get-value (eval_ast ast env))
                 f (first eval-list)
                 args (drop 1 eval-list)]
-            (if-let [body (f :ast)] ## tco
+            (if-let [body (t/get-ast f)] ## tco
               (do
                 (set ast body)
-                (set env (make-env (f :env) (f :params) args)))
+                (set env (e/make-env (t/get-env f) (t/get-params f) args)))
               (return result
-                ((f :content) args)))))))))
+                ((t/get-value f) args)))))))))
 
 (defn PRINT
   [ast]
-  (pr_str ast true))
+  (printer/pr_str ast true))
 
 (defn rep
   [code-str]
@@ -240,10 +237,10 @@
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
-(env-set repl_env
-         (t/make-symbol "eval")
-         (t/make-function (fn [asts]
-                            (EVAL (in asts 0) repl_env))))
+(e/env-set repl_env
+           (t/make-symbol "eval")
+           (t/make-function (fn [asts]
+                              (EVAL (in asts 0) repl_env))))
 
 (rep ``
   (def! load-file
@@ -278,9 +275,9 @@
         argv (if (<= 2 args-len)
                (drop 2 args)
                ())]
-    (env-set repl_env
-             (t/make-symbol "*ARGV*")
-             (t/make-list (map t/make-string argv)))
+    (e/env-set repl_env
+               (t/make-symbol "*ARGV*")
+               (t/make-list (map t/make-string argv)))
     (if (< 1 args-len)
       (rep
         (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?

--- a/impls/janet/step9_try.janet
+++ b/impls/janet/step9_try.janet
@@ -118,6 +118,24 @@
           ## tco
           (set ast (core/quasiquote* (in (ast :content) 1)))
           ##
+          "try*"
+          (let [res
+                (try
+                  (EVAL (in (ast :content) 1) env)
+                  ([err]
+                   (if-let [maybe-catch-ast (get (ast :content) 2)]
+                     (if (not (core/starts-with maybe-catch-ast "catch*"))
+                       (make-exception err)
+                       (let [catch-asts (maybe-catch-ast :content)
+                             # XXX: assert appropriate length?
+                             catch-sym-ast (in catch-asts 1)
+                             catch-body-ast (in catch-asts 2)]
+                         (EVAL catch-body-ast (make-env env
+                                                        [catch-sym-ast]
+                                                        [err]))))
+                     (make-exception err))))]
+            (return result res))
+          ##
           "do"
           (let [most-do-body-forms (slice (ast :content) 1 -2)
                 last-body-form (last (ast :content))
@@ -168,7 +186,10 @@
   (let [ds (READ code-str)]
     (when ds
       (PRINT
-        (EVAL ds repl_env)))))
+        (try
+          (EVAL ds repl_env)
+          ([err]
+           (make-exception err)))))))
 
 (rep "(def! not (fn* (a) (if a false true)))")
 

--- a/impls/janet/step9_try.janet
+++ b/impls/janet/step9_try.janet
@@ -17,7 +17,7 @@
 (defn is_macro_call
   [ast env]
   (when (and (core/list?* ast)
-             (not (core/is-empty?* ast)))
+             (not (core/empty?* ast)))
     (when-let [head-ast (in (ast :content) 0)]
       (when (= :symbol (head-ast :tag))
         (when (env-find env head-ast)
@@ -61,7 +61,7 @@
 (defn starts-with
   [ast name]
   (when (and (core/list?* ast)
-             (not (core/is-empty?* ast)))
+             (not (core/empty?* ast)))
     (let [head-ast (in (ast :content) 0)]
       (and (= :symbol (head-ast :tag))
            (= name (head-ast :content))))))
@@ -70,7 +70,7 @@
 
 (defn qq-iter
   [ast]
-  (if (core/is-empty?* ast)
+  (if (core/empty?* ast)
     (make-list ())
     (let [elt (in (ast :content) 0)
           acc (qq-iter (make-list (slice (ast :content) 1)))]

--- a/impls/janet/stepA_mal.janet
+++ b/impls/janet/stepA_mal.janet
@@ -130,11 +130,8 @@
           "defmacro!"
           (let [def-name (in (ast :content) 1)
                 def-val (EVAL (in (ast :content) 2) env)
-                macro-ast (make-function (def-val :content)
-                                         (def-val :meta)
-                                         true
-                                         nil nil
-                                         (def-val :env))]
+                macro-ast (core/spawn-function def-val
+                                               {:is-macro true})]
             (env-set env
                      def-name macro-ast)
             (return result macro-ast))

--- a/impls/janet/stepA_mal.janet
+++ b/impls/janet/stepA_mal.janet
@@ -124,7 +124,7 @@
           (let [def-name (in (ast :content) 1)
                 def-val (EVAL (in (ast :content) 2) env)]
             (env-set env
-              def-name def-val)
+                     def-name def-val)
             (return result def-val))
           ##
           "defmacro!"
@@ -144,7 +144,7 @@
                 bindings ((in (ast :content) 1) :content)]
             (each [let-name let-val] (partition 2 bindings)
                   (env-set new-env
-                    let-name (EVAL let-val new-env)))
+                           let-name (EVAL let-val new-env)))
             ## tco
             (set ast (in (ast :content) 2))
             (set env new-env))
@@ -190,8 +190,8 @@
                 cond-type (cond-res :tag)
                 cond-val (cond-res :content)]
             (if (or (= cond-type :nil)
-                  (and (= cond-type :boolean)
-                    (= cond-val "false")))
+                    (and (= cond-type :boolean)
+                         (= cond-val "false")))
               (if-let [else-ast (get (ast :content) 3)]
                 ## tco
                 (set ast else-ast)

--- a/impls/janet/stepA_mal.janet
+++ b/impls/janet/stepA_mal.janet
@@ -58,6 +58,48 @@
     #
     ast))
 
+(defn starts-with
+  [ast name]
+  (when (and (core/list?* ast)
+             (not (core/is-empty?* ast)))
+    (let [head-ast (in (ast :content) 0)]
+      (and (= :symbol (head-ast :tag))
+           (= name (head-ast :content))))))
+
+(var quasiquote* nil)
+
+(defn qq-iter
+  [ast]
+  (if (core/is-empty?* ast)
+    (make-list ())
+    (let [elt (in (ast :content) 0)
+          acc (qq-iter (make-list (slice (ast :content) 1)))]
+      (if (starts-with elt "splice-unquote")
+        (make-list [(make-symbol "concat")
+                    (in (elt :content) 1)
+                    acc])
+        (make-list [(make-symbol "cons")
+                    (quasiquote* elt)
+                    acc])))))
+
+(varfn quasiquote*
+  [ast]
+  (cond
+    (starts-with ast "unquote")
+    (in (ast :content) 1)
+    ##
+    (core/list?* ast)
+    (qq-iter ast)
+    ##
+    (core/vector?* ast)
+    (make-list [(make-symbol "vec") (qq-iter ast)])
+    ##
+    (or (= :symbol (ast :tag))
+        (= :hash-map (ast :tag)))
+    (make-list [(make-symbol "quote") ast])
+    ##
+    ast))
+
 (varfn EVAL
   [ast-param env-param]
   (var ast ast-param)
@@ -115,11 +157,11 @@
           ##
           "quasiquoteexpand"
           ## tco
-          (return result (core/quasiquote* (in (ast :content) 1)))
+          (return result (quasiquote* (in (ast :content) 1)))
           ##
           "quasiquote"
           ## tco
-          (set ast (core/quasiquote* (in (ast :content) 1)))
+          (set ast (quasiquote* (in (ast :content) 1)))
           ##
           "try*"
           (let [res
@@ -127,7 +169,7 @@
                   (EVAL (in (ast :content) 1) env)
                   ([err]
                    (if-let [maybe-catch-ast (get (ast :content) 2)]
-                     (if (not (core/starts-with maybe-catch-ast "catch*"))
+                     (if (not (starts-with maybe-catch-ast "catch*"))
                        (make-exception err)
                        (let [catch-asts (maybe-catch-ast :content)
                              # XXX: assert appropriate length?

--- a/impls/janet/stepA_mal.janet
+++ b/impls/janet/stepA_mal.janet
@@ -1,6 +1,7 @@
 (import ./reader)
 (import ./printer)
 (import ./types :as t)
+(import ./utils :as u)
 (import ./env :as e)
 (import ./core)
 
@@ -172,14 +173,14 @@
                              (EVAL catch-body-ast (e/make-env env
                                                               [catch-sym-ast]
                                                               [err])))
-                           (t/make-exception
+                           (u/throw*
                              (t/make-string
                                "catch* requires at least 2 arguments"))))
-                       (t/make-exception
+                       (u/throw*
                          (t/make-string
                            "Expected catch* form")))
                      # XXX: is this appropriate?  show error message?
-                     (t/make-exception err))))]
+                     (u/throw* err))))]
             (return result res))
           ##
           "do"
@@ -227,13 +228,7 @@
 
 (defn rep
   [code-str]
-  (let [ds (READ code-str)]
-    (when ds
-      (PRINT
-        (try
-          (EVAL ds repl_env)
-          ([err]
-           (t/make-exception err)))))))
+  (PRINT (EVAL (READ code-str) repl_env)))
 
 (rep "(def! not (fn* (a) (if a false true)))")
 
@@ -273,6 +268,17 @@
   (file/flush stdout)
   (file/read stdin :line buf))
 
+(defn handle-error
+  [err]
+  (cond
+    (t/nil?* err)
+    (print)
+    ##
+    (= (string? err))
+    (print err)
+    ##
+    (print (string "Error: " (PRINT err)))))
+
 (defn main
   [& args]
   (let [args-len (length args)
@@ -283,8 +289,11 @@
                (t/make-symbol "*ARGV*")
                (t/make-list (map t/make-string argv)))
     (if (< 1 args-len)
-      (rep
-        (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+      (try
+        (rep
+          (string "(load-file \"" (in args 1) "\")")) # XXX: escaping?
+        ([err]
+         (handle-error err)))
       (do
         (var buf nil)
         (rep "(println (str \"Mal [\" *host-language* \"]\"))")
@@ -296,4 +305,4 @@
             (try
               (print (rep buf))
               ([err]
-               (print err)))))))))
+               (handle-error err)))))))))

--- a/impls/janet/stepA_mal.janet
+++ b/impls/janet/stepA_mal.janet
@@ -17,7 +17,7 @@
 (defn is_macro_call
   [ast env]
   (when (and (core/list?* ast)
-             (not (core/is-empty?* ast)))
+             (not (core/empty?* ast)))
     (when-let [head-ast (in (ast :content) 0)]
       (when (= :symbol (head-ast :tag))
         (when (env-find env head-ast)
@@ -61,7 +61,7 @@
 (defn starts-with
   [ast name]
   (when (and (core/list?* ast)
-             (not (core/is-empty?* ast)))
+             (not (core/empty?* ast)))
     (let [head-ast (in (ast :content) 0)]
       (and (= :symbol (head-ast :tag))
            (= name (head-ast :content))))))
@@ -70,7 +70,7 @@
 
 (defn qq-iter
   [ast]
-  (if (core/is-empty?* ast)
+  (if (core/empty?* ast)
     (make-list ())
     (let [elt (in (ast :content) 0)
           acc (qq-iter (make-list (slice (ast :content) 1)))]

--- a/impls/janet/tests/stepA_mal.mal
+++ b/impls/janet/tests/stepA_mal.mal
@@ -1,0 +1,42 @@
+;; Testing basic Janet interop
+
+(janet-eval "7")
+;=>7
+
+(janet-eval "\"7\"")
+;=>"7"
+
+(janet-eval "nil")
+;=>nil
+
+(janet-eval "(= 123 123)")
+;=>true
+
+(janet-eval "(= 123 456)")
+;=>false
+
+(janet-eval ":my-keyword")
+;=>:my-keyword
+
+(janet-eval "'(7 8 9)")
+;=>(7 8 9)
+
+(janet-eval "{:abc 789}")
+;=>{:abc 789}
+
+(janet-eval "(print \"hello\")")
+;/hello
+;=>nil
+
+(janet-eval "(defn foo [] 8)")
+(janet-eval "(foo)")
+;=>8
+
+(janet-eval "(let [tup [:a 1 :b 2]] (struct ;tup))")
+;=>{:a 1 :b 2}
+
+(janet-eval "(do (def tbl @{}) (put tbl :x 8) tbl)")
+;=>{:x 8}
+
+(janet-eval "(do (var mut 1) (set mut 2) mut)")
+;=>2

--- a/impls/janet/types.janet
+++ b/impls/janet/types.janet
@@ -69,7 +69,177 @@
   @{:tag :atom
     :content ast})
 
+(defn set-atom-value!
+  [atom-ast value-ast]
+  (put atom-ast
+       :content value-ast))
+
 (defn make-exception
   [ast]
   {:tag :exception
    :content ast})
+
+## common accessors
+
+(defn get-value
+  [ast]
+  (ast :content))
+
+(defn get-type
+  [ast]
+  (ast :tag))
+
+(defn get-meta
+  [ast]
+  (ast :meta))
+
+## function-specific accessors
+
+(defn get-is-macro
+  [ast]
+  (ast :is-macro))
+
+(defn get-ast
+  [ast]
+  (ast :ast))
+
+(defn get-params
+  [ast]
+  (ast :params))
+
+(defn get-env
+  [ast]
+  (ast :env))
+
+## function-specific functions
+
+(defn macrofy
+  [fn-ast]
+  (merge fn-ast {:is-macro true}))
+
+(defn clone-with-meta
+  [fn-ast meta-ast]
+  (merge fn-ast {:meta meta-ast}))
+
+## predicates
+
+(defn nil?*
+  [ast]
+  (= :nil (get-type ast)))
+
+(defn boolean?*
+  [ast]
+  (= :boolean (get-type ast)))
+
+(defn true?*
+  [ast]
+  (and (boolean?* ast)
+       (= "true" (get-value ast))))
+
+(defn false?*
+  [ast]
+  (and (boolean?* ast)
+       (= "false" (get-value ast))))
+
+(defn number?*
+  [ast]
+  (= :number (get-type ast)))
+
+(defn symbol?*
+  [ast]
+  (= :symbol (get-type ast)))
+
+(defn keyword?*
+  [ast]
+  (= :keyword (get-type ast)))
+
+(defn string?*
+  [ast]
+  (= :string (get-type ast)))
+
+(defn list?*
+  [ast]
+  (= :list (get-type ast)))
+
+(defn vector?*
+  [ast]
+  (= :vector (get-type ast)))
+
+(defn hash-map?*
+  [ast]
+  (= :hash-map (get-type ast)))
+
+(defn fn?*
+  [ast]
+  (= :function (get-type ast)))
+
+(defn macro?*
+  [ast]
+  (and (fn?* ast)
+       (get-is-macro ast)))
+
+(defn atom?*
+  [ast]
+  (= :atom (get-type ast)))
+
+(defn exception?*
+  [ast]
+  (= :exception (get-type ast)))
+
+(defn empty?*
+  [ast]
+  (empty? (get-value ast)))
+
+# XXX: likely this could be simpler
+(defn equals?*
+  [ast-1 ast-2]
+  (let [type-1 (get-type ast-1)
+        type-2 (get-type ast-2)]
+    (if (and (not= type-1 type-2)
+             # XXX: not elegant
+             (not (and (list?* ast-1) (vector?* ast-2)))
+             (not (and (list?* ast-2) (vector?* ast-1))))
+      false
+      (let [val-1 (get-value ast-1)
+            val-2 (get-value ast-2)]
+        # XXX: when not a collection...
+        (if (and (not (list?* ast-1))
+                 (not (vector?* ast-1))
+                 (not (hash-map?* ast-1)))
+          (= val-1 val-2)
+          (if (not= (length val-1) (length val-2))
+            false
+            (if (and (not (hash-map?* ast-1))
+                     (not (hash-map?* ast-2)))
+              (do
+                (var found-unequal false)
+                (each [v1 v2] (partition 2 (interleave val-1 val-2))
+                      (when (not (equals?* v1 v2))
+                        (set found-unequal true)
+                        (break)))
+                (not found-unequal))
+              (if (or (not (hash-map?* ast-1))
+                      (not (hash-map?* ast-2)))
+                false
+                (do
+                  (var found-unequal false)
+                  (each [k1 k2] (partition 2 (interleave (keys val-1)
+                                                         (keys val-2)))
+                        (when (not (equals?* k1 k2))
+                          (set found-unequal true)
+                          (break))
+                        (when (not (equals?* (val-1 k1) (val-2 k2)))
+                          (set found-unequal true)
+                          (break)))
+                  (not found-unequal))))))))))
+
+## highlander types
+
+(def mal-nil
+  (make-nil))
+
+(def mal-true
+  (make-boolean true))
+
+(def mal-false
+  (make-boolean false))

--- a/impls/janet/types.janet
+++ b/impls/janet/types.janet
@@ -29,31 +29,40 @@
    :content a-str})
 
 (defn make-hash-map
-  [items]
+  [items &opt meta]
+  (default meta (make-nil))
   (let [a-struct (if (dictionary? items)
                    items
                    (struct ;items))]
     {:tag :hash-map
-     :content a-struct}))
+     :content a-struct
+     :meta meta}))
 
 (defn make-list
-  [items]
+  [items &opt meta]
+  (default meta (make-nil))
   {:tag :list
-   :content items})
+   :content items
+   :meta meta})
 
 (defn make-vector
-  [items]
+  [items &opt meta]
+  (default meta (make-nil))
   {:tag :vector
-   :content items})
+   :content items
+   :meta meta})
 
 (defn make-function
-  [a-fn &opt ast params env]
-  @{:tag :function
-    :content a-fn
-    :ast ast
-    :params params
-    :env env
-    :is-macro false})
+  [a-fn &opt meta is-macro ast params env]
+  (default meta (make-nil))
+  (default is-macro false)
+  {:tag :function
+   :content a-fn
+   :meta meta
+   :is-macro is-macro
+   :ast ast
+   :params params
+   :env env})
 
 (defn make-atom
   [ast]

--- a/impls/janet/types.janet
+++ b/impls/janet/types.janet
@@ -14,9 +14,9 @@
    :content a-str})
 
 (defn make-number
-  [a-str]
+  [a-num]
   {:tag :number
-   :content a-str})
+   :content a-num})
 
 (defn make-string
   [a-str]

--- a/impls/janet/types.janet
+++ b/impls/janet/types.janet
@@ -1,0 +1,24 @@
+(defn make-number
+  [a-str]
+  {:tag :number
+   :content a-str})
+
+(defn make-symbol
+  [a-str]
+  {:tag :symbol
+   :content a-str})
+
+(defn make-hash-map
+  [items]
+  {:tag :hash-map
+   :content items})
+
+(defn make-list
+  [items]
+  {:tag :list
+   :content items})
+
+(defn make-vector
+  [items]
+  {:tag :vector
+   :content items})

--- a/impls/janet/types.janet
+++ b/impls/janet/types.janet
@@ -1,6 +1,21 @@
+(defn make-nil
+  []
+  {:tag :nil
+   :content "nil"})
+
+(defn make-boolean
+  [bool]
+  {:tag :boolean
+   :content (string bool)})
+
 (defn make-number
   [a-str]
   {:tag :number
+   :content a-str})
+
+(defn make-string
+  [a-str]
+  {:tag :string
    :content a-str})
 
 (defn make-symbol
@@ -22,3 +37,8 @@
   [items]
   {:tag :vector
    :content items})
+
+(defn make-function
+  [a-fn]
+  {:tag :function
+   :content a-fn})

--- a/impls/janet/types.janet
+++ b/impls/janet/types.janet
@@ -45,3 +45,8 @@
    :ast ast
    :params params
    :env env})
+
+(defn make-atom
+  [ast]
+  @{:tag :atom
+    :content ast})

--- a/impls/janet/types.janet
+++ b/impls/janet/types.janet
@@ -40,11 +40,12 @@
 
 (defn make-function
   [a-fn &opt ast params env]
-  {:tag :function
-   :content a-fn
-   :ast ast
-   :params params
-   :env env})
+  @{:tag :function
+    :content a-fn
+    :ast ast
+    :params params
+    :env env
+    :is-macro false})
 
 (defn make-atom
   [ast]

--- a/impls/janet/types.janet
+++ b/impls/janet/types.janet
@@ -39,6 +39,9 @@
    :content items})
 
 (defn make-function
-  [a-fn]
+  [a-fn &opt ast params env]
   {:tag :function
-   :content a-fn})
+   :content a-fn
+   :ast ast
+   :params params
+   :env env})

--- a/impls/janet/types.janet
+++ b/impls/janet/types.janet
@@ -8,6 +8,11 @@
   {:tag :boolean
    :content (string bool)})
 
+(defn make-keyword
+  [a-str]
+  {:tag :keyword
+   :content a-str})
+
 (defn make-number
   [a-str]
   {:tag :number
@@ -25,8 +30,11 @@
 
 (defn make-hash-map
   [items]
-  {:tag :hash-map
-   :content items})
+  (let [a-struct (if (dictionary? items)
+                   items
+                   (struct ;items))]
+    {:tag :hash-map
+     :content a-struct}))
 
 (defn make-list
   [items]
@@ -51,3 +59,8 @@
   [ast]
   @{:tag :atom
     :content ast})
+
+(defn make-exception
+  [ast]
+  {:tag :exception
+   :content ast})

--- a/impls/janet/utils.janet
+++ b/impls/janet/utils.janet
@@ -1,0 +1,3 @@
+(defn throw*
+  [ast]
+  (error ast))


### PR DESCRIPTION
This is an implementation of mal in [janet](https://janet-lang.org).

All tests pass in both direct and self-hosted modes:
```
make "test^janet"
make MAL_IMPL=janet "test^mal"
```

One notable feature is the use of peg parsing instead of regular expressions as Janet has built-in support for the former but not the latter.

Included in the PR is a Dockerfile I successfully tested in a VM.
