### PR TITLE
Add Fennel implementation

### DIFF
--- a/IMPLS.yml
+++ b/IMPLS.yml
@@ -26,6 +26,7 @@ IMPL:
   - {IMPL: es6}
   - {IMPL: factor}
   - {IMPL: fantom}
+  - {IMPL: fennel}
   - {IMPL: forth}
   - {IMPL: fsharp}
   - {IMPL: go}

--- a/Makefile.impls
+++ b/Makefile.impls
@@ -33,7 +33,7 @@ wasm_MODE = wasmtime
 #
 
 IMPLS = ada ada.2 awk bash basic bbc-basic c chuck clojure coffee common-lisp cpp crystal cs d dart \
-	elisp elixir elm erlang es6 factor fantom forth fsharp go groovy gnu-smalltalk \
+	elisp elixir elm erlang es6 factor fantom fennel forth fsharp go groovy gnu-smalltalk \
 	guile haskell haxe hy io janet java js jq julia kotlin livescript logo lua make mal \
 	matlab miniMAL nasm nim objc objpascal ocaml perl perl6 php picolisp pike plpgsql \
 	plsql powershell prolog ps python python.2 r racket rexx rpython ruby rust scala scheme skew \
@@ -123,6 +123,7 @@ erlang_STEP_TO_PROG =        impls/erlang/$($(1))
 es6_STEP_TO_PROG =           impls/es6/$($(1)).mjs
 factor_STEP_TO_PROG =        impls/factor/$($(1))/$($(1)).factor
 fantom_STEP_TO_PROG =        impls/fantom/lib/fan/$($(1)).pod
+fenne_STEP_TO_PROG =         impls/fennel/$($(1)).fnl
 forth_STEP_TO_PROG =         impls/forth/$($(1)).fs
 fsharp_STEP_TO_PROG =        impls/fsharp/$($(1)).exe
 go_STEP_TO_PROG =            impls/go/$($(1))

--- a/impls/fennel/Dockerfile
+++ b/impls/fennel/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:20.04
+MAINTAINER Joel Martin <github@martintribe.org>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+##########################################################
+# General requirements for testing or common across many
+# implementations
+##########################################################
+
+RUN apt-get -y update
+
+# Required for running tests
+RUN apt-get -y install make python
+
+# Some typical implementation and test requirements
+RUN apt-get -y install libreadline-dev libedit-dev
+
+RUN mkdir -p /mal
+WORKDIR /mal
+
+##########################################################
+# Specific implementation requirements
+##########################################################
+
+# fennel
+
+RUN apt-get -y install gcc wget unzip libpcre3-dev
+
+# lua
+RUN \
+wget http://www.lua.org/ftp/lua-5.4.1.tar.gz && \
+tar -zxf lua-5.4.1.tar.gz && \
+cd lua-5.4.1 && \
+make linux test && \
+make install
+
+# luarocks
+RUN \
+wget https://luarocks.org/releases/luarocks-3.3.1.tar.gz && \
+tar zxpf luarocks-3.3.1.tar.gz && \
+cd luarocks-3.3.1 && \
+./configure && \
+make && \
+make install
+
+# fennel, lpeg
+RUN luarocks install fennel
+RUN luarocks install lpeg
+
+# luarocks .cache directory is relative to HOME
+ENV HOME /mal

--- a/impls/fennel/Makefile
+++ b/impls/fennel/Makefile
@@ -1,0 +1,2 @@
+all:
+	true

--- a/impls/fennel/core.fnl
+++ b/impls/fennel/core.fnl
@@ -670,7 +670,7 @@
   (t.make-fn
     (fn [asts]
         (t.make-number
-         (math.floor (* 1000 (os.clock)))))))
+         (math.floor (* 1000000 (os.clock)))))))
 
 (fn fennel-eval*
   [fennel-val]

--- a/impls/fennel/core.fnl
+++ b/impls/fennel/core.fnl
@@ -195,6 +195,39 @@
             ;;
             (u.throw* (t.make-string "vec takes a vector, list, or nil")))))))
 
+(local mal-nth
+  (t.make-fn
+    (fn [asts]
+      (when (< (length asts) 2)
+        (u.throw* (t.make-string "nth takes 2 arguments")))
+      (let [elts (t.get-value (. asts 1))
+            i (t.get-value (. asts 2))]
+        (if (< i (length elts))
+            (. elts (+ i 1))
+            (u.throw* (t.make-string (.. "Index out of range: " i))))))))
+
+(local mal-first
+  (t.make-fn
+    (fn [asts]
+      (when (< (length asts) 1)
+        (u.throw* (t.make-string "first takes 1 argument")))
+      (let [coll-or-nil-ast (. asts 1)]
+        (if (or (t.nil?* coll-or-nil-ast)
+                (t.empty?* coll-or-nil-ast))
+            t.mal-nil
+            (. (t.get-value coll-or-nil-ast) 1))))))
+
+(local mal-rest
+  (t.make-fn
+    (fn [asts]
+      (when (< (length asts) 1)
+        (u.throw* (t.make-string "rest takes 1 argument")))
+      (let [coll-or-nil-ast (. asts 1)]
+        (if (or (t.nil?* coll-or-nil-ast)
+                (t.empty?* coll-or-nil-ast))
+            (t.make-list [])
+            (t.make-list (u.slice (t.get-value coll-or-nil-ast) 2 -1)))))))
+
 {"+" (t.make-fn (fn [asts]
                   (var total 0)
                   (each [i val (ipairs asts)]
@@ -270,4 +303,7 @@
  "cons" mal-cons
  "concat" mal-concat
  "vec" mal-vec
+ "nth" mal-nth
+ "first" mal-first
+ "rest" mal-rest
 }

--- a/impls/fennel/core.fnl
+++ b/impls/fennel/core.fnl
@@ -1,0 +1,160 @@
+(local t (require :types))
+(local u (require :utils))
+(local printer (require :printer))
+
+(local mal-list
+  (t.make-fn
+    (fn [asts]
+      (t.make-list asts))))
+
+(local mal-list?
+  (t.make-fn
+    (fn [asts]
+      (when (< (length asts) 1)
+        (u.throw* (t.make-string "list? takes 1 argument")))
+      (t.make-boolean (t.list?* (. asts 1))))))
+
+(local mal-empty?
+  (t.make-fn
+    (fn [asts]
+      (when (< (length asts) 1)
+        (u.throw* (t.make-string "empty? takes 1 argument")))
+      (let [arg-ast (. asts 1)]
+        (if (t.nil?* arg-ast)
+            t.mal-true
+            (t.make-boolean (t.empty?* arg-ast)))))))
+
+(local mal-count
+  (t.make-fn
+    (fn [asts]
+      (when (< (length asts) 1)
+        (u.throw* (t.make-string "count takes 1 argument")))
+      (let [arg-ast (. asts 1)]
+        (if (t.nil?* arg-ast)
+            (t.make-number 0)
+            (t.make-number (length (t.get-value arg-ast))))))))
+
+(local mal-=
+  (t.make-fn
+    (fn [asts]
+      (when (< (length asts) 2)
+        (u.throw* (t.make-string "= takes 2 arguments")))
+      (let [ast-1 (. asts 1)
+            ast-2 (. asts 2)]
+        (if (t.equals?* ast-1 ast-2)
+            t.mal-true
+            t.mal-false)))))
+
+(local mal-pr-str
+  (t.make-fn
+    (fn [asts]
+      (local buf [])
+      (when (> (length asts) 0)
+        (each [i ast (ipairs asts)]
+          (table.insert buf (printer.pr_str ast true))
+          (table.insert buf " "))
+        ;; remove extra space at end
+        (table.remove buf))
+      (t.make-string (table.concat buf)))))
+
+(local mal-str
+  (t.make-fn
+    (fn [asts]
+      (local buf [])
+      (when (> (length asts) 0)
+        (each [i ast (ipairs asts)]
+          (table.insert buf (printer.pr_str ast false))))
+      (t.make-string (table.concat buf)))))
+
+(local mal-prn
+  (t.make-fn
+    (fn [asts]
+      (local buf [])
+      (when (> (length asts) 0)
+        (each [i ast (ipairs asts)]
+          (table.insert buf (printer.pr_str ast true))
+          (table.insert buf " "))
+        ;; remove extra space at end
+        (table.remove buf))
+      (print (table.concat buf))
+      t.mal-nil)))
+
+(local mal-println
+  (t.make-fn
+    (fn [asts]
+      (local buf [])
+      (when (> (length asts) 0)
+        (each [i ast (ipairs asts)]
+          (table.insert buf (printer.pr_str ast false))
+          (table.insert buf " "))
+        ;; remove extra space at end
+        (table.remove buf))
+      (print (table.concat buf))
+      t.mal-nil)))
+
+{"+" (t.make-fn (fn [asts]
+                  (var total 0)
+                  (each [i val (ipairs asts)]
+                    (set total
+                         (+ total (t.get-value val))))
+                  (t.make-number total)))
+ "-" (t.make-fn (fn [asts]
+                  (var total 0)
+                  (let [n-args (length asts)]
+                    (if (= 0 n-args)
+                        (t.make-number 0)
+                        (= 1 n-args)
+                        (t.make-number (- 0 (t.get-value (. asts 1))))
+                        (do
+                         (set total (t.get-value (. asts 1)))
+                         (for [idx 2 n-args]
+                           (let [cur (t.get-value (. asts idx))]
+                             (set total
+                                  (- total cur))))
+                         (t.make-number total))))))
+ "*" (t.make-fn (fn [asts]
+                  (var total 1)
+                  (each [i val (ipairs asts)]
+                    (set total
+                         (* total (t.get-value val))))
+                  (t.make-number total)))
+ "/" (t.make-fn (fn [asts]
+                  (var total 1)
+                  (let [n-args (length asts)]
+                    (if (= 0 n-args)
+                        (t.make-number 1)
+                        (= 1 n-args)
+                        (t.make-number (/ 1 (t.get-value (. asts 1))))
+                        (do
+                         (set total (t.get-value (. asts 1)))
+                         (for [idx 2 n-args]
+                           (let [cur (t.get-value (. asts idx))]
+                             (set total
+                                  (/ total cur))))
+                          (t.make-number total))))))
+ "list" mal-list
+ "list?" mal-list?
+ "empty?" mal-empty?
+ "count" mal-count
+ "=" mal-=
+ "<" (t.make-fn (fn [asts]
+                  (let [val-1 (t.get-value (. asts 1))
+                        val-2 (t.get-value (. asts 2))]
+                    (t.make-boolean (< val-1 val-2)))))
+ "<=" (t.make-fn (fn [asts]
+                   (let [val-1 (t.get-value (. asts 1))
+                         val-2 (t.get-value (. asts 2))]
+                     (t.make-boolean (<= val-1 val-2)))))
+ ">" (t.make-fn (fn [asts]
+                  (let [val-1 (t.get-value (. asts 1))
+                        val-2 (t.get-value (. asts 2))]
+                    (t.make-boolean (> val-1 val-2)))))
+ ">=" (t.make-fn (fn [asts]
+                   (let [val-1 (t.get-value (. asts 1))
+                         val-2 (t.get-value (. asts 2))]
+                     (t.make-boolean (>= val-1 val-2)))))
+ "pr-str" mal-pr-str
+ "str" mal-str
+ "prn" mal-prn
+ "println" mal-println
+}

--- a/impls/fennel/core.fnl
+++ b/impls/fennel/core.fnl
@@ -159,6 +159,42 @@
         (t.reset!* atom-ast
                    ((t.get-value fn-ast) args-tbl))))))
 
