### PR TITLE
Add missing expected result for test case

### DIFF
--- a/impls/tests/step1_read_print.mal
+++ b/impls/tests/step1_read_print.mal
@@ -281,6 +281,7 @@ false
 ;=>1
 ;;; Hopefully less problematic characters
 1; &()*+,-./:;<=>?@[]^_{|}~
+;=>1
 
 ;; FIXME: These tests have no reasons to be optional, but...
 ;; fantom fails this one


### PR DESCRIPTION
Heya - I might be wrong, but I think this line needs to be added - it's the expected output from evaluating the line above - `1; &()*+,-./:;<=>?@[]^_{|}~`