### PR TITLE
Fix formatting of note about `throw` when defining `cond` (Step 8)

### DIFF
--- a/process/guide.md
+++ b/process/guide.md
@@ -1386,10 +1386,10 @@ implementation. Let us continue!
 ```
 "(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))"
 ```
-    * Note that `cond` calls the `throw` function when `cond` is
-      called with an odd number of args. The `throw` function is
-      implemented in the next step, but it will still serve it's
-      purpose here by causing an undefined symbol error.
+  * Note that `cond` calls the `throw` function when `cond` is
+    called with an odd number of args. The `throw` function is
+    implemented in the next step, but it will still serve it's
+    purpose here by causing an undefined symbol error.
 
 
 <a name="step9"></a>


### PR DESCRIPTION
This change removes one level of indentation on the note about using `throw` (which is not yet defined) when defining the `cond` macro at the end of Step 8. The Markdown engine on Github cannot start an indented list following a block of code, so it treats the bullet as 4-space indented code, causing the bullet point to be formatted as ugly pre-formatted text.