+(local mal-cons
+  (t.make-fn
+    (fn [asts]
+      (when (< (length asts) 2)
+        (u.throw* (t.make-string "cons takes 2 arguments")))
+      (let [head-ast (. asts 1)
+            tail-ast (. asts 2)]
+        (t.make-list [head-ast
+                      (table.unpack (t.get-value tail-ast))])))))
+
+(local mal-concat
+  (t.make-fn
+    (fn [asts]
+      (local acc [])
+      (for [i 1 (length asts)]
+         (each [j elt (ipairs (t.get-value (. asts i)))]
+           (table.insert acc elt)))
+      (t.make-list acc))))
+
+(local mal-vec
+  (t.make-fn
+    (fn [asts]
+      (when (< (length asts) 1)
+        (u.throw* (t.make-string "vec takes 1 argument")))
+      (let [ast (. asts 1)]
+        (if (t.vector?* ast)
+            ast
+            ;;
+            (t.list?* ast)
+            (t.make-vector (t.get-value ast))
+            ;;
+            (t.nil?* ast)
+            (t.make-vector [])
+            ;;
+            (u.throw* (t.make-string "vec takes a vector, list, or nil")))))))
+
 {"+" (t.make-fn (fn [asts]
                   (var total 0)
                   (each [i val (ipairs asts)]
@@ -231,4 +267,7 @@
  "deref" mal-deref
  "reset!" mal-reset!
  "swap!" mal-swap!
+ "cons" mal-cons
+ "concat" mal-concat
+ "vec" mal-vec
 }

--- a/impls/fennel/core.fnl
+++ b/impls/fennel/core.fnl
@@ -669,7 +669,8 @@
 (local mal-time-ms
   (t.make-fn
     (fn [asts]
-      (t.make-number (os.clock)))))
+        (t.make-number
+         (math.floor (* 1000 (os.clock)))))))
 
 (fn fennel-eval*
   [fennel-val]

--- a/impls/fennel/env.fnl
+++ b/impls/fennel/env.fnl
@@ -1,0 +1,75 @@
+(local t (require :types))
+(local u (require :utils))
+
+(fn make-env
+  [outer]
+  {:outer outer
+   :data {}})
+
+(fn env-set
+  [env sym-ast val-ast]
+  (tset (. env :data)
+        (t.get-value sym-ast)
+        val-ast)
+  env)
+
+(fn env-find
+  [env sym-ast]
+  (let [inner-env (. env :data)
+        val-ast (. inner-env (t.get-value sym-ast))]
+    (if val-ast
+        env
+        (let [outer (. env :outer)]
+          (when outer
+            (env-find outer sym-ast))))))
+
+(fn env-get
+  [env sym-ast]
+  (let [target-env (env-find env sym-ast)]
+    (if target-env
+        (. (. target-env :data)
+           (t.get-value sym-ast))
+        (u.throw*
+         (t.make-string (.. "'" (t.get-value sym-ast) "'"
+                            " not found"))))))
+
+(comment
+
+ (local test-env (make-env {}))
+
+ (env-set test-env
+          (t.make-symbol "fun")
+          (t.make-number 1))
+
+ (env-find test-env (t.make-symbol "fun"))
+
+ (env-get test-env (t.make-symbol "fun"))
+
+ (local test-env-2 (make-env nil))
+
+ (env-set test-env-2
+          (t.make-symbol "smile")
+          (t.make-keyword ":yay"))
+
+ (env-find test-env-2 (t.make-symbol "smile"))
+
+ (env-get test-env-2 (t.make-symbol "smile"))
+
+ (local test-env-3 (make-env nil))
+
+ (env-set test-env-3
+          (t.make-symbol "+")
+          (fn [ast-1 ast-2]
+            (t.make-number (+ (t.get-value ast-1)
+                              (t.get-value ast-2)))))
+
+ (env-find test-env-3 (t.make-symbol "+"))
+
+ (env-get test-env-3 (t.make-symbol "+"))
+
+ )
+
+{:make-env make-env
+ :env-set env-set
+ :env-find env-find
+ :env-get env-get}

--- a/impls/fennel/printer.fnl
+++ b/impls/fennel/printer.fnl
@@ -1,0 +1,86 @@
+(local t (require :types))
+
+(fn escape
+  [a-str]
+  (pick-values 1
+               (-> a-str
+                   (string.gsub "\\" "\\\\")
+                   (string.gsub "\"" "\\\"")
+                   (string.gsub "\n" "\\n"))))
+
+(fn code*
+  [ast buf print_readably]
+  (let [value (t.get-value ast)]
+    (if (t.nil?* ast)
+        (table.insert buf value)
+        ;;
+        (t.boolean?* ast)
+        (table.insert buf (if value "true" "false"))
+        ;;
+        (t.number?* ast)
+        (table.insert buf (tostring value))
+        ;;
+        (t.keyword?* ast)
+        (table.insert buf value)
+        ;;
+        (t.symbol?* ast)
+        (table.insert buf value)
+        ;;
+        (t.string?* ast)
+        (if print_readably
+            (do
+             (table.insert buf "\"")
+             (table.insert buf (escape value))
+             (table.insert buf "\""))
+            (table.insert buf value))
+        ;;
+        (t.list?* ast)
+        (do
+         (table.insert buf "(")
+         (var remove false)
+         (each [idx elt (ipairs value)]
+               (code* elt buf print_readably)
+               (table.insert buf " ")
+               (set remove true))
+         (when remove
+           (table.remove buf))
+         (table.insert buf ")"))
+        ;;
+        (t.vector?* ast)
+        (do
+         (table.insert buf "[")
+         (var remove false)
+         (each [idx elt (ipairs value)]
+               (code* elt buf print_readably)
+               (table.insert buf " ")
+               (set remove true))
+         (when remove
+           (table.remove buf))
+         (table.insert buf "]"))
+        ;;
+        (t.hash-map?* ast)
+        (do
+         (table.insert buf "{")
+         (var remove false)
+         (each [idx elt (ipairs value)]
+               (code* elt buf print_readably)
+               (table.insert buf " ")
+               (set remove true))
+         (when remove
+           (table.remove buf))
+         (table.insert buf "}")))
+    buf))
+
+(fn pr_str
+  [ast print_readably]
+  (let [buf []]
+    (code* ast buf print_readably)
+    (table.concat buf)))
+
+(comment
+
+ (pr_str (t.make-number 1) false)
+
+ )
+
+{:pr_str pr_str}

--- a/impls/fennel/printer.fnl
+++ b/impls/fennel/printer.fnl
@@ -68,7 +68,13 @@
                (set remove true))
          (when remove
            (table.remove buf))
-         (table.insert buf "}")))
+         (table.insert buf "}"))
+        ;;
+        (t.atom?* ast)
+        (do
+         (table.insert buf "(atom ")
+         (code* (t.get-value ast) buf print_readably)
+         (table.insert buf ")")))
     buf))
 
 (fn pr_str

--- a/impls/fennel/reader.fnl
+++ b/impls/fennel/reader.fnl
@@ -1,0 +1,200 @@
+(local t (require :types))
+(local u (require :utils))
+
+(local lpeg (require :lpeg))
+
+(local P lpeg.P)
+
+(local S lpeg.S)
+
+(local C lpeg.C)
+
+(local V lpeg.V)
+
+(local Cmt lpeg.Cmt)
+
+(fn unescape
+  [a-str]
+  (pick-values 1
+               (-> a-str
+                   (string.gsub "\\\\" "\u{029e}") ;; temporarily hide
+                   (string.gsub "\\\"" "\"")
+                   (string.gsub "\\n" "\n")
+                   (string.gsub "\u{029e}" "\\")))) ;; now replace
+
+(local grammar
+  {1 "main"
+  "main" (^ (V "input") 1)
+  "input" (+ (V "gap") (V "form"))
+  "gap" (+ (V "ws") (V "comment"))
+  "ws" (^ (S " \f\n\r\t,") 1)
+  "comment" (* ";"
+               (^ (- (P 1) (S "\r\n"))
+                  0))
+  "form" (+ (V "boolean") (V "nil")
+            (V "number") (V "keyword") (V "symbol") (V "string")
+            (V "list") (V "vector") (V "hash-map")
+            (V "deref") (V "quasiquote") (V "quote")
+            (V "splice-unquote")
+            (V "unquote")
+            (V "with-meta"))
+  "name-char" (- (P 1)
+                 (S " \f\n\r\t,[]{}()'`~^@\";"))
+  "nil" (Cmt (C (* (P "nil")
+                   (- (V "name-char"))))
+             (fn [s i a]
+                 (values i t.mal-nil)))
+  "boolean" (Cmt (C (* (+ (P "false") (P "true"))
+                       (- (V "name-char"))))
+                 (fn [s i a]
+                     (values i (if (= a "true")
+                                   t.mal-true
+                                   t.mal-false))))
+  "number" (Cmt (C (^ (- (P 1)
+                         (S " \f\n\r\t,[]{}()'`~^@\";"))
+                      1))
+                (fn [s i a]
+                    (let [result (tonumber a)]
+                      (if result
+                          (values i (t.make-number result))
+                          nil))))
+  "keyword" (Cmt (C (* ":"
+                       (^ (V "name-char") 0)))
+                 (fn [s i a]
+                     (values i (t.make-keyword a))))
+  "symbol" (Cmt (^ (V "name-char") 1)
+                (fn [s i a]
+                    (values i (t.make-symbol a))))
+  "string" (* (P "\"")
+              (Cmt (C (* (^ (- (P 1)
+                               (S "\"\\"))
+                            0)
+                         (^ (* (P "\\")
+                               (P 1)
+                               (^ (- (P 1)
+                                     (S "\"\\"))
+                                  0))
+                            0)))
+                   (fn [s i a]
+                       (values i (t.make-string (unescape a)))))
+              (+ (P "\"")
+                 (P (fn [s i]
+                        (error "unbalanced \"")))))
+  "list" (* (P "(")
+            (Cmt (C (^ (V "input") 0))
+                 (fn [s i a ...]
+                     (values i (t.make-list [...]))))
+            (+ (P ")")
+               (P (fn [s i]
+                      (error "unbalanced )")))))
+  "vector" (* (P "[")
+              (Cmt (C (^ (V "input") 0))
+                   (fn [s i a ...]
+                       (values i (t.make-vector [...]))))
+              (+ (P "]")
+                 (P (fn [s i]
+                        (error "unbalanced ]")))))
+  "hash-map" (* (P "{")
+                (Cmt (C (^ (V "input") 0))
+                     (fn [s i a ...]
+                         (values i (t.make-hash-map [...]))))
+                (+ (P "}")
+                   (P (fn [s i]
+                          (error "unbalanced }")))))
+  "deref" (Cmt (C (* (P "@")
+                     (V "form")))
+               (fn [s i ...]
+                   (let [content [(t.make-symbol "deref")]]
+                     (table.insert content (. [...] 2))
+                     (values i (t.make-list content)))))
+  "quasiquote" (Cmt (C (* (P "`")
+                          (V "form")))
+                    (fn [s i ...]
+                        (let [content [(t.make-symbol "quasiquote")]]
+                          (table.insert content (. [...] 2))
+                          (values i (t.make-list content)))))
+  "quote" (Cmt (C (* (P "'")
+                     (V "form")))
+               (fn [s i ...]
+                   (let [content [(t.make-symbol "quote")]]
+                     (table.insert content (. [...] 2))
+                     (values i (t.make-list content)))))
+  "splice-unquote" (Cmt (C (* (P "~@")
+                              (V "form")))
+                        (fn [s i ...]
+                            (let [content [(t.make-symbol "splice-unquote")]]
+                              (table.insert content (. [...] 2))
+                              (values i (t.make-list content)))))
+  "unquote" (Cmt (C (* (P "~")
+                       (V "form")))
+                 (fn [s i ...]
+                     (let [content [(t.make-symbol "unquote")]]
+                       (table.insert content (. [...] 2))
+                       (values i (t.make-list content)))))
+  "with-meta" (Cmt (C (* (P "^")
+                         (V "form")
+                         (^ (V "gap") 1)
+                         (V "form")))
+                   (fn [s i ...]
+                       (let [content [(t.make-symbol "with-meta")]]
+                         (table.insert content (. [...] 3))
+                         (table.insert content (. [...] 2))
+                         (values i (t.make-list content)))))
+  })
+
+(comment
+
+ (lpeg.match grammar "; hello")
+
+ (lpeg.match grammar "nil")
+
+ (lpeg.match grammar "true")
+
+ (lpeg.match grammar "false")
+
+ (lpeg.match grammar "1.2")
+
+ (lpeg.match grammar "(+ 1 1)")
+
+ (lpeg.match grammar "[:a :b :c]")
+
+ (lpeg.match grammar "\"hello there\"")
+
+ (lpeg.match grammar "\"hello\" there\"")
+
+)
+
+(fn read_str
+  [a-str]
+  (let [(ok? result) (pcall lpeg.match grammar a-str)]
+    (if ok?
+        (let [res-type (type result)]
+          (if (= res-type "table")
+              result
+              (u.throw* t.mal-nil)))
+        (u.throw*
+         (t.make-string result)))))
+
+(comment
+
+ (read_str "; hello")
+
+ (read_str "nil")
+
+ (read_str "true")
+
+ (read_str "false")
+
+ (read_str "1.2")
+
+ (read_str "(+ 1 1)")
+
+ (read_str "[:a :b :c]")
+
+ (read_str "\"hello there\"")
+
+ (read_str "\"hello\" there\"")
+
+ )
+
+{:read_str read_str}

--- a/impls/fennel/run
+++ b/impls/fennel/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec fennel $(dirname $0)/${STEP:-stepA_mal}.fnl "${@}"

--- a/impls/fennel/step0_repl.fnl
+++ b/impls/fennel/step0_repl.fnl
@@ -1,0 +1,21 @@
+(fn READ [code-str]
+    code-str)
+
+(fn EVAL [ast]
+    ast)
+
+(fn PRINT [ast]
+    ast)
+
+(fn rep [code-str]
+    (PRINT (EVAL (READ code-str))))
+
+(var done false)
+
+(while (not done)
+  (io.write "user> ")
+  (io.flush)
+  (let [input (io.read)]
+    (if (not input)
+        (set done true)
+        (print (rep input)))))

--- a/impls/fennel/step1_read_print.fnl
+++ b/impls/fennel/step1_read_print.fnl
@@ -1,0 +1,39 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+
+(fn READ
+  [code-str]
+  (reader.read_str code-str))
+
+(fn EVAL
+  [ast]
+  ast)
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str))))
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(var done false)
+
+(while (not done)
+  (io.write "user> ")
+  (io.flush)
+  (let [input (io.read)]
+    (if (not input)
+        (set done true)
+        (xpcall (fn []
+                  (print (rep input)))
+                handle-error))))

