### PR TITLE
Suggest use StdIn.ReadLine instend of Predef.ReadLine cause Predef.ReadLine has been deprecated

### DIFF
--- a/impls/scala/step0_repl.scala
+++ b/impls/scala/step0_repl.scala
@@ -1,3 +1,5 @@
+import scala.io.StdIn
+
 object step0_repl {
   def READ(str: String): String = {
     str
@@ -17,7 +19,7 @@ object step0_repl {
 
   def main(args: Array[String]) {
     var line:String = null
-    while ({line = readLine("user> "); line != null}) {
+    while ({line = StdIn.readLine("user> "); line != null}) {
       try {
         println(REP(line))
       } catch {


### PR DESCRIPTION
method ReadLine defined in predef has been deprecated since scala 2.11.0

I change the code with StdIn.ReadLine in step0_repl.scala,and it works fine

If this pull will be accepted,I will change other code in the files