### PR TITLE
Reader Macro Expansion Test Step 8

### DIFF
--- a/impls/tests/step8_macros.mal
+++ b/impls/tests/step8_macros.mal
@@ -43,6 +43,11 @@
 `(1)
 ;=>(1)
 
+;; Testing reader macro expansion in complex expressions
+(defmacro! expansiontest (fn* () (let* [sym (symbol "s")] `(let* (~sym (list "bol")) (do (println "sym:" ~sym))))))
+(expansiontest)
+;=>sym: (bol)
+
 ;>>> deferrable=True
 ;;
 ;; -------- Deferrable Functionality --------


### PR DESCRIPTION
Pull request added per issue #560.

Test has been added to step 8 rather than step 7 in order to be able to use defmacro!.

My first pull request here: apologies in advance if I've done anything wrong: let me know and I'll try and fix it.