--- a/impls/fennel/step2_eval.fnl
+++ b/impls/fennel/step2_eval.fnl
@@ -1,0 +1,89 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+(local u (require :utils))
+
+(local repl_env
+  {"+" (fn [ast-1 ast-2]
+         (t.make-number (+ (t.get-value ast-1)
+                           (t.get-value ast-2))))
+   "-" (fn [ast-1 ast-2]
+         (t.make-number (- (t.get-value ast-1)
+                          (t.get-value ast-2))))
+   "*" (fn [ast-1 ast-2]
+         (t.make-number (* (t.get-value ast-1)
+                           (t.get-value ast-2))))
+   "/" (fn [ast-1 ast-2]
+         (t.make-number (/ (t.get-value ast-1)
+                           (t.get-value ast-2))))})
+
+(fn READ
+  [code-str]
+  (reader.read_str code-str))
+
+;; forward declaration
+(var EVAL 1)
+
+(fn eval_ast
+  [ast env]
+  (if (t.symbol?* ast)
+      (. env (t.get-value ast))
+      ;;
+      (t.list?* ast)
+      (t.make-list (u.map (fn [elt-ast]
+                            (EVAL elt-ast env))
+                          (t.get-value ast)))
+      ;;
+      (t.vector?* ast)
+      (t.make-vector (u.map (fn [elt-ast]
+                              (EVAL elt-ast env))
+                            (t.get-value ast)))
+      ;;
+      (t.hash-map?* ast)
+      (t.make-hash-map (u.map (fn [elt-ast]
+                                (EVAL elt-ast env))
+                              (t.get-value ast)))
+      ;;
+      ast))
+
+(set EVAL
+  (fn [ast env]
+      (if (not (t.list?* ast))
+          (eval_ast ast env)
+          ;;
+          (t.empty?* ast)
+          ast
+          ;;
+          (let [eval-list (eval_ast ast env)
+                f (u.first (t.get-value eval-list))
+                args (u.slice (t.get-value eval-list) 2 -1)]
+            (f (table.unpack args))))))
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str) repl_env)))
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(var done false)
+
+(while (not done)
+  (io.write "user> ")
+  (io.flush)
+  (let [input (io.read)]
+    (if (not input)
+        (set done true)
+        (xpcall (fn []
+                  (print (rep input)))
+                handle-error))))
+

--- a/impls/fennel/step3_env.fnl
+++ b/impls/fennel/step3_env.fnl
@@ -1,0 +1,115 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+(local e (require :env))
+(local u (require :utils))
+
+(local repl_env
+  (-> (e.make-env nil)
+      (e.env-set (t.make-symbol "+")
+                 (fn [ast-1 ast-2]
+                   (t.make-number (+ (t.get-value ast-1)
+                                     (t.get-value ast-2)))))
+      (e.env-set (t.make-symbol "-")
+                 (fn [ast-1 ast-2]
+                   (t.make-number (- (t.get-value ast-1)
+                                     (t.get-value ast-2)))))
+      (e.env-set (t.make-symbol "*")
+                 (fn [ast-1 ast-2]
+                   (t.make-number (* (t.get-value ast-1)
+                                     (t.get-value ast-2)))))
+      (e.env-set (t.make-symbol "/")
+                 (fn [ast-1 ast-2]
+                   (t.make-number (/ (t.get-value ast-1)
+                                     (t.get-value ast-2)))))))
+
+(fn READ
+  [arg]
+  (reader.read_str arg))
+
+;; forward declaration
+(var EVAL 1)
+
+(fn eval_ast
+  [ast env]
+  (if (t.symbol?* ast)
+      (e.env-get env ast)
+      ;;
+      (t.list?* ast)
+      (t.make-list (u.map (fn [elt-ast]
+                            (EVAL elt-ast env))
+                          (t.get-value ast)))
+      ;;
+      (t.vector?* ast)
+      (t.make-vector (u.map (fn [elt-ast]
+                              (EVAL elt-ast env))
+                            (t.get-value ast)))
+      ;;
+      (t.hash-map?* ast)
+      (t.make-hash-map (u.map (fn [elt-ast]
+                                (EVAL elt-ast env))
+                              (t.get-value ast)))
+      ;;
+      ast))
+
+(set EVAL
+  (fn [ast env]
+      (if (not (t.list?* ast))
+          (eval_ast ast env)
+          ;;
+          (t.empty?* ast)
+          ast
+          ;;
+          (let [ast-elts (t.get-value ast)
+                head-name (t.get-value (. ast-elts 1))]
+            ;; XXX: want to check for symbol, but that screws up logic below
+            (if (= "def!" head-name)
+                (let [def-name (. ast-elts 2)
+                      def-val (EVAL (. ast-elts 3) env)]
+                  (e.env-set env
+                             def-name def-val)
+                  def-val)
+                ;;
+                (= "let*" head-name)
+                (let [new-env (e.make-env env)
+                      bindings (t.get-value (. ast-elts 2))
+                      stop (/ (length bindings) 2)]
+                  (for [idx 1 stop]
+                       (let [b-name (. bindings (- (* 2 idx) 1))
+                             b-val (EVAL (. bindings (* 2 idx)) new-env)]
+                         (e.env-set new-env
+                                    b-name b-val)))
+                  (EVAL (. ast-elts 3) new-env))
+                ;;
+                (let [eval-list (t.get-value (eval_ast ast env))
+                      f (. eval-list 1)
+                      args (u.slice eval-list 2 -1)]
+                  (f (table.unpack args))))))))
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str) repl_env)))
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(var done false)
+
+(while (not done)
+  (io.write "user> ")
+  (io.flush)
+  (let [input (io.read)]
+    (if (not input)
+        (set done true)
+        (xpcall (fn []
+                  (print (rep input)))
+                handle-error))))

--- a/impls/fennel/step4_if_fn_do.fnl
+++ b/impls/fennel/step4_if_fn_do.fnl
@@ -1,0 +1,136 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+(local e (require :env))
+(local core (require :core))
+(local u (require :utils))
+
+(local repl_env
+  (let [env (e.make-env)]
+    (each [name func (pairs core)]
+      (e.env-set env
+                 (t.make-symbol name)
+                 func))
+    env))
+
+(fn READ
+  [code-str]
+  (reader.read_str code-str))
+
+;; forward declaration
+(var EVAL 1)
+
+(fn eval_ast
+  [ast env]
+  (if (t.symbol?* ast)
+      (e.env-get env ast)
+      ;;
+      (t.list?* ast)
+      (t.make-list (u.map (fn [elt-ast]
+                            (EVAL elt-ast env))
+                          (t.get-value ast)))
+      ;;
+      (t.vector?* ast)
+      (t.make-vector (u.map (fn [elt-ast]
+                              (EVAL elt-ast env))
+                            (t.get-value ast)))
+      ;;
+      (t.hash-map?* ast)
+      (t.make-hash-map (u.map (fn [elt-ast]
+                                (EVAL elt-ast env))
+                              (t.get-value ast)))
+      ;;
+      ast))
+
+(set EVAL
+  (fn [ast env]
+      (if (not (t.list?* ast))
+          (eval_ast ast env)
+          ;;
+          (t.empty?* ast)
+          ast
+          ;;
+          (let [ast-elts (t.get-value ast)
+                head-name (t.get-value (. ast-elts 1))]
+            ;; XXX: want to check for symbol, but that screws up logic below
+            (if (= "def!" head-name)
+                (let [def-name (. ast-elts 2)
+                      def-val (EVAL (. ast-elts 3) env)]
+                  (e.env-set env
+                             def-name def-val)
+                  def-val)
+                ;;
+                (= "let*" head-name)
+                (let [new-env (e.make-env env)
+                      bindings (t.get-value (. ast-elts 2))
+                      stop (/ (length bindings) 2)]
+                  (for [idx 1 stop]
+                       (let [b-name (. bindings (- (* 2 idx) 1))
+                             b-val (EVAL (. bindings (* 2 idx)) new-env)]
+                         (e.env-set new-env
+                                    b-name b-val)))
+                  (EVAL (. ast-elts 3) new-env))
+                ;;
+                (= "do" head-name)
+                (let [do-body-evaled (eval_ast (t.make-list
+                                                (u.slice ast-elts 2 -1))
+                                               env)]
+                  (u.last (t.get-value do-body-evaled)))
+                ;;
+                (= "if" head-name)
+                (let [cond-res (EVAL (. ast-elts 2) env)]
+                  (if (or (t.nil?* cond-res)
+                          (t.false?* cond-res))
+                      (let [else-ast (. ast-elts 4)]
+                        (if (not else-ast)
+                            t.mal-nil
+                            (EVAL else-ast env)))
+                      (EVAL (. ast-elts 3) env)))
+                ;;
+                (= "fn*" head-name)
+                (let [args (t.get-value (. ast-elts 2))
+                      body (. ast-elts 3)]
+                  (t.make-fn (fn [params]
+                               (EVAL body
+                                     (e.make-env env args params)))))
+                ;;
+                (let [eval-list (t.get-value (eval_ast ast env))
+                      f (. eval-list 1)
+                      args (u.slice eval-list 2 -1)]
+                  ((t.get-value f) args)))))))
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str) repl_env)))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(var done false)
+
+(while (not done)
+  (io.write "user> ")
+  (io.flush)
+  (let [input (io.read)]
+    (if (not input)
+        (set done true)
+        (xpcall (fn []
+                  (print (rep input)))
+                handle-error))))
+                ;; (fn [exc]
+                ;;   (if (t.nil?* exc)
+                ;;       (print)
+                ;;       (= "string" (type exc))
+                ;;       (print exc)
+                ;;       (print (PRINT exc))))))))

