### PR TITLE
ada.2: stop supporting metadata for atoms

### DIFF
--- a/impls/ada.2/core.adb
+++ b/impls/ada.2/core.adb
@@ -179,10 +179,8 @@ package body Core is
                return A1.Builtin_With_Meta.all.Meta;
             when Kind_Builtin =>
                return Types.Nil;
-            when Kind_Atom =>
-               return A1.Atom.all.Meta;
             when others =>
-               Err.Raise_With ("expected an atom, function, map or sequence");
+               Err.Raise_With ("expected a function, map or sequence");
          end case;
       end;
    end Meta;
@@ -451,8 +449,6 @@ package body Core is
             when Kind_Fn =>
                return (Kind_Fn, Types.Fns.New_Function
                          (A1.Fn.all.Params, A1.Fn.all.Ast, A1.Fn.all.Env, A2));
-            when Kind_Atom =>
-               return A1.Atom.all.With_Meta (A2);
             when others =>
                Err.Raise_With
                  ("parameter 1 must be a function, map or sequence");

--- a/impls/ada.2/types-atoms.adb
+++ b/impls/ada.2/types-atoms.adb
@@ -29,11 +29,7 @@ package body Types.Atoms is
    procedure Keep_References (Object : in out Instance) is
    begin
       Keep (Object.Data);
-      Keep (Object.Meta);
    end Keep_References;
-
-   function Meta (Item : in Instance) return T
-   is (Item.F_Meta);
 
    function Reset (Args : in T_Array) return T is
    begin
@@ -65,15 +61,5 @@ package body Types.Atoms is
          return X;
       end;
    end Swap;
-
-   function With_Meta (Item     : in Instance;
-                       Metadata : in T) return T is
-      Ref : constant Atom_Ptr := new Instance;
-   begin
-      Garbage_Collected.Register (Garbage_Collected.Pointer (Ref));
-      Ref.all.Data := Item.Data;
-      Ref.all.F_Meta := Metadata;
-      return (Kind_Atom, Ref);
-   end With_Meta;
 
 end Types.Atoms;

--- a/impls/ada.2/types-atoms.ads
+++ b/impls/ada.2/types-atoms.ads
@@ -13,15 +13,10 @@ package Types.Atoms is
    --  Helper for print.
    function Deref (Item : in Instance) return T with Inline;
 
-   function With_Meta (Item     : in Instance;
-                       Metadata : in T) return T;
-   function Meta (Item : in Instance) return T;
-
 private
 
    type Instance is new Garbage_Collected.Instance with record
       Data : T;
-      F_Meta : T;
    end record;
 
    overriding procedure Keep_References (Object : in out Instance) with Inline;


### PR DESCRIPTION
This is not required anymore.