### PR TITLE
fix: got syntax error when string is bigger than 500 chars

### DIFF
--- a/impls/bash/reader.sh
+++ b/impls/bash/reader.sh
@@ -111,7 +111,7 @@ TOKENIZE () {
     local datalen=${#data}
     local idx=0
     local chunk=0
-    local chunksz=500
+    local chunksz=$datalen
     local token=
     local str=
 


### PR DESCRIPTION
got `Error: "expected ')', got EOF"` when string value is bigger than 500 chars.

if chunksz is equal datalen solve this problem.