--- a/impls/fennel/step5_tco.fnl
+++ b/impls/fennel/step5_tco.fnl
@@ -1,0 +1,150 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+(local e (require :env))
+(local core (require :core))
+(local u (require :utils))
+
+(local repl_env
+  (let [env (e.make-env)]
+    (each [name func (pairs core)]
+      (e.env-set env
+                 (t.make-symbol name)
+                 func))
+    env))
+
+(fn READ
+  [code-str]
+  (reader.read_str code-str))
+
+;; forward declaration
+(var EVAL 1)
+
+(fn eval_ast
+  [ast env]
+  (if (t.symbol?* ast)
+      (e.env-get env ast)
+      ;;
+      (t.list?* ast)
+      (t.make-list (u.map (fn [elt-ast]
+                            (EVAL elt-ast env))
+                          (t.get-value ast)))
+      ;;
+      (t.vector?* ast)
+      (t.make-vector (u.map (fn [elt-ast]
+                              (EVAL elt-ast env))
+                            (t.get-value ast)))
+      ;;
+      (t.hash-map?* ast)
+      (t.make-hash-map (u.map (fn [elt-ast]
+                                (EVAL elt-ast env))
+                              (t.get-value ast)))
+      ;;
+      ast))
+
+(set EVAL
+  (fn [ast-param env-param]
+    (var ast ast-param)
+    (var env env-param)
+    (var result nil)
+    (while (not result)
+      (if (not (t.list?* ast))
+          (set result (eval_ast ast env))
+          ;;
+          (t.empty?* ast)
+          (set result ast)
+          ;;
+          (let [ast-elts (t.get-value ast)
+                head-name (t.get-value (. ast-elts 1))]
+            ;; XXX: want to check for symbol, but that screws up logic below
+            (if (= "def!" head-name)
+                (let [def-name (. ast-elts 2)
+                      def-val (EVAL (. ast-elts 3) env)]
+                  (e.env-set env
+                             def-name def-val)
+                  (set result def-val))
+                ;;
+                (= "let*" head-name)
+                (let [new-env (e.make-env env)
+                      bindings (t.get-value (. ast-elts 2))
+                      stop (/ (length bindings) 2)]
+                  (for [idx 1 stop]
+                       (let [b-name (. bindings (- (* 2 idx) 1))
+                             b-val (EVAL (. bindings (* 2 idx)) new-env)]
+                         (e.env-set new-env
+                                    b-name b-val)))
+                  ;; tco
+                  (set ast (. ast-elts 3))
+                  (set env new-env))
+                ;;
+                (= "do" head-name)
+                (let [most-forms (u.slice ast-elts 2 -2) ;; XXX
+                      last-body-form (u.last ast-elts)
+                      res-ast (eval_ast (t.make-list most-forms) env)]
+                  ;; tco
+                  (set ast last-body-form))
+                ;;
+                (= "if" head-name)
+                (let [cond-res (EVAL (. ast-elts 2) env)]
+                  (if (or (t.nil?* cond-res)
+                          (t.false?* cond-res))
+                      (let [else-ast (. ast-elts 4)]
+                        (if (not else-ast)
+                            ;; tco
+                            (set result t.mal-nil)
+                            (set ast else-ast)))
+                      ;; tco
+                      (set ast (. ast-elts 3))))
+                ;;
+                (= "fn*" head-name)
+                (let [params (t.get-value (. ast-elts 2))
+                      body (. ast-elts 3)]
+                  ;; tco
+                  (set result
+                       (t.make-fn (fn [args]
+                                    (EVAL body
+                                          (e.make-env env params args)))
+                                  body params env)))
+                ;;
+                (let [eval-list (t.get-value (eval_ast ast env))
+                      f (. eval-list 1)
+                      args (u.slice eval-list 2 -1)]
+                  (let [body (t.get-ast f)] ;; tco
+                    (if body
+                        (do
+                          (set ast body)
+                          (set env (e.make-env (t.get-env f)
+                                               (t.get-params f) args)))
+                        (set result
+                             ((t.get-value f) args)))))))))
+    result))
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str) repl_env)))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(var done false)
+
+(while (not done)
+  (io.write "user> ")
+  (io.flush)
+  (let [input (io.read)]
+    (if (not input)
+        (set done true)
+        (xpcall (fn []
+                  (print (rep input)))
+                handle-error))))

--- a/impls/fennel/step6_file.fnl
+++ b/impls/fennel/step6_file.fnl
@@ -1,0 +1,175 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+(local e (require :env))
+(local core (require :core))
+(local u (require :utils))
+
+(local repl_env
+  (let [env (e.make-env)]
+    (each [name func (pairs core)]
+      (e.env-set env
+                 (t.make-symbol name)
+                 func))
+    env))
+
+(fn READ
+  [code-str]
+  (reader.read_str code-str))
+
+;; forward declaration
+(var EVAL 1)
+
+(fn eval_ast
+  [ast env]
+  (if (t.symbol?* ast)
+      (e.env-get env ast)
+      ;;
+      (t.list?* ast)
+      (t.make-list (u.map (fn [elt-ast]
+                            (EVAL elt-ast env))
+                          (t.get-value ast)))
+      ;;
+      (t.vector?* ast)
+      (t.make-vector (u.map (fn [elt-ast]
+                              (EVAL elt-ast env))
+                            (t.get-value ast)))
+      ;;
+      (t.hash-map?* ast)
+      (t.make-hash-map (u.map (fn [elt-ast]
+                                (EVAL elt-ast env))
+                              (t.get-value ast)))
+      ;;
+      ast))
+
+(set EVAL
+  (fn [ast-param env-param]
+    (var ast ast-param)
+    (var env env-param)
+    (var result nil)
+    (while (not result)
+      (if (not (t.list?* ast))
+          (set result (eval_ast ast env))
+          ;;
+          (t.empty?* ast)
+          (set result ast)
+          ;;
+          (let [ast-elts (t.get-value ast)
+                head-name (t.get-value (. ast-elts 1))]
+            ;; XXX: want to check for symbol, but that screws up logic below
+            (if (= "def!" head-name)
+                (let [def-name (. ast-elts 2)
+                      def-val (EVAL (. ast-elts 3) env)]
+                  (e.env-set env
+                             def-name def-val)
+                  (set result def-val))
+                ;;
+                (= "let*" head-name)
+                (let [new-env (e.make-env env)
+                      bindings (t.get-value (. ast-elts 2))
+                      stop (/ (length bindings) 2)]
+                  (for [idx 1 stop]
+                       (let [b-name (. bindings (- (* 2 idx) 1))
+                             b-val (EVAL (. bindings (* 2 idx)) new-env)]
+                         (e.env-set new-env
+                                    b-name b-val)))
+                  ;; tco
+                  (set ast (. ast-elts 3))
+                  (set env new-env))
+                ;;
+                (= "do" head-name)
+                (let [most-forms (u.slice ast-elts 2 -2) ;; XXX
+                      last-body-form (u.last ast-elts)
+                      res-ast (eval_ast (t.make-list most-forms) env)]
+                  ;; tco
+                  (set ast last-body-form))
+                ;;
+                (= "if" head-name)
+                (let [cond-res (EVAL (. ast-elts 2) env)]
+                  (if (or (t.nil?* cond-res)
+                          (t.false?* cond-res))
+                      (let [else-ast (. ast-elts 4)]
+                        (if (not else-ast)
+                            ;; tco
+                            (set result t.mal-nil)
+                            (set ast else-ast)))
+                      ;; tco
+                      (set ast (. ast-elts 3))))
+                ;;
+                (= "fn*" head-name)
+                (let [params (t.get-value (. ast-elts 2))
+                      body (. ast-elts 3)]
+                  ;; tco
+                  (set result
+                       (t.make-fn (fn [args]
+                                    (EVAL body
+                                          (e.make-env env params args)))
+                                  body params env)))
+                ;;
+                (let [eval-list (t.get-value (eval_ast ast env))
+                      f (. eval-list 1)
+                      args (u.slice eval-list 2 -1)]
+                  (let [body (t.get-ast f)] ;; tco
+                    (if body
+                        (do
+                          (set ast body)
+                          (set env (e.make-env (t.get-env f)
+                                               (t.get-params f) args)))
+                        (set result
+                             ((t.get-value f) args)))))))))
+    result))
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str) repl_env)))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(e.env-set repl_env
+           (t.make-symbol "eval")
+           (t.make-fn
+             (fn [asts]
+               (when (< (length asts) 1)
+                 ;; XXX
+                 (error "eval takes 1 arguments"))
+               (EVAL (u.first asts) repl_env))))
+
+(rep "(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))")
+
+(e.env-set repl_env
+           (t.make-symbol "*ARGV*")
+           (t.make-list (u.map t.make-string (u.slice arg 2))))
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(if (<= 1 (length arg))
+    (xpcall (fn []
+              (rep (.. "(load-file \"" (. arg 1) "\")"))) ;; XXX: escaping?
+            handle-error)
+    (do
+     (var done false)
+     (while (not done)
+       (io.write "user> ")
+       (io.flush)
+       (let [input (io.read)]
+         (if (not input)
+             (set done true)
+        (xpcall (fn []
+                  (print (rep input)))
+                handle-error))))))
+;                (fn [exc]
+                  ;; (if (t.nil?* exc)
+                  ;;     (print)
+                  ;;     (= "string" (type exc))
+                  ;;     (print exc)
+                  ;;     (print (PRINT exc))))))))))

--- a/impls/fennel/step7_quote.fnl
+++ b/impls/fennel/step7_quote.fnl
@@ -1,0 +1,223 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+(local e (require :env))
+(local core (require :core))
+(local u (require :utils))
+
+(local repl_env
+  (let [env (e.make-env)]
+    (each [name func (pairs core)]
+      (e.env-set env
+                 (t.make-symbol name)
+                 func))
+    env))
+
+(fn READ
+  [code-str]
+  (reader.read_str code-str))
+
+;; forward declaration
+(var EVAL 1)
+
+(fn eval_ast
+  [ast env]
+  (if (t.symbol?* ast)
+      (e.env-get env ast)
+      ;;
+      (t.list?* ast)
+      (t.make-list (u.map (fn [elt-ast]
+                            (EVAL elt-ast env))
+                          (t.get-value ast)))
+      ;;
+      (t.vector?* ast)
+      (t.make-vector (u.map (fn [elt-ast]
+                              (EVAL elt-ast env))
+                            (t.get-value ast)))
+      ;;
+      (t.hash-map?* ast)
+      (t.make-hash-map (u.map (fn [elt-ast]
+                                (EVAL elt-ast env))
+                              (t.get-value ast)))
+      ;;
+      ast))
+
+(fn starts-with
+  [ast name]
+  (when (and (t.list?* ast)
+             (not (t.empty?* ast)))
+    (let [head-ast (. (t.get-value ast) 1)]
+      (and (t.symbol?* head-ast)
+           (= name (t.get-value head-ast))))))
+
+(var quasiquote* nil)
+
+(fn qq-iter
+  [ast]
+  (if (t.empty?* ast)
+      (t.make-list [])
+      (let [ast-value (t.get-value ast)
+            elt (. ast-value 1)
+            acc (qq-iter (t.make-list (u.slice ast-value 2 -1)))]
+        (if (starts-with elt "splice-unquote")
+            (t.make-list [(t.make-symbol "concat")
+                          (. (t.get-value elt) 2)
+                          acc])
+            (t.make-list [(t.make-symbol "cons")
+                          (quasiquote* elt)
+                          acc])))))
+
+(set quasiquote*
+  (fn [ast]
+    (if (starts-with ast "unquote")
+        (. (t.get-value ast) 2)
+        ;;
+        (t.list?* ast)
+        (qq-iter ast)
+        ;;
+        (t.vector?* ast)
+        (t.make-list [(t.make-symbol "vec") (qq-iter ast)])
+        ;;
+        (or (t.symbol?* ast)
+            (t.hash-map?* ast))
+        (t.make-list [(t.make-symbol "quote") ast])
+        ;;
+        ast)))
+
+(set EVAL
+  (fn [ast-param env-param]
+    (var ast ast-param)
+    (var env env-param)
+    (var result nil)
+    (while (not result)
+      (if (not (t.list?* ast))
+          (set result (eval_ast ast env))
+          ;;
+          (t.empty?* ast)
+          (set result ast)
+          ;;
+          (let [ast-elts (t.get-value ast)
+                head-name (t.get-value (. ast-elts 1))]
+            ;; XXX: want to check for symbol, but that screws up logic below
+            (if (= "def!" head-name)
+                (let [def-name (. ast-elts 2)
+                      def-val (EVAL (. ast-elts 3) env)]
+                  (e.env-set env
+                             def-name def-val)
+                  (set result def-val))
+                ;;
+                (= "let*" head-name)
+                (let [new-env (e.make-env env)
+                      bindings (t.get-value (. ast-elts 2))
+                      stop (/ (length bindings) 2)]
+                  (for [idx 1 stop]
+                       (let [b-name (. bindings (- (* 2 idx) 1))
+                             b-val (EVAL (. bindings (* 2 idx)) new-env)]
+                         (e.env-set new-env
+                                    b-name b-val)))
+                  ;; tco
+                  (set ast (. ast-elts 3))
+                  (set env new-env))
+                ;;
+                (= "quote" head-name)
+                ;; tco
+                (set result (. ast-elts 2))
+                ;;
+                (= "quasiquoteexpand" head-name)
+                ;; tco
+                (set result (quasiquote* (. ast-elts 2)))
+                ;;
+                (= "quasiquote" head-name)
+                ;; tco
+                (set ast (quasiquote* (. ast-elts 2)))
+                ;;
+                (= "do" head-name)
+                (let [most-forms (u.slice ast-elts 2 -2) ;; XXX
+                      last-body-form (u.last ast-elts)
+                      res-ast (eval_ast (t.make-list most-forms) env)]
+                  ;; tco
+                  (set ast last-body-form))
+                ;;
+                (= "if" head-name)
+                (let [cond-res (EVAL (. ast-elts 2) env)]
+                  (if (or (t.nil?* cond-res)
+                          (t.false?* cond-res))
+                      (let [else-ast (. ast-elts 4)]
+                        (if (not else-ast)
+                            ;; tco
+                            (set result t.mal-nil)
+                            (set ast else-ast)))
+                      ;; tco
+                      (set ast (. ast-elts 3))))
+                ;;
+                (= "fn*" head-name)
+                (let [params (t.get-value (. ast-elts 2))
+                      body (. ast-elts 3)]
+                  ;; tco
+                  (set result
+                       (t.make-fn (fn [args]
+                                    (EVAL body
+                                          (e.make-env env params args)))
+                                  body params env)))
+                ;;
+                (let [eval-list (t.get-value (eval_ast ast env))
+                      f (. eval-list 1)
+                      args (u.slice eval-list 2 -1)]
+                  (let [body (t.get-ast f)] ;; tco
+                    (if body
+                        (do
+                          (set ast body)
+                          (set env (e.make-env (t.get-env f)
+                                               (t.get-params f) args)))
+                        (set result
+                             ((t.get-value f) args)))))))))
+    result))
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str) repl_env)))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(e.env-set repl_env
+           (t.make-symbol "eval")
+           (t.make-fn
+             (fn [asts]
+               (when (< (length asts) 1)
+                 ;; XXX
+                 (error "eval takes 1 arguments"))
+               (EVAL (u.first asts) repl_env))))
+
+(rep "(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))")
+
+(e.env-set repl_env
+           (t.make-symbol "*ARGV*")
+           (t.make-list (u.map t.make-string (u.slice arg 2 -1))))
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(if (<= 1 (length arg))
+    (xpcall (fn []
+              (rep (.. "(load-file \"" (. arg 1) "\")"))) ;; XXX: escaping?
+            handle-error)
+    (do
+     (var done false)
+     (while (not done)
+       (io.write "user> ")
+       (io.flush)
+       (let [input (io.read)]
+         (if (not input)
+             (set done true)
+        (xpcall (fn []
+                  (print (rep input)))
+                handle-error))))))

--- a/impls/fennel/step8_macros.fnl
+++ b/impls/fennel/step8_macros.fnl
@@ -1,0 +1,278 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+(local e (require :env))
+(local core (require :core))
+(local u (require :utils))
+
+(local repl_env
+  (let [env (e.make-env)]
+    (each [name func (pairs core)]
+      (e.env-set env
+                 (t.make-symbol name)
+                 func))
+    env))
+
+(fn READ
+  [code-str]
+  (reader.read_str code-str))
+
+(fn is_macro_call
+  [ast env]
+  (when (and (t.list?* ast)
+             (not (t.empty?* ast)))
+    (let [head-ast (. (t.get-value ast) 1)]
+      (when (and (t.symbol?* head-ast)
+                 (e.env-find env head-ast))
+        (let [target-ast (e.env-get env head-ast)]
+          (t.macro?* target-ast))))))
+
+(fn macroexpand
+  [ast env]
+  (var ast-var ast)
+  (while (is_macro_call ast-var env)
+    (let [inner-asts (t.get-value ast-var)
+          head-ast (. inner-asts 1)
+          macro-fn (t.get-value (e.env-get env head-ast))
+          args (u.slice inner-asts 2 -1)]
+      (set ast-var (macro-fn args))))
+  ast-var)
+
+;; forward declaration
+(var EVAL 1)
+
+(fn eval_ast
+  [ast env]
+  (if (t.symbol?* ast)
+      (e.env-get env ast)
+      ;;
+      (t.list?* ast)
+      (t.make-list (u.map (fn [elt-ast]
+                            (EVAL elt-ast env))
+                          (t.get-value ast)))
+      ;;
+      (t.vector?* ast)
+      (t.make-vector (u.map (fn [elt-ast]
+                              (EVAL elt-ast env))
+                            (t.get-value ast)))
+      ;;
+      (t.hash-map?* ast)
+      (t.make-hash-map (u.map (fn [elt-ast]
+                                (EVAL elt-ast env))
+                              (t.get-value ast)))
+      ;;
+      ast))
+
+(fn starts-with
+  [ast name]
+  (when (and (t.list?* ast)
+             (not (t.empty?* ast)))
+    (let [head-ast (. (t.get-value ast) 1)]
+      (and (t.symbol?* head-ast)
+           (= name (t.get-value head-ast))))))
+
+(var quasiquote* nil)
+
+(fn qq-iter
+  [ast]
+  (if (t.empty?* ast)
+      (t.make-list [])
+      (let [ast-value (t.get-value ast)
+            elt (. ast-value 1)
+            acc (qq-iter (t.make-list (u.slice ast-value 2 -1)))]
+        (if (starts-with elt "splice-unquote")
+            (t.make-list [(t.make-symbol "concat")
+                          (. (t.get-value elt) 2)
+                          acc])
+            (t.make-list [(t.make-symbol "cons")
+                          (quasiquote* elt)
+                          acc])))))
+
+(set quasiquote*
+  (fn [ast]
+    (if (starts-with ast "unquote")
+        (. (t.get-value ast) 2)
+        ;;
+        (t.list?* ast)
+        (qq-iter ast)
+        ;;
+        (t.vector?* ast)
+        (t.make-list [(t.make-symbol "vec") (qq-iter ast)])
+        ;;
+        (or (t.symbol?* ast)
+            (t.hash-map?* ast))
+        (t.make-list [(t.make-symbol "quote") ast])
+        ;;
+        ast)))
+
+(set EVAL
+  (fn [ast-param env-param]
+    (var ast ast-param)
+    (var env env-param)
+    (var result nil)
+    (while (not result)
+      (if (not (t.list?* ast))
+          (set result (eval_ast ast env))
+          (do
+           (set ast (macroexpand ast env))
+           (if (not (t.list?* ast))
+               (set result (eval_ast ast env))
+               (if (t.empty?* ast)
+                   (set result ast)
+                   (let [ast-elts (t.get-value ast)
+                         head-name (t.get-value (. ast-elts 1))]
+                     ;; XXX: want to check for symbol, but...
+                     (if (= "def!" head-name)
+                         (let [def-name (. ast-elts 2)
+                               def-val (EVAL (. ast-elts 3) env)]
+                           (e.env-set env
+                                      def-name def-val)
+                           (set result def-val))
+                         ;;
+                         (= "defmacro!" head-name)
+                         (let [def-name (. ast-elts 2)
+                               def-val (EVAL (. ast-elts 3) env)
+                               macro-ast (t.macrofy def-val)]
+                           (e.env-set env
+                                      def-name macro-ast)
+                           (set result macro-ast))
+                         ;;
+                         (= "macroexpand" head-name)
+                         (set result (macroexpand (. ast-elts 2) env))
+                         ;;
+                         (= "let*" head-name)
+                         (let [new-env (e.make-env env)
+                               bindings (t.get-value (. ast-elts 2))
+                               stop (/ (length bindings) 2)]
+                           (for [idx 1 stop]
+                                (let [b-name
+                                      (. bindings (- (* 2 idx) 1))
+                                      b-val
+                                      (EVAL (. bindings (* 2 idx)) new-env)]
+                                  (e.env-set new-env
+                                             b-name b-val)))
+                           ;; tco
+                           (set ast (. ast-elts 3))
+                           (set env new-env))
+                         ;;
+                         (= "quote" head-name)
+                         ;; tco
+                         (set result (. ast-elts 2))
+                         ;;
+                         (= "quasiquoteexpand" head-name)
+                         ;; tco
+                         (set result (quasiquote* (. ast-elts 2)))
+                         ;;
+                         (= "quasiquote" head-name)
+                         ;; tco
+                         (set ast (quasiquote* (. ast-elts 2)))
+                         ;;
+                         (= "do" head-name)
+                         (let [most-forms (u.slice ast-elts 2 -2) ;; XXX
+                               last-body-form (u.last ast-elts)
+                               res-ast (eval_ast
+                                        (t.make-list most-forms) env)]
+                           ;; tco
+                           (set ast last-body-form))
+                         ;;
+                         (= "if" head-name)
+                         (let [cond-res (EVAL (. ast-elts 2) env)]
+                           (if (or (t.nil?* cond-res)
+                                   (t.false?* cond-res))
+                               (let [else-ast (. ast-elts 4)]
+                                 (if (not else-ast)
+                                     ;; tco
+                                     (set result t.mal-nil)
+                                     (set ast else-ast)))
+                               ;; tco
+                               (set ast (. ast-elts 3))))
+                         ;;
+                         (= "fn*" head-name)
+                         (let [params (t.get-value (. ast-elts 2))
+                               body (. ast-elts 3)]
+                           ;; tco
+                           (set result
+                                (t.make-fn
+                                 (fn [args]
+                                   (EVAL body
+                                         (e.make-env env params args)))
+                                 body params env false)))
+                         ;;
+                         (let [eval-list (t.get-value (eval_ast ast env))
+                               f (. eval-list 1)
+                               args (u.slice eval-list 2 -1)]
+                           (let [body (t.get-ast f)] ;; tco
+                             (if body
+                                 (do
+                                  (set ast body)
+                                  (set env
+                                       (e.make-env (t.get-env f)
+                                                   (t.get-params f)
+                                                   args)))
+                                 (set result
+                                      ((t.get-value f) args))))))))))))
+    result))
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str) repl_env)))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(e.env-set repl_env
+           (t.make-symbol "eval")
+           (t.make-fn
+             (fn [asts]
+               (when (< (length asts) 1)
+                 ;; XXX
+                 (error "eval takes 1 arguments"))
+               (EVAL (u.first asts) repl_env))))
+
+(rep
+ (.. "(def! load-file "
+     "  (fn* (f) "
+     "    (eval "
+     "      (read-string "
+     "        (str \"(do \" (slurp f) \"\nnil)\")))))"))
+
+(rep
+ (.. "(defmacro! cond "
+     "  (fn* (& xs) "
+     "    (if (> (count xs) 0) "
+     "        (list 'if (first xs) "
+     "                  (if (> (count xs) 1) "
+     "                      (nth xs 1) "
+     "                      (throw \"odd number of forms to cond\")) "
+     "                  (cons 'cond (rest (rest xs)))))))"))
+
+(e.env-set repl_env
+           (t.make-symbol "*ARGV*")
+           (t.make-list (u.map t.make-string (u.slice arg 2 -1))))
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(if (<= 1 (length arg))
+    (xpcall (fn []
+              (rep (.. "(load-file \"" (. arg 1) "\")"))) ;; XXX: escaping?
+            handle-error)
+    (do
+     (var done false)
+     (while (not done)
+       (io.write "user> ")
+       (io.flush)
+       (let [input (io.read)]
+         (if (not input)
+             (set done true)
+        (xpcall (fn []
+                  (print (rep input)))
+                handle-error))))))

--- a/impls/fennel/step9_try.fnl
+++ b/impls/fennel/step9_try.fnl
@@ -1,0 +1,311 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+(local e (require :env))
+(local core (require :core))
+(local u (require :utils))
+
+(local repl_env
+  (let [env (e.make-env)]
+    (each [name func (pairs core)]
+      (e.env-set env
+                 (t.make-symbol name)
+                 func))
+    env))
+
+(fn READ
+  [code-str]
+  (reader.read_str code-str))
+
+(fn is_macro_call
+  [ast env]
+  (when (and (t.list?* ast)
+             (not (t.empty?* ast)))
+    (let [head-ast (. (t.get-value ast) 1)]
+      (when (and (t.symbol?* head-ast)
+                 (e.env-find env head-ast))
+        (let [target-ast (e.env-get env head-ast)]
+          (t.macro?* target-ast))))))
+
+(fn macroexpand
+  [ast env]
+  (var ast-var ast)
+  (while (is_macro_call ast-var env)
+    (let [inner-asts (t.get-value ast-var)
+          head-ast (. inner-asts 1)
+          macro-fn (t.get-value (e.env-get env head-ast))
+          args (u.slice inner-asts 2 -1)]
+      (set ast-var (macro-fn args))))
+  ast-var)
+
+;; forward declaration
+(var EVAL 1)
+
+(fn eval_ast
+  [ast env]
+  (if (t.symbol?* ast)
+      (e.env-get env ast)
+      ;;
+      (t.list?* ast)
+      (t.make-list (u.map (fn [elt-ast]
+                            (EVAL elt-ast env))
+                          (t.get-value ast)))
+      ;;
+      (t.vector?* ast)
+      (t.make-vector (u.map (fn [elt-ast]
+                              (EVAL elt-ast env))
+                            (t.get-value ast)))
+      ;;
+      (t.hash-map?* ast)
+      (t.make-hash-map (u.map (fn [elt-ast]
+                                (EVAL elt-ast env))
+                              (t.get-value ast)))
+      ;;
+      ast))
+
+(fn starts-with
+  [ast name]
+  (when (and (t.list?* ast)
+             (not (t.empty?* ast)))
+    (let [head-ast (. (t.get-value ast) 1)]
+      (and (t.symbol?* head-ast)
+           (= name (t.get-value head-ast))))))
+
+(var quasiquote* nil)
+
+(fn qq-iter
+  [ast]
+  (if (t.empty?* ast)
+      (t.make-list [])
+      (let [ast-value (t.get-value ast)
+            elt (. ast-value 1)
+            acc (qq-iter (t.make-list (u.slice ast-value 2 -1)))]
+        (if (starts-with elt "splice-unquote")
+            (t.make-list [(t.make-symbol "concat")
+                          (. (t.get-value elt) 2)
+                          acc])
+            (t.make-list [(t.make-symbol "cons")
+                          (quasiquote* elt)
+                          acc])))))
+
+(set quasiquote*
+  (fn [ast]
+    (if (starts-with ast "unquote")
+        (. (t.get-value ast) 2)
+        ;;
+        (t.list?* ast)
+        (qq-iter ast)
+        ;;
+        (t.vector?* ast)
+        (t.make-list [(t.make-symbol "vec") (qq-iter ast)])
+        ;;
+        (or (t.symbol?* ast)
+            (t.hash-map?* ast))
+        (t.make-list [(t.make-symbol "quote") ast])
+        ;;
+        ast)))
+
+(set EVAL
+  (fn [ast-param env-param]
+    (var ast ast-param)
+    (var env env-param)
+    (var result nil)
+    (while (not result)
+      (if (not (t.list?* ast))
+          (set result (eval_ast ast env))
+          (do
+           (set ast (macroexpand ast env))
+           (if (not (t.list?* ast))
+               (set result (eval_ast ast env))
+               (if (t.empty?* ast)
+                   (set result ast)
+                   (let [ast-elts (t.get-value ast)
+                         head-name (t.get-value (. ast-elts 1))]
+                     ;; XXX: want to check for symbol, but...
+                     (if (= "def!" head-name)
+                         (let [def-name (. ast-elts 2)
+                               def-val (EVAL (. ast-elts 3) env)]
+                           (e.env-set env
+                                      def-name def-val)
+                           (set result def-val))
+                         ;;
+                         (= "defmacro!" head-name)
+                         (let [def-name (. ast-elts 2)
+                               def-val (EVAL (. ast-elts 3) env)
+                               macro-ast (t.macrofy def-val)]
+                           (e.env-set env
+                                      def-name macro-ast)
+                           (set result macro-ast))
+                         ;;
+                         (= "macroexpand" head-name)
+                         (set result (macroexpand (. ast-elts 2) env))
+                         ;;
+                         (= "let*" head-name)
+                         (let [new-env (e.make-env env)
+                               bindings (t.get-value (. ast-elts 2))
+                               stop (/ (length bindings) 2)]
+                           (for [idx 1 stop]
+                                (let [b-name
+                                      (. bindings (- (* 2 idx) 1))
+                                      b-val
+                                      (EVAL (. bindings (* 2 idx)) new-env)]
+                                  (e.env-set new-env
+                                             b-name b-val)))
+                           ;; tco
+                           (set ast (. ast-elts 3))
+                           (set env new-env))
+                         ;;
+                         (= "quote" head-name)
+                         ;; tco
+                         (set result (. ast-elts 2))
+                         ;;
+                         (= "quasiquoteexpand" head-name)
+                         ;; tco
+                         (set result (quasiquote* (. ast-elts 2)))
+                         ;;
+                         (= "quasiquote" head-name)
+                         ;; tco
+                         (set ast (quasiquote* (. ast-elts 2)))
+                         ;;
+                         (= "try*" head-name)
+                         (set result
+                              (let [(ok? res)
+                                    (pcall EVAL (. ast-elts 2) env)]
+                                (if (not ok?)
+                                    (let [maybe-catch-ast (. ast-elts 3)]
+                                      (if (not maybe-catch-ast)
+                                          (u.throw* res)
+                                          (if (not (starts-with maybe-catch-ast
+                                                                "catch*"))
+                                              (u.throw*
+                                               (t.make-string
+                                                "Expected catch* form"))
+                                              (let [catch-asts
+                                                    (t.get-value
+                                                     maybe-catch-ast)]
+                                                (if (< (length catch-asts) 2)
+                                                    (u.throw*
+                                                     (t.make-string
+                                                      (.. "catch* requires at "
+                                                          "least 2 "
+                                                          "arguments")))
+                                                    (let [catch-sym-ast
+                                                          (. catch-asts 2)
+                                                          catch-body-ast
+                                                          (. catch-asts 3)]
+                                                      (EVAL catch-body-ast
+                                                            (e.make-env
+                                                             env
+                                                             [catch-sym-ast]
+                                                             [res]))))))))
+                                    res)))
+                         ;;
+                         (= "do" head-name)
+                         (let [most-forms (u.slice ast-elts 2 -2) ;; XXX
+                               last-body-form (u.last ast-elts)
+                               res-ast (eval_ast
+                                        (t.make-list most-forms) env)]
+                           ;; tco
+                           (set ast last-body-form))
+                         ;;
+                         (= "if" head-name)
+                         (let [cond-res (EVAL (. ast-elts 2) env)]
+                           (if (or (t.nil?* cond-res)
+                                   (t.false?* cond-res))
+                               (let [else-ast (. ast-elts 4)]
+                                 (if (not else-ast)
+                                     ;; tco
+                                     (set result t.mal-nil)
+                                     (set ast else-ast)))
+                               ;; tco
+                               (set ast (. ast-elts 3))))
+                         ;;
+                         (= "fn*" head-name)
+                         (let [params (t.get-value (. ast-elts 2))
+                               body (. ast-elts 3)]
+                           ;; tco
+                           (set result
+                                (t.make-fn
+                                 (fn [args]
+                                   (EVAL body
+                                         (e.make-env env params args)))
+                                 body params env false)))
+                         ;;
+                         (let [eval-list (t.get-value (eval_ast ast env))
+                               f (. eval-list 1)
+                               args (u.slice eval-list 2 -1)]
+                           (let [body (t.get-ast f)] ;; tco
+                             (if body
+                                 (do
+                                  (set ast body)
+                                  (set env
+                                       (e.make-env (t.get-env f)
+                                                   (t.get-params f)
+                                                   args)))
+                                 (set result
+                                      ((t.get-value f) args))))))))))))
+    result))
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str) repl_env)))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(e.env-set repl_env
+           (t.make-symbol "eval")
+           (t.make-fn
+             (fn [asts]
+               (when (< (length asts) 1)
+                 (u.throw*
+                  (t.make-string "eval takes 1 argument")))
+               (EVAL (u.first asts) repl_env))))
+
+(rep
+ (.. "(def! load-file "
+     "  (fn* (f) "
+     "    (eval "
+     "      (read-string "
+     "        (str \"(do \" (slurp f) \"\nnil)\")))))"))
+
+(rep
+ (.. "(defmacro! cond "
+     "  (fn* (& xs) "
+     "    (if (> (count xs) 0) "
+     "        (list 'if (first xs) "
+     "                  (if (> (count xs) 1) "
+     "                      (nth xs 1) "
+     "                      (throw \"odd number of forms to cond\")) "
+     "                  (cons 'cond (rest (rest xs)))))))"))
+
+(e.env-set repl_env
+           (t.make-symbol "*ARGV*")
+           (t.make-list (u.map t.make-string (u.slice arg 2 -1))))
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(if (<= 1 (length arg))
+    (xpcall (fn []
+              (rep (.. "(load-file \"" (. arg 1) "\")"))) ;; XXX: escaping?
+            handle-error)
+    (do
+     (var done false)
+     (while (not done)
+       (io.write "user> ")
+       (io.flush)
+       (let [input (io.read)]
+         (if (not input)
+             (set done true)
+        (xpcall (fn []
+                  (print (rep input)))
+                handle-error))))))

--- a/impls/fennel/stepA_mal.fnl
+++ b/impls/fennel/stepA_mal.fnl
@@ -1,0 +1,316 @@
+(local printer (require :printer))
+(local reader (require :reader))
+(local t (require :types))
+(local e (require :env))
+(local core (require :core))
+(local u (require :utils))
+
+(local repl_env
+  (let [env (e.make-env)]
+    (each [name func (pairs core)]
+      (e.env-set env
+                 (t.make-symbol name)
+                 func))
+    env))
+
+(fn READ
+  [code-str]
+  (reader.read_str code-str))
+
+(fn is_macro_call
+  [ast env]
+  (when (and (t.list?* ast)
+             (not (t.empty?* ast)))
+    (let [head-ast (. (t.get-value ast) 1)]
+      (when (and (t.symbol?* head-ast)
+                 (e.env-find env head-ast))
+        (let [target-ast (e.env-get env head-ast)]
+          (t.macro?* target-ast))))))
+
+(fn macroexpand
+  [ast env]
+  (var ast-var ast)
+  (while (is_macro_call ast-var env)
+    (let [inner-asts (t.get-value ast-var)
+          head-ast (. inner-asts 1)
+          macro-fn (t.get-value (e.env-get env head-ast))
+          args (u.slice inner-asts 2 -1)]
+      (set ast-var (macro-fn args))))
+  ast-var)
+
+;; forward declaration
+(var EVAL 1)
+
+(fn eval_ast
+  [ast env]
+  (if (t.symbol?* ast)
+      (e.env-get env ast)
+      ;;
+      (t.list?* ast)
+      (t.make-list (u.map (fn [elt-ast]
+                            (EVAL elt-ast env))
+                          (t.get-value ast)))
+      ;;
+      (t.vector?* ast)
+      (t.make-vector (u.map (fn [elt-ast]
+                              (EVAL elt-ast env))
+                            (t.get-value ast)))
+      ;;
+      (t.hash-map?* ast)
+      (t.make-hash-map (u.map (fn [elt-ast]
+                                (EVAL elt-ast env))
+                              (t.get-value ast)))
+      ;;
+      ast))
+
+(fn starts-with
+  [ast name]
+  (when (and (t.list?* ast)
+             (not (t.empty?* ast)))
+    (let [head-ast (. (t.get-value ast) 1)]
+      (and (t.symbol?* head-ast)
+           (= name (t.get-value head-ast))))))
+
+(var quasiquote* nil)
+
+(fn qq-iter
+  [ast]
+  (if (t.empty?* ast)
+      (t.make-list [])
+      (let [ast-value (t.get-value ast)
+            elt (. ast-value 1)
+            acc (qq-iter (t.make-list (u.slice ast-value 2 -1)))]
+        (if (starts-with elt "splice-unquote")
+            (t.make-list [(t.make-symbol "concat")
+                          (. (t.get-value elt) 2)
+                          acc])
+            (t.make-list [(t.make-symbol "cons")
+                          (quasiquote* elt)
+                          acc])))))
+
+(set quasiquote*
+  (fn [ast]
+    (if (starts-with ast "unquote")
+        (. (t.get-value ast) 2)
+        ;;
+        (t.list?* ast)
+        (qq-iter ast)
+        ;;
+        (t.vector?* ast)
+        (t.make-list [(t.make-symbol "vec") (qq-iter ast)])
+        ;;
+        (or (t.symbol?* ast)
+            (t.hash-map?* ast))
+        (t.make-list [(t.make-symbol "quote") ast])
+        ;;
+        ast)))
+
+(set EVAL
+  (fn [ast-param env-param]
+    (var ast ast-param)
+    (var env env-param)
+    (var result nil)
+    (while (not result)
+      (if (not (t.list?* ast))
+          (set result (eval_ast ast env))
+          (do
+           (set ast (macroexpand ast env))
+           (if (not (t.list?* ast))
+               (set result (eval_ast ast env))
+               (if (t.empty?* ast)
+                   (set result ast)
+                   (let [ast-elts (t.get-value ast)
+                         head-name (t.get-value (. ast-elts 1))]
+                     ;; XXX: want to check for symbol, but...
+                     (if (= "def!" head-name)
+                         (let [def-name (. ast-elts 2)
+                               def-val (EVAL (. ast-elts 3) env)]
+                           (e.env-set env
+                                      def-name def-val)
+                           (set result def-val))
+                         ;;
+                         (= "defmacro!" head-name)
+                         (let [def-name (. ast-elts 2)
+                               def-val (EVAL (. ast-elts 3) env)
+                               macro-ast (t.macrofy def-val)]
+                           (e.env-set env
+                                      def-name macro-ast)
+                           (set result macro-ast))
+                         ;;
+                         (= "macroexpand" head-name)
+                         (set result (macroexpand (. ast-elts 2) env))
+                         ;;
+                         (= "let*" head-name)
+                         (let [new-env (e.make-env env)
+                               bindings (t.get-value (. ast-elts 2))
+                               stop (/ (length bindings) 2)]
+                           (for [idx 1 stop]
+                                (let [b-name
+                                      (. bindings (- (* 2 idx) 1))
+                                      b-val
+                                      (EVAL (. bindings (* 2 idx)) new-env)]
+                                  (e.env-set new-env
+                                             b-name b-val)))
+                           ;; tco
+                           (set ast (. ast-elts 3))
+                           (set env new-env))
+                         ;;
+                         (= "quote" head-name)
+                         ;; tco
+                         (set result (. ast-elts 2))
+                         ;;
+                         (= "quasiquoteexpand" head-name)
+                         ;; tco
+                         (set result (quasiquote* (. ast-elts 2)))
+                         ;;
+                         (= "quasiquote" head-name)
+                         ;; tco
+                         (set ast (quasiquote* (. ast-elts 2)))
+                         ;;
+                         (= "try*" head-name)
+                         (set result
+                              (let [(ok? res)
+                                    (pcall EVAL (. ast-elts 2) env)]
+                                (if (not ok?)
+                                    (let [maybe-catch-ast (. ast-elts 3)]
+                                      (if (not maybe-catch-ast)
+                                          (u.throw* res)
+                                          (if (not (starts-with maybe-catch-ast
+                                                                "catch*"))
+                                              (u.throw*
+                                               (t.make-string
+                                                "Expected catch* form"))
+                                              (let [catch-asts
+                                                    (t.get-value
+                                                     maybe-catch-ast)]
+                                                (if (< (length catch-asts) 2)
+                                                    (u.throw*
+                                                     (t.make-string
+                                                      (.. "catch* requires at "
+                                                          "least 2 "
+                                                          "arguments")))
+                                                    (let [catch-sym-ast
+                                                          (. catch-asts 2)
+                                                          catch-body-ast
+                                                          (. catch-asts 3)]
+                                                      (EVAL catch-body-ast
+                                                            (e.make-env
+                                                             env
+                                                             [catch-sym-ast]
+                                                             [res]))))))))
+                                    res)))
+                         ;;
+                         (= "do" head-name)
+                         (let [most-forms (u.slice ast-elts 2 -2) ;; XXX
+                               last-body-form (u.last ast-elts)
+                               res-ast (eval_ast
+                                        (t.make-list most-forms) env)]
+                           ;; tco
+                           (set ast last-body-form))
+                         ;;
+                         (= "if" head-name)
+                         (let [cond-res (EVAL (. ast-elts 2) env)]
+                           (if (or (t.nil?* cond-res)
+                                   (t.false?* cond-res))
+                               (let [else-ast (. ast-elts 4)]
+                                 (if (not else-ast)
+                                     ;; tco
+                                     (set result t.mal-nil)
+                                     (set ast else-ast)))
+                               ;; tco
+                               (set ast (. ast-elts 3))))
+                         ;;
+                         (= "fn*" head-name)
+                         (let [params (t.get-value (. ast-elts 2))
+                               body (. ast-elts 3)]
+                           ;; tco
+                           (set result
+                                (t.make-fn
+                                 (fn [args]
+                                   (EVAL body
+                                         (e.make-env env params args)))
+                                 body params env false nil)))
+                         ;;
+                         (let [eval-list (t.get-value (eval_ast ast env))
+                               f (. eval-list 1)
+                               args (u.slice eval-list 2 -1)]
+                           (let [body (t.get-ast f)] ;; tco
+                             (if body
+                                 (do
+                                  (set ast body)
+                                  (set env
+                                       (e.make-env (t.get-env f)
+                                                   (t.get-params f)
+                                                   args)))
+                                 (set result
+                                      ((t.get-value f) args))))))))))))
+    result))
+
+(fn PRINT
+  [ast]
+  (printer.pr_str ast true))
+
+(fn rep
+  [code-str]
+  (PRINT (EVAL (READ code-str) repl_env)))
+
+(rep "(def! not (fn* (a) (if a false true)))")
+
+(e.env-set repl_env
+           (t.make-symbol "eval")
+           (t.make-fn
+             (fn [asts]
+               (when (< (length asts) 1)
+                 (u.throw*
+                  (t.make-string "eval takes 1 argument")))
+               (EVAL (u.first asts) repl_env))))
+
+(rep
+ (.. "(def! load-file "
+     "  (fn* (f) "
+     "    (eval "
+     "      (read-string "
+     "        (str \"(do \" (slurp f) \"\nnil)\")))))"))
+
+(rep
+ (.. "(defmacro! cond "
+     "  (fn* (& xs) "
+     "    (if (> (count xs) 0) "
+     "        (list 'if (first xs) "
+     "                  (if (> (count xs) 1) "
+     "                      (nth xs 1) "
+     "                      (throw \"odd number of forms to cond\")) "
+     "                  (cons 'cond (rest (rest xs)))))))"))
+
+(e.env-set repl_env
+           (t.make-symbol "*host-language*")
+           (t.make-string "fennel"))
+
+(e.env-set repl_env
+           (t.make-symbol "*ARGV*")
+           (t.make-list (u.map t.make-string (u.slice arg 2 -1))))
+
+(fn handle-error
+  [err]
+  (if (t.nil?* err)
+      (print)
+      (= "string" (type err))
+      (print err)
+      (print (.. "Error: " (PRINT err)))))
+
+(if (<= 1 (length arg))
+    (xpcall (fn []
+              (rep (.. "(load-file \"" (. arg 1) "\")"))) ;; XXX: escaping?
+            handle-error)
+    (do
+     (rep "(println (str \"Mal [\" *host-language* \"]\"))")
+     (var done false)
+     (while (not done)
+       (io.write "user> ")
+       (io.flush)
+       (let [input (io.read)]
+         (if (not input)
+             (set done true)
+             (xpcall (fn []
+                       (print (rep input)))
+                     handle-error))))))

--- a/impls/fennel/types.fnl
+++ b/impls/fennel/types.fnl
@@ -53,35 +53,14 @@
    :params params
    :env env})
 
+(fn make-atom
+  [ast]
+  {:tag :atom
+   :content ast})
+
 (local mal-true (make-boolean true))
 
 (local mal-false (make-boolean false))
-
-;;
-
-(fn get-value
-  [ast]
-  (. ast :content))
-
-(fn get-type
-  [ast]
-  (. ast :tag))
-
-;;
-
-(fn get-ast
-  [ast]
-  (. ast :ast))
-
-(fn get-params
-  [ast]
-  (. ast :params))
-
-(fn get-env
-  [ast]
-  (. ast :env))
-
-;;
 
 (fn nil?*
   [ast]
@@ -122,6 +101,53 @@
 (fn fn?*
   [ast]
   (= :fn (. ast :tag)))
+
+(fn atom?*
+  [ast]
+  (= :atom (. ast :tag)))
+
+;;
+
+(fn get-value
+  [ast]
+  (. ast :content))
+
+(fn get-type
+  [ast]
+  (. ast :tag))
+
+;;
+
+(fn get-ast
+  [ast]
+  (. ast :ast))
+
+(fn get-params
+  [ast]
+  (. ast :params))
+
+(fn get-env
+  [ast]
+  (. ast :env))
+
+;;
+
+(fn set-atom-value!
+  [atom-ast value-ast]
+  (tset atom-ast
+        :content value-ast))
+
+(fn deref*
+  [ast]
+  (if (not (atom?* ast))
+      ;; XXX
+      (error (.. "Expected atom, got: " (get-type ast)))
+      (get-value ast)))
+
+(fn reset!*
+  [atom-ast val-ast]
+  (set-atom-value! atom-ast val-ast)
+  val-ast)
 
 ;;
 
@@ -209,15 +235,11 @@
  :make-vector make-vector
  :make-hash-map make-hash-map
  :make-fn make-fn
+ :make-atom make-atom
  ;;
  :mal-nil mal-nil
  :mal-true mal-true
  :mal-false mal-false
- ;;
- :get-value get-value
- :get-ast get-ast
- :get-params get-params
- :get-env get-env
  ;;
  :nil?* nil?*
  :boolean?* boolean?*
@@ -229,6 +251,16 @@
  :vector?* vector?*
  :hash-map?* hash-map?*
  :fn?* fn?*
+ :atom?* atom?*
+ ;;
+ :get-value get-value
+ :get-ast get-ast
+ :get-params get-params
+ :get-env get-env
+ ;;
+ :set-atom-value! set-atom-value!
+ :deref* deref*
+ :reset!* reset!*
  ;;
  :empty?* empty?*
  :true?* true?*

--- a/impls/fennel/types.fnl
+++ b/impls/fennel/types.fnl
@@ -46,9 +46,12 @@
    :content elts})
 
 (fn make-fn
-  [a-fn]
+  [a-fn ast params env]
   {:tag :fn
-   :content a-fn})
+   :content a-fn
+   :ast ast
+   :params params
+   :env env})
 
 (local mal-true (make-boolean true))
 
@@ -63,6 +66,20 @@
 (fn get-type
   [ast]
   (. ast :tag))
+
+;;
+
+(fn get-ast
+  [ast]
+  (. ast :ast))
+
+(fn get-params
+  [ast]
+  (. ast :params))
+
+(fn get-env
+  [ast]
+  (. ast :env))
 
 ;;
 
@@ -101,6 +118,10 @@
 (fn hash-map?*
   [ast]
   (= :hash-map (. ast :tag)))
+
+(fn fn?*
+  [ast]
+  (= :fn (. ast :tag)))
 
 ;;
 
@@ -194,6 +215,9 @@
  :mal-false mal-false
  ;;
  :get-value get-value
+ :get-ast get-ast
+ :get-params get-params
+ :get-env get-env
  ;;
  :nil?* nil?*
  :boolean?* boolean?*
@@ -204,6 +228,7 @@
  :list?* list?*
  :vector?* vector?*
  :hash-map?* hash-map?*
+ :fn?* fn?*
  ;;
  :empty?* empty?*
  :true?* true?*

--- a/impls/fennel/types.fnl
+++ b/impls/fennel/types.fnl
@@ -46,12 +46,14 @@
    :content elts})
 
 (fn make-fn
-  [a-fn ast params env]
+  [a-fn ast params env is-macro]
+  (local is-macro (if is-macro is-macro false))
   {:tag :fn
    :content a-fn
    :ast ast
    :params params
-   :env env})
+   :env env
+   :is-macro is-macro})
 
 (fn make-atom
   [ast]
@@ -61,6 +63,36 @@
 (local mal-true (make-boolean true))
 
 (local mal-false (make-boolean false))
+
+;;
+
+(fn get-value
+  [ast]
+  (. ast :content))
+
+(fn get-type
+  [ast]
+  (. ast :tag))
+
+;;
+
+(fn get-is-macro
+  [ast]
+  (. ast :is-macro))
+
+(fn get-ast
+  [ast]
+  (. ast :ast))
+
+(fn get-params
+  [ast]
+  (. ast :params))
+
+(fn get-env
+  [ast]
+  (. ast :env))
+
+;;
 
 (fn nil?*
   [ast]
@@ -106,29 +138,21 @@
   [ast]
   (= :atom (. ast :tag)))
 
-;;
-
-(fn get-value
+(fn macro?*
   [ast]
-  (. ast :content))
-
-(fn get-type
-  [ast]
-  (. ast :tag))
+  (and (fn?* ast)
+       (get-is-macro ast)))
 
 ;;
 
-(fn get-ast
-  [ast]
-  (. ast :ast))
-
-(fn get-params
-  [ast]
-  (. ast :params))
-
-(fn get-env
-  [ast]
-  (. ast :env))
+(fn macrofy
+  [fn-ast]
+  (local macro-ast {})
+  (each [k v (pairs fn-ast)]
+    (tset macro-ast k v))
+  (tset macro-ast
+        :is-macro true)
+  macro-ast)
 
 ;;
 
@@ -241,6 +265,12 @@
  :mal-true mal-true
  :mal-false mal-false
  ;;
+ :get-value get-value
+ :get-is-macro get-is-macro
+ :get-ast get-ast
+ :get-params get-params
+ :get-env get-env
+ ;;
  :nil?* nil?*
  :boolean?* boolean?*
  :number?* number?*
@@ -252,11 +282,9 @@
  :hash-map?* hash-map?*
  :fn?* fn?*
  :atom?* atom?*
+ :macro?* macro?*
  ;;
- :get-value get-value
- :get-ast get-ast
- :get-params get-params
- :get-env get-env
+ :macrofy macrofy
  ;;
  :set-atom-value! set-atom-value!
  :deref* deref*

--- a/impls/fennel/types.fnl
+++ b/impls/fennel/types.fnl
@@ -93,6 +93,14 @@
   [ast]
   (= :hash-map (. ast :tag)))
 
+;;
+
+(fn empty?*
+  [ast]
+  (when (or (list?* ast)
+            (vector?* ast))
+    (= (length (get-value ast)) 0)))
+
 {
  :make-nil make-nil
  :make-boolean make-boolean
@@ -108,6 +116,8 @@
  :mal-true mal-true
  :mal-false mal-false
  ;;
+ :get-value get-value
+ ;;
  :nil?* nil?*
  :boolean?* boolean?*
  :number?* number?*
@@ -118,5 +128,5 @@
  :vector?* vector?*
  :hash-map?* hash-map?*
  ;;
- :get-value get-value
+ :empty?* empty?*
 }

--- a/impls/fennel/types.fnl
+++ b/impls/fennel/types.fnl
@@ -1,0 +1,122 @@
+(fn make-nil
+  [a-str]
+  {:tag :nil
+   :content "nil"})
+
+(fn make-boolean
+  [a-bool]
+  {:tag :boolean
+   :content a-bool})
+
+(fn make-number
+  [a-num]
+  {:tag :number
+   :content a-num})
+
+(fn make-keyword
+  [a-str]
+  {:tag :keyword
+   :content a-str})
+
+(fn make-symbol
+  [a-str]
+  {:tag :symbol
+   :content a-str})
+
+(fn make-string
+  [a-str]
+  {:tag :string
+   :content a-str})
+
+(local mal-nil (make-nil))
+
+(fn make-list
+  [elts]
+  {:tag :list
+   :content elts})
+
+(fn make-vector
+  [elts]
+  {:tag :vector
+   :content elts})
+
+(fn make-hash-map
+  [elts]
+  {:tag :hash-map
+   :content elts})
+
+(local mal-true (make-boolean true))
+
+(local mal-false (make-boolean false))
+
+;;
+
+(fn get-value
+  [ast]
+  (. ast :content))
+
+;;
+
+(fn nil?*
+  [ast]
+  (= :nil (. ast :tag)))
+
+(fn boolean?*
+  [ast]
+  (= :boolean (. ast :tag)))
+
+(fn number?*
+  [ast]
+  (= :number (. ast :tag)))
+
+(fn keyword?*
+  [ast]
+  (= :keyword (. ast :tag)))
+
+(fn symbol?*
+  [ast]
+  (= :symbol (. ast :tag)))
+
+(fn string?*
+  [ast]
+  (= :string (. ast :tag)))
+
+(fn list?*
+  [ast]
+  (= :list (. ast :tag)))
+
+(fn vector?*
+  [ast]
+  (= :vector (. ast :tag)))
+
+(fn hash-map?*
+  [ast]
+  (= :hash-map (. ast :tag)))
+
+{
+ :make-nil make-nil
+ :make-boolean make-boolean
+ :make-number make-number
+ :make-keyword make-keyword
+ :make-symbol make-symbol
+ :make-string make-string
+ :make-list make-list
+ :make-vector make-vector
+ :make-hash-map make-hash-map
+ ;;
+ :mal-nil mal-nil
+ :mal-true mal-true
+ :mal-false mal-false
+ ;;
+ :nil?* nil?*
+ :boolean?* boolean?*
+ :number?* number?*
+ :keyword?* keyword?*
+ :symbol?* symbol?*
+ :string?* string?*
+ :list?* list?*
+ :vector?* vector?*
+ :hash-map?* hash-map?*
+ ;;
+ :get-value get-value
+}

--- a/impls/fennel/types.fnl
+++ b/impls/fennel/types.fnl
@@ -31,29 +31,37 @@
 (local mal-nil (make-nil))
 
 (fn make-list
-  [elts]
+  [elts md]
+  (local md (if md md mal-nil))
   {:tag :list
-   :content elts})
+   :content elts
+   :md md})
 
 (fn make-vector
-  [elts]
+  [elts md]
+  (local md (if md md mal-nil))
   {:tag :vector
-   :content elts})
+   :content elts
+   :md md})
 
 (fn make-hash-map
-  [elts]
+  [elts md]
+  (local md (if md md mal-nil))
   {:tag :hash-map
-   :content elts})
+   :content elts
+   :md md})
 
 (fn make-fn
-  [a-fn ast params env is-macro]
+  [a-fn ast params env is-macro md]
   (local is-macro (if is-macro is-macro false))
+  (local md (if md md mal-nil))
   {:tag :fn
    :content a-fn
    :ast ast
    :params params
    :env env
-   :is-macro is-macro})
+   :is-macro is-macro
+   :md md})
 
 (fn make-atom
   [ast]
@@ -73,6 +81,10 @@
 (fn get-type
   [ast]
   (. ast :tag))
+
+(fn get-md
+  [ast]
+  (. ast :md))
 
 ;;
 
@@ -153,6 +165,15 @@
   (tset macro-ast
         :is-macro true)
   macro-ast)
+
+(fn clone-with-meta
+  [fn-ast meta-ast]
+  (local new-fn-ast {})
+  (each [k v (pairs fn-ast)]
+    (tset new-fn-ast k v))
+  (tset new-fn-ast
+        :md meta-ast)
+  new-fn-ast)
 
 ;;
 
@@ -266,6 +287,7 @@
  :mal-false mal-false
  ;;
  :get-value get-value
+ :get-md get-md
  :get-is-macro get-is-macro
  :get-ast get-ast
  :get-params get-params
@@ -285,6 +307,7 @@
  :macro?* macro?*
  ;;
  :macrofy macrofy
+ :clone-with-meta clone-with-meta
  ;;
  :set-atom-value! set-atom-value!
  :deref* deref*

--- a/impls/fennel/utils.fnl
+++ b/impls/fennel/utils.fnl
@@ -2,6 +2,101 @@
   [ast]
   (error ast))
 
+(fn abs-index
+  [i len]
+  (if (> i 0)
+      i
+      (< i 0)
+      (+ len i 1)
+      nil))
+
+(comment
+
+ (abs-index 0 9)
+ ;; => nil
+
+ (abs-index 1 9)
+ ;; => 1
+
+ (abs-index -1 9)
+ ;; => 9
+
+ (abs-index -2 9)
+ ;; => 8
+
+ )
+
+(fn slice
+  [tbl beg end]
+  (local len-tbl (length tbl))
+  (local new-beg
+    (if beg (abs-index beg len-tbl) 1))
+  (local new-end
+    (if end (abs-index end len-tbl) len-tbl))
+  (local start
+    (if (< new-beg 1) 1 new-beg))
+  (local fin
+    (if (< len-tbl new-end) len-tbl new-end))
+  (local new-tbl [])
+  (for [idx start fin]
+    (tset new-tbl
+          (+ (length new-tbl) 1)
+          (. tbl idx)))
+  new-tbl)
+
+(comment
+
+ (slice [7 8 9] 2 -1)
+ ;; => [8 9]
+
+ (slice [1 2 3] 1 2)
+ ;; => [1 2]
+
+ )
+
+(fn first
+  [tbl]
+  (. tbl 1))
+
+(comment
+
+ (first [7 8 9])
+ ;; => 7
+
+ )
+
+(fn last
+  [tbl]
+  (. tbl (length tbl)))
+
+(comment
+
+ (last [7 8 9])
+ ;; => 9
+
+ )
+
+(fn map
+  [a-fn tbl]
+  (local new-tbl [])
+  (each [i elt (ipairs tbl)]
+    (tset new-tbl i (a-fn elt)))
+  new-tbl)
+
+(comment
+
+ (map (fn [x] (+ x 1)) [7 8 9])
+ ;; => [8 9 10]
+
+ (map (fn [n] [n (+ n 1)]) [1 2 3])
+ ;; => [[1 2] [2 3] [3 4]]
+
+ )
+
 {
  :throw* throw*
+ :slice slice
+ :first first
+ :last last
+ :map map
 }

--- a/impls/fennel/utils.fnl
+++ b/impls/fennel/utils.fnl
@@ -1,0 +1,7 @@
+(fn throw*
+  [ast]
+  (error ast))
+
+{
+ :throw* throw*
+}

--- a/impls/fennel/utils.fnl
+++ b/impls/fennel/utils.fnl
@@ -93,10 +93,45 @@
 
  )
 
+(fn reverse
+  [tbl]
+  (local new-tbl [])
+  (for [i (length tbl) 1 -1]
+    (table.insert new-tbl (. tbl i)))
+  new-tbl)
+
+(comment
+
+ (reverse [:a :b :c])
+ ;; => ["c" "b" "a"]
+
+ )
+
+(fn concat-two
+  [tbl-1 tbl-2]
+  (local new-tbl [])
+  (each [i elt (ipairs tbl-1)]
+    (table.insert new-tbl elt))
+  (each [i elt (ipairs tbl-2)]
+    (table.insert new-tbl elt))
+  new-tbl)
+
+(comment
+
+ (concat-two [:a :b :c] [:d :e :f])
+ ;; => ["a" "b" "c" "d" "e" "f"]
+
+ (concat-two {1 :a 2 :b 3 :c} {1 :d 2 :e 3 :f})
+ ;; => ["a" "b" "c" "d" "e" "f"]
+
+ )
+
 {
  :throw* throw*
  :slice slice
  :first first
  :last last
  :map map
+ :reverse reverse
+ :concat-two concat-two
 }


### PR DESCRIPTION
This is an implementation of mal in [Fennel](https://fennel-lang.org/).

All tests pass in both direct and self-hosted modes:

make "test^fennel"
make MAL_IMPL=fennel "test^mal"

I also used a peg in this implementation and not regular expressions.

Included in the PR is a Dockerfile I successfully tested in a VM.

I haven't changed the README yet -- thought I might wait to see what happens with the Janet PR.