### PR TITLE
python: various simplifications

### DIFF
--- a/impls/python/env.py
+++ b/impls/python/env.py
@@ -1,32 +1,33 @@
 # Environment
+from mal_types import List
 
 class Env():
     def __init__(self, outer=None, binds=None, exprs=None):
+        """If binds is not None, exprs must be an iterable.."""
         self.data = {}
-        self.outer = outer or None
+        self.outer = outer
 
         if binds:
+            exprs_it = iter(exprs)
             for i in range(len(binds)):
                 if binds[i] == "&":
-                    self.data[binds[i+1]] = exprs[i:]
+                    # binds may be a non-list iterable
+                    self.data[binds[i+1]] = List(exprs_it)
                     break
                 else:
-                    self.data[binds[i]] = exprs[i]
-
-    def find(self, key):
-        if key in self.data: return self
-        elif self.outer:     return self.outer.find(key)
-        else:                return None
+                    self.data[binds[i]] = next(exprs_it)
 
     def set(self, key, value):
         self.data[key] = value
         return value
 
-    def get(self, key):
-        env = self.find(key)
-        if not env: raise Exception("'" + key + "' not found")
+    def get(self, key, return_nil=False):
+        # Python prefers iteration over recursion.
+        env = self
+        while key not in env.data:
+            env = env.outer
+            if env is None:
+                if return_nil:
+                    return None
+                raise Exception("'" + key + "' not found")
         return env.data[key]
-
-    def get_or_nil(self, key):
-        env = self.find(key)
-        if env: return env.data[key]

--- a/impls/python/mal_readline.py
+++ b/impls/python/mal_readline.py
@@ -1,32 +1,23 @@
-import os, sys, readline as pyreadline
+# Importing this module is sufficient for the 'input' builtin command
+# to support readline.
 
-history_loaded = False
-histfile = os.path.expanduser("~/.mal-history")
-if sys.version_info[0] >= 3:
-    rl = input
+import atexit
+import os.path
+from readline import read_history_file, set_history_length, write_history_file
+import sys
+
+if sys.version_info[0] < 3:
+    _exc = Exception
+    readline = raw_input
 else:
-    rl = raw_input
+    _exc = FileNotFoundError
+    readline = input
 
-def readline(prompt="user> "):
-    global history_loaded
-    if not history_loaded:
-        history_loaded = True
-        try:
-            with open(histfile, "r") as hf:
-                for line in hf.readlines():
-                    pyreadline.add_history(line.rstrip("\r\n"))
-                    pass
-        except IOError:
-            #print("Could not open %s" % histfile)
-            pass
+histfile = os.path.join(os.path.expanduser("~"), ".mal-history")
+try:
+    read_history_file(histfile)
+except _exc:
+    pass
+set_history_length(1000)
 
-    try:
-        line = rl(prompt)
-        pyreadline.add_history(line)
-        with open(histfile, "a") as hf:
-            hf.write(line + "\n")
-    except IOError:
-        pass
-    except EOFError:
-        return None
-    return line
+atexit.register(write_history_file, histfile)

--- a/impls/python/mal_types.py
+++ b/impls/python/mal_types.py
@@ -1,60 +1,31 @@
-import sys, copy, types as pytypes
-
-# python 3.0 differences
-if sys.hexversion > 0x3000000:
-    _u = lambda x: x
-    _s2u = lambda x: x
-else:
-    import codecs
-    _u = lambda x: codecs.unicode_escape_decode(x)[0]
-    _s2u = lambda x: unicode(x)
-
-if sys.version_info[0] >= 3:
-    str_types = [str]
-else:
-    str_types = [str, unicode]
+import copy
 
 # General functions
 
 def _equal_Q(a, b):
-    ota, otb = type(a), type(b)
-    if _string_Q(a) and _string_Q(b):
-        return a == b
-    if not (ota == otb or (_sequential_Q(a) and _sequential_Q(b))):
-        return False;
-    if _symbol_Q(a):
-        return a == b
-    elif _list_Q(a) or _vector_Q(a):
-        if len(a) != len(b): return False
-        for i in range(len(a)):
-            if not _equal_Q(a[i], b[i]): return False
-        return True
+    if _sequential_Q(a):
+        return _sequential_Q(b) \
+            and len(a) == len(b) \
+            and all(_equal_Q(a[k], b[k]) for k in range(len(a)))
     elif _hash_map_Q(a):
-        akeys = sorted(a.keys())
-        bkeys = sorted(b.keys())
-        if len(akeys) != len(bkeys): return False
-        for i in range(len(akeys)):
-            if akeys[i] != bkeys[i]: return False
-            if not _equal_Q(a[akeys[i]], b[bkeys[i]]): return False
-        return True
+        return _hash_map_Q(b) \
+            and len(a) == len(b) \
+            and all(k in b and _equal_Q(v, b[k]) for k, v in a.items())
     else:
-        return a == b
+        return type(a) == type(b) \
+            and a == b
 
 def _sequential_Q(seq): return _list_Q(seq) or _vector_Q(seq)
 
 def _clone(obj):
-    #if type(obj) == type(lambda x:x):
-    if type(obj) == pytypes.FunctionType:
-        if obj.__code__:
-            return pytypes.FunctionType(
-                    obj.__code__, obj.__globals__, name = obj.__name__,
-                    argdefs = obj.__defaults__, closure = obj.__closure__)
-        else:
-            return pytypes.FunctionType(
-                    obj.func_code, obj.func_globals, name = obj.func_name,
-                    argdefs = obj.func_defaults, closure = obj.func_closure)
-    else:
-        return copy.copy(obj)
+    if callable(obj):
+        def fn(*args):
+            return obj(*args)
+        if hasattr(obj, '__ast__'):
+            fn.__ast__ = obj.__ast__
+            fn.__gen_env__ = obj.__gen_env__
+        return fn
+    return copy.copy(obj)
 
 #
 # Exception type
@@ -69,75 +40,61 @@ def _nil_Q(exp):    return exp is None
 def _true_Q(exp):   return exp is True
 def _false_Q(exp):  return exp is False
 def _string_Q(exp):
-    if type(exp) in str_types:
-        return len(exp) == 0 or exp[0] != _u("\u029e")
-    else:
-        return False
+    return type(exp) == str and not exp.startswith(keywordPrefix)
 def _number_Q(exp): return type(exp) == int
 
 # Symbols
 class Symbol(str): pass
-def _symbol(str): return Symbol(str)
+_symbol = Symbol
 def _symbol_Q(exp): return type(exp) == Symbol
 
 # Keywords
 # A specially prefixed string
+keywordPrefix = '\x7F'
 def _keyword(str):
-    if str[0] == _u("\u029e"): return str
-    else:                      return _u("\u029e") + str
-def _keyword_Q(exp):
-    if type(exp) in str_types:
-        return len(exp) != 0 and exp[0] == _u("\u029e")
+    if str.startswith(keywordPrefix):
+        return str
     else:
-        return False
+        return keywordPrefix + str
+def _keyword_Q(exp):
+    return type(exp) == str and exp.startswith(keywordPrefix)
 
 # Functions
-def _function(Eval, Env, ast, env, params):
-    def fn(*args):
-        return Eval(ast, Env(env, params, List(args)))
-    fn.__meta__ = None
-    fn.__ast__ = ast
-    fn.__gen_env__ = lambda args: Env(env, params, args)
-    return fn
-def _function_Q(f):
-    return callable(f)
+# are just python functions, with
+# * no attributes (core functions)
+# * __ast__ and __gen_env__ attributes (user-defined functions)
+# * __ast__, __gen_env__ and _ismacro_ attributes (macro).
+_function_Q = callable
 
 # lists
-class List(list):
-    def __add__(self, rhs): return List(list.__add__(self, rhs))
-    def __getitem__(self, i):
-        if type(i) == slice: return List(list.__getitem__(self, i))
-        elif i >= len(self): return None
-        else:                return list.__getitem__(self, i)
-    def __getslice__(self, *a): return List(list.__getslice__(self, *a))
+class List(tuple):
+    pass
 def _list(*vals): return List(vals)
 def _list_Q(exp):   return type(exp) == List
 
 
 # vectors
-class Vector(list):
-    def __add__(self, rhs): return Vector(list.__add__(self, rhs))
-    def __getitem__(self, i):
-        if type(i) == slice: return Vector(list.__getitem__(self, i))
-        elif i >= len(self): return None
-        else:                return list.__getitem__(self, i)
-    def __getslice__(self, *a): return Vector(list.__getslice__(self, *a))
+class Vector(tuple):
+    pass
 def _vector(*vals): return Vector(vals)
 def _vector_Q(exp): return type(exp) == Vector
 
 # Hash maps
 class Hash_Map(dict): pass
 def _hash_map(*key_vals):
-    hm = Hash_Map()
-    for i in range(0,len(key_vals),2): hm[key_vals[i]] = key_vals[i+1]
-    return hm
+    return Hash_Map(asPairs(key_vals))
 def _hash_map_Q(exp): return type(exp) == Hash_Map
+
+def asPairs(iterable):
+    """ k0, v0, k1, v1..  ->  (k0, v0), (k1, v1).. """
+    it = iter(iterable)
+    return zip(it, it)
 
 # atoms
 class Atom(object):
     def __init__(self, val):
         self.val = val
-def _atom(val): return Atom(val)
+_atom = Atom
 def _atom_Q(exp):   return type(exp) == Atom
 
 def py_to_mal(obj):

--- a/impls/python/printer.py
+++ b/impls/python/printer.py
@@ -1,3 +1,5 @@
+from itertools import chain
+
 import mal_types as types
 
 def _escape(s):
@@ -6,18 +8,16 @@ def _escape(s):
 def _pr_str(obj, print_readably=True):
     _r = print_readably
     if types._list_Q(obj):
-        return "(" + " ".join(map(lambda e: _pr_str(e,_r), obj)) + ")"
-    elif types._vector_Q(obj):                                    
-        return "[" + " ".join(map(lambda e: _pr_str(e,_r), obj)) + "]"
+        return "(" + pr_list(obj, " ", _r) + ")"
+    elif types._vector_Q(obj):
+        return "[" + pr_list(obj, " ", _r) + "]"
     elif types._hash_map_Q(obj):
-        ret = []
-        for k in obj.keys():
-            ret.extend((_pr_str(k), _pr_str(obj[k],_r)))
-        return "{" + " ".join(ret) + "}"
-    elif type(obj) in types.str_types:
-        if len(obj) > 0 and obj[0] == types._u('\u029e'):
-            return ':' + obj[1:]
-        elif print_readably:
+        ret = pr_list(chain.from_iterable(obj.items()), " ", _r)
+        return "{" + ret + "}"
+    elif types._keyword_Q(obj):
+        return ':' + obj[1:]
+    elif types._string_Q(obj):
+        if _r:
             return '"' + _escape(obj) + '"'
         else:
             return obj
@@ -30,5 +30,7 @@ def _pr_str(obj, print_readably=True):
     elif types._atom_Q(obj):
         return "(atom " + _pr_str(obj.val,_r) + ")"
     else:
-        return obj.__str__()
+        return str(obj)
 
+def pr_list(iterable, separator, readably):
+    return separator.join(_pr_str(exp, readably) for exp in iterable)

--- a/impls/python/reader.py
+++ b/impls/python/reader.py
@@ -1,5 +1,6 @@
 import re
-from mal_types import (_symbol, _keyword, _list, _vector, _hash_map, _s2u, _u)
+
+from mal_types import (_symbol, _keyword, _list, List, Vector, Hash_Map, asPairs)
 
 class Blank(Exception): pass
 
@@ -23,7 +24,7 @@ def tokenize(str):
     return [t for t in re.findall(tre, str) if t[0] != ';']
 
 def _unescape(s):
-    return s.replace('\\\\', _u('\u029e')).replace('\\"', '"').replace('\\n', '\n').replace(_u('\u029e'), '\\')
+    return s.replace('\\\\', '\b').replace('\\"', '"').replace('\\n', '\n').replace('\b', '\\')
 
 def read_atom(reader):
     int_re = re.compile(r"-?[0-9]+$")
@@ -31,8 +32,8 @@ def read_atom(reader):
     string_re = re.compile(r'"(?:[\\].|[^\\"])*"')
     token = reader.next()
     if re.match(int_re, token):     return int(token)
-    elif re.match(float_re, token): return float(token)
-    elif re.match(string_re, token):return _s2u(_unescape(token[1:-1]))
+    elif re.match(float_re, token): return int(token)
+    elif re.match(string_re, token):return _unescape(token[1:-1])
     elif token[0] == '"':           raise Exception("expected '\"', got EOF")
     elif token[0] == ':':           return _keyword(token[1:])
     elif token == "nil":            return None
@@ -40,28 +41,26 @@ def read_atom(reader):
     elif token == "false":          return False
     else:                           return _symbol(token)
 
-def read_sequence(reader, typ=list, start='(', end=')'):
-    ast = typ()
+def read_sequence(reader, start='(', end=')'):
     token = reader.next()
     if token != start: raise Exception("expected '" + start + "'")
 
     token = reader.peek()
     while token != end:
         if not token: raise Exception("expected '" + end + "', got EOF")
-        ast.append(read_form(reader))
+        yield read_form(reader)
         token = reader.peek()
     reader.next()
-    return ast
 
 def read_hash_map(reader):
-    lst = read_sequence(reader, list, '{', '}')
-    return _hash_map(*lst)
+    lst = read_sequence(reader, '{', '}')
+    return Hash_Map(asPairs(lst))
 
 def read_list(reader):
-    return read_sequence(reader, _list, '(', ')')
+    return List(read_sequence(reader, '(', ')'))
 
 def read_vector(reader):
-    return read_sequence(reader, _vector, '[', ']')
+    return Vector(read_sequence(reader, '[', ']'))
 
 def read_form(reader):
     token = reader.peek()

--- a/impls/python/step0_repl.py
+++ b/impls/python/step0_repl.py
@@ -6,8 +6,7 @@ def READ(str):
     return str
 
 # eval
-def EVAL(ast, env):
-        #print("EVAL %s" % printer._pr_str(ast))
+def EVAL(ast):
         return ast
 
 # print
@@ -16,14 +15,15 @@ def PRINT(exp):
 
 # repl
 def REP(str):
-    return PRINT(EVAL(READ(str), {}))
+    return PRINT(EVAL(READ(str)))
 
 # repl loop
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
-    except Exception as e:
+    except EOFError:
+        print()
+        break
+    except Exception:
         print("".join(traceback.format_exception(*sys.exc_info())))

--- a/impls/python/step1_read_print.py
+++ b/impls/python/step1_read_print.py
@@ -1,32 +1,29 @@
 import sys, traceback
 import mal_readline
-import mal_types as types
 import reader, printer
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
-def EVAL(ast, env):
-        #print("EVAL %s" % printer._pr_str(ast))
+def EVAL(ast):
         return ast
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 def REP(str):
-    return PRINT(EVAL(READ(str), {}))
+    return PRINT(EVAL(READ(str)))
 
 # repl loop
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
-    except Exception as e:
+    except Exception:
         print("".join(traceback.format_exception(*sys.exc_info())))

--- a/impls/python/step2_eval.py
+++ b/impls/python/step2_eval.py
@@ -4,8 +4,7 @@ import mal_types as types
 import reader, printer
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
 def EVAL(ast, env):
@@ -17,7 +16,7 @@ def EVAL(ast, env):
         except:
             raise Exception("'" + ast + "' not found")
     elif types._vector_Q(ast):
-        return types._vector(*map(lambda a: EVAL(a, env), ast))
+        return types.Vector(EVAL(a, env) for a in ast)
     elif types._hash_map_Q(ast):
         return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     elif not types._list_Q(ast):
@@ -31,8 +30,7 @@ def EVAL(ast, env):
         return f(*(EVAL(a, env) for a in args))
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 repl_env = {}
@@ -42,15 +40,16 @@ def REP(str):
 repl_env['+'] = lambda a,b: a+b
 repl_env['-'] = lambda a,b: a-b
 repl_env['*'] = lambda a,b: a*b
-repl_env['/'] = lambda a,b: int(a/b)
+repl_env['/'] = lambda a,b: a//b
 
 # repl loop
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
-    except Exception as e:
+    except Exception:
         print("".join(traceback.format_exception(*sys.exc_info())))

--- a/impls/python/step3_env.py
+++ b/impls/python/step3_env.py
@@ -5,19 +5,18 @@ import reader, printer
 from env import Env
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
 def EVAL(ast, env):
-    dbgeval = env.get_or_nil('DEBUG-EVAL')
+    dbgeval = env.get(types._symbol('DEBUG-EVAL'), return_nil=True)
     if dbgeval is not None and dbgeval is not False:
         print('EVAL: ' + printer._pr_str(ast))
 
     if types._symbol_Q(ast):
         return env.get(ast)
     elif types._vector_Q(ast):
-        return types._vector(*map(lambda a: EVAL(a, env), ast))
+        return types.Vector(EVAL(a, env) for a in ast)
     elif types._hash_map_Q(ast):
         return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     elif not types._list_Q(ast):
@@ -28,6 +27,7 @@ def EVAL(ast, env):
         if len(ast) == 0: return ast
         a0 = ast[0]
 
+    if types._symbol_Q(a0):
         if "def!" == a0:
             a1, a2 = ast[1], ast[2]
             res = EVAL(a2, env)
@@ -35,17 +35,19 @@ def EVAL(ast, env):
         elif "let*" == a0:
             a1, a2 = ast[1], ast[2]
             let_env = Env(env)
-            for i in range(0, len(a1), 2):
-                let_env.set(a1[i], EVAL(a1[i+1], let_env))
+            for k, v in types.asPairs(a1):
+                let_env.set(k, EVAL(v, let_env))
             return EVAL(a2, let_env)
-        else:
-            f = EVAL(a0, env)
+
+    f = EVAL(a0, env)
+    if types._function_Q(f):
             args = ast[1:]
             return f(*(EVAL(a, env) for a in args))
+    else:
+        raise Exception('Can only apply functions')
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 repl_env = Env()
@@ -55,15 +57,16 @@ def REP(str):
 repl_env.set(types._symbol('+'), lambda a,b: a+b)
 repl_env.set(types._symbol('-'), lambda a,b: a-b)
 repl_env.set(types._symbol('*'), lambda a,b: a*b)
-repl_env.set(types._symbol('/'), lambda a,b: int(a/b))
+repl_env.set(types._symbol('/'), lambda a,b: a//b)
 
 # repl loop
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
-    except Exception as e:
+    except Exception:
         print("".join(traceback.format_exception(*sys.exc_info())))

--- a/impls/python/step4_if_fn_do.py
+++ b/impls/python/step4_if_fn_do.py
@@ -6,19 +6,18 @@ from env import Env
 import core
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
 def EVAL(ast, env):
-    dbgeval = env.get_or_nil('DEBUG-EVAL')
+    dbgeval = env.get(types._symbol('DEBUG-EVAL'), return_nil=True)
     if dbgeval is not None and dbgeval is not False:
         print('EVAL: ' + printer._pr_str(ast))
 
     if types._symbol_Q(ast):
         return env.get(ast)
     elif types._vector_Q(ast):
-        return types._vector(*map(lambda a: EVAL(a, env), ast))
+        return types.Vector(EVAL(a, env) for a in ast)
     elif types._hash_map_Q(ast):
         return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     elif not types._list_Q(ast):
@@ -29,6 +28,7 @@ def EVAL(ast, env):
         if len(ast) == 0: return ast
         a0 = ast[0]
 
+    if types._symbol_Q(a0):
         if "def!" == a0:
             a1, a2 = ast[1], ast[2]
             res = EVAL(a2, env)
@@ -36,8 +36,8 @@ def EVAL(ast, env):
         elif "let*" == a0:
             a1, a2 = ast[1], ast[2]
             let_env = Env(env)
-            for i in range(0, len(a1), 2):
-                let_env.set(a1[i], EVAL(a1[i+1], let_env))
+            for k, v in types.asPairs(a1):
+                let_env.set(k, EVAL(v, let_env))
             return EVAL(a2, let_env)
         elif "do" == a0:
             for i in range(1, len(ast)-1):
@@ -47,21 +47,27 @@ def EVAL(ast, env):
             a1, a2 = ast[1], ast[2]
             cond = EVAL(a1, env)
             if cond is None or cond is False:
-                if len(ast) > 3: return EVAL(ast[3], env)
-                else:            return None
+                if len(ast) > 3:
+                    return EVAL(ast[3], env)
+                else:
+                    return None
             else:
                 return EVAL(a2, env)
         elif "fn*" == a0:
             a1, a2 = ast[1], ast[2]
-            return types._function(EVAL, Env, a2, env, a1)
-        else:
-            f = EVAL(a0, env)
+            def fn(*args):
+                return EVAL(a2, Env(env, a1, args))
+            return fn
+
+    f = EVAL(a0, env)
+    if types._function_Q(f):
             args = ast[1:]
             return f(*(EVAL(a, env) for a in args))
+    else:
+        raise Exception('Can only apply functions')
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 repl_env = Env()
@@ -78,9 +84,10 @@ REP("(def! not (fn* (a) (if a false true)))")
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
-    except Exception as e:
+    except Exception:
         print("".join(traceback.format_exception(*sys.exc_info())))

--- a/impls/python/step5_tco.py
+++ b/impls/python/step5_tco.py
@@ -6,21 +6,20 @@ from env import Env
 import core
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
 def EVAL(ast, env):
   while True:
 
-    dbgeval = env.get_or_nil('DEBUG-EVAL')
+    dbgeval = env.get(types._symbol('DEBUG-EVAL'), return_nil=True)
     if dbgeval is not None and dbgeval is not False:
         print('EVAL: ' + printer._pr_str(ast))
 
     if types._symbol_Q(ast):
         return env.get(ast)
     elif types._vector_Q(ast):
-        return types._vector(*map(lambda a: EVAL(a, env), ast))
+        return types.Vector(EVAL(a, env) for a in ast)
     elif types._hash_map_Q(ast):
         return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     elif not types._list_Q(ast):
@@ -31,6 +30,7 @@ def EVAL(ast, env):
         if len(ast) == 0: return ast
         a0 = ast[0]
 
+    if types._symbol_Q(a0):
         if "def!" == a0:
             a1, a2 = ast[1], ast[2]
             res = EVAL(a2, env)
@@ -38,40 +38,50 @@ def EVAL(ast, env):
         elif "let*" == a0:
             a1, a2 = ast[1], ast[2]
             let_env = Env(env)
-            for i in range(0, len(a1), 2):
-                let_env.set(a1[i], EVAL(a1[i+1], let_env))
+            for k, v in types.asPairs(a1):
+                let_env.set(k, EVAL(v, let_env))
             ast = a2
             env = let_env
-            # Continue loop (TCO)
+            continue # TCO
         elif "do" == a0:
             for i in range(1, len(ast)-1):
                 EVAL(ast[i], env)
             ast = ast[-1]
-            # Continue loop (TCO)
+            continue # TCO
         elif "if" == a0:
             a1, a2 = ast[1], ast[2]
             cond = EVAL(a1, env)
             if cond is None or cond is False:
-                if len(ast) > 3: ast = ast[3]
-                else:            ast = None
+                if len(ast) > 3:
+                    ast = ast[3]
+                    continue # TCO
+                else:
+                    return None
             else:
                 ast = a2
-            # Continue loop (TCO)
+                continue # TCO
         elif "fn*" == a0:
             a1, a2 = ast[1], ast[2]
-            return types._function(EVAL, Env, a2, env, a1)
-        else:
-            f = EVAL(a0, env)
+            def fn(*args):
+                return EVAL(a2, Env(env, a1, args))
+            fn.__ast__ = a2
+            fn.__gen_env__ = lambda args: Env(env, a1, args)
+            return fn
+
+    f = EVAL(a0, env)
+    if types._function_Q(f):
             args = ast[1:]
             if hasattr(f, '__ast__'):
                 ast = f.__ast__
-                env = f.__gen_env__(types.List(EVAL(a, env) for a in args))
+                env = f.__gen_env__(EVAL(a, env) for a in args)
+                continue # TCO
             else:
                 return f(*(EVAL(a, env) for a in args))
+    else:
+        raise Exception('Can only apply functions')
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 repl_env = Env()
@@ -88,9 +98,11 @@ REP("(def! not (fn* (a) (if a false true)))")
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
-    except Exception as e:
+    except Exception:
+        # See tests/step5_tco.mal in this directory.
         print("".join(traceback.format_exception(*sys.exc_info())[0:100]))

--- a/impls/python/step6_file.py
+++ b/impls/python/step6_file.py
@@ -6,21 +6,20 @@ from env import Env
 import core
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
 def EVAL(ast, env):
   while True:
 
-    dbgeval = env.get_or_nil('DEBUG-EVAL')
+    dbgeval = env.get(types._symbol('DEBUG-EVAL'), return_nil=True)
     if dbgeval is not None and dbgeval is not False:
         print('EVAL: ' + printer._pr_str(ast))
 
     if types._symbol_Q(ast):
         return env.get(ast)
     elif types._vector_Q(ast):
-        return types._vector(*map(lambda a: EVAL(a, env), ast))
+        return types.Vector(EVAL(a, env) for a in ast)
     elif types._hash_map_Q(ast):
         return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     elif not types._list_Q(ast):
@@ -31,6 +30,7 @@ def EVAL(ast, env):
         if len(ast) == 0: return ast
         a0 = ast[0]
 
+    if types._symbol_Q(a0):
         if "def!" == a0:
             a1, a2 = ast[1], ast[2]
             res = EVAL(a2, env)
@@ -38,40 +38,50 @@ def EVAL(ast, env):
         elif "let*" == a0:
             a1, a2 = ast[1], ast[2]
             let_env = Env(env)
-            for i in range(0, len(a1), 2):
-                let_env.set(a1[i], EVAL(a1[i+1], let_env))
+            for k, v in types.asPairs(a1):
+                let_env.set(k, EVAL(v, let_env))
             ast = a2
             env = let_env
-            # Continue loop (TCO)
+            continue # TCO
         elif "do" == a0:
             for i in range(1, len(ast)-1):
                 EVAL(ast[i], env)
             ast = ast[-1]
-            # Continue loop (TCO)
+            continue # TCO
         elif "if" == a0:
             a1, a2 = ast[1], ast[2]
             cond = EVAL(a1, env)
             if cond is None or cond is False:
-                if len(ast) > 3: ast = ast[3]
-                else:            ast = None
+                if len(ast) > 3:
+                    ast = ast[3]
+                    continue # TCO
+                else:
+                    return None
             else:
                 ast = a2
-            # Continue loop (TCO)
+                continue # TCO
         elif "fn*" == a0:
             a1, a2 = ast[1], ast[2]
-            return types._function(EVAL, Env, a2, env, a1)
-        else:
-            f = EVAL(a0, env)
+            def fn(*args):
+                return EVAL(a2, Env(env, a1, args))
+            fn.__ast__ = a2
+            fn.__gen_env__ = lambda args: Env(env, a1, args)
+            return fn
+
+    f = EVAL(a0, env)
+    if types._function_Q(f):
             args = ast[1:]
             if hasattr(f, '__ast__'):
                 ast = f.__ast__
-                env = f.__gen_env__(types.List(EVAL(a, env) for a in args))
+                env = f.__gen_env__(EVAL(a, env) for a in args)
+                continue # TCO
             else:
                 return f(*(EVAL(a, env) for a in args))
+    else:
+        raise Exception('Can only apply functions')
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 repl_env = Env()
@@ -81,11 +91,11 @@ def REP(str):
 # core.py: defined using python
 for k, v in core.ns.items(): repl_env.set(types._symbol(k), v)
 repl_env.set(types._symbol('eval'), lambda ast: EVAL(ast, repl_env))
-repl_env.set(types._symbol('*ARGV*'), types._list(*sys.argv[2:]))
+repl_env.set(types._symbol('*ARGV*'), types.List(sys.argv[2:]))
 
 # core.mal: defined using the language itself
 REP("(def! not (fn* (a) (if a false true)))")
-REP("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))")
+REP('(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) "\nnil)")))))')
 
 if len(sys.argv) >= 2:
     REP('(load-file "' + sys.argv[1] + '")')
@@ -95,9 +105,11 @@ if len(sys.argv) >= 2:
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
-    except Exception as e:
-        print("".join(traceback.format_exception(*sys.exc_info())))
+    except Exception:
+        # See tests/step5_tco.mal in this directory.
+        print("".join(traceback.format_exception(*sys.exc_info())[0:100]))

--- a/impls/python/step7_quote.py
+++ b/impls/python/step7_quote.py
@@ -7,43 +7,47 @@ from env import Env
 import core
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
 def qq_loop(acc, elt):
-    if types._list_Q(elt) and len(elt) == 2 and elt[0] == u'splice-unquote':
-        return types._list(types._symbol(u'concat'), elt[1], acc)
+    if types._list_Q(elt) \
+       and len(elt) == 2 \
+       and types._symbol_Q(elt[0]) \
+       and elt[0] == 'splice-unquote':
+        return types._list(types._symbol('concat'), elt[1], acc)
     else:
-        return types._list(types._symbol(u'cons'), quasiquote(elt), acc)
+        return types._list(types._symbol('cons'), quasiquote(elt), acc)
 
 def qq_foldr(seq):
     return functools.reduce(qq_loop, reversed(seq), types._list())
 
 def quasiquote(ast):
     if types._list_Q(ast):
-        if len(ast) == 2 and ast[0] == u'unquote':
+        if len(ast) == 2 \
+           and types._symbol_Q(ast[0]) \
+           and ast[0] == 'unquote':
             return ast[1]
         else:
             return qq_foldr(ast)
     elif types._hash_map_Q(ast) or types._symbol_Q(ast):
-        return types._list(types._symbol(u'quote'), ast)
-    elif types._vector_Q (ast):
-        return types._list(types._symbol(u'vec'), qq_foldr(ast))
+        return types._list(types._symbol('quote'), ast)
+    elif types._vector_Q(ast):
+        return types._list(types._symbol('vec'), qq_foldr(ast))
     else:
         return ast
 
 def EVAL(ast, env):
   while True:
 
-    dbgeval = env.get_or_nil('DEBUG-EVAL')
+    dbgeval = env.get(types._symbol('DEBUG-EVAL'), return_nil=True)
     if dbgeval is not None and dbgeval is not False:
         print('EVAL: ' + printer._pr_str(ast))
 
     if types._symbol_Q(ast):
         return env.get(ast)
     elif types._vector_Q(ast):
-        return types._vector(*map(lambda a: EVAL(a, env), ast))
+        return types.Vector(EVAL(a, env) for a in ast)
     elif types._hash_map_Q(ast):
         return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     elif not types._list_Q(ast):
@@ -54,6 +58,7 @@ def EVAL(ast, env):
         if len(ast) == 0: return ast
         a0 = ast[0]
 
+    if types._symbol_Q(a0):
         if "def!" == a0:
             a1, a2 = ast[1], ast[2]
             res = EVAL(a2, env)
@@ -61,45 +66,55 @@ def EVAL(ast, env):
         elif "let*" == a0:
             a1, a2 = ast[1], ast[2]
             let_env = Env(env)
-            for i in range(0, len(a1), 2):
-                let_env.set(a1[i], EVAL(a1[i+1], let_env))
+            for k, v in types.asPairs(a1):
+                let_env.set(k, EVAL(v, let_env))
             ast = a2
             env = let_env
-            # Continue loop (TCO)
+            continue # TCO
         elif "quote" == a0:
             return ast[1]
         elif "quasiquote" == a0:
-            ast = quasiquote(ast[1]);
-            # Continue loop (TCO)
+            ast = quasiquote(ast[1])
+            continue # TCO
         elif "do" == a0:
             for i in range(1, len(ast)-1):
                 EVAL(ast[i], env)
             ast = ast[-1]
-            # Continue loop (TCO)
+            continue # TCO
         elif "if" == a0:
             a1, a2 = ast[1], ast[2]
             cond = EVAL(a1, env)
             if cond is None or cond is False:
-                if len(ast) > 3: ast = ast[3]
-                else:            ast = None
+                if len(ast) > 3:
+                    ast = ast[3]
+                    continue # TCO
+                else:
+                    return None
             else:
                 ast = a2
-            # Continue loop (TCO)
+                continue # TCO
         elif "fn*" == a0:
             a1, a2 = ast[1], ast[2]
-            return types._function(EVAL, Env, a2, env, a1)
-        else:
-            f = EVAL(a0, env)
+            def fn(*args):
+                return EVAL(a2, Env(env, a1, args))
+            fn.__ast__ = a2
+            fn.__gen_env__ = lambda args: Env(env, a1, args)
+            return fn
+
+    f = EVAL(a0, env)
+    if types._function_Q(f):
             args = ast[1:]
             if hasattr(f, '__ast__'):
                 ast = f.__ast__
-                env = f.__gen_env__(types.List(EVAL(a, env) for a in args))
+                env = f.__gen_env__(EVAL(a, env) for a in args)
+                continue # TCO
             else:
                 return f(*(EVAL(a, env) for a in args))
+    else:
+        raise Exception('Can only apply functions')
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 repl_env = Env()
@@ -109,11 +124,11 @@ def REP(str):
 # core.py: defined using python
 for k, v in core.ns.items(): repl_env.set(types._symbol(k), v)
 repl_env.set(types._symbol('eval'), lambda ast: EVAL(ast, repl_env))
-repl_env.set(types._symbol('*ARGV*'), types._list(*sys.argv[2:]))
+repl_env.set(types._symbol('*ARGV*'), types.List(sys.argv[2:]))
 
 # core.mal: defined using the language itself
 REP("(def! not (fn* (a) (if a false true)))")
-REP("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))")
+REP('(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) "\nnil)")))))')
 
 if len(sys.argv) >= 2:
     REP('(load-file "' + sys.argv[1] + '")')
@@ -123,9 +138,11 @@ if len(sys.argv) >= 2:
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
-    except Exception as e:
-        print("".join(traceback.format_exception(*sys.exc_info())))
+    except Exception:
+        # See tests/step5_tco.mal in this directory.
+        print("".join(traceback.format_exception(*sys.exc_info())[0:100]))

--- a/impls/python/step8_macros.py
+++ b/impls/python/step8_macros.py
@@ -7,43 +7,47 @@ from env import Env
 import core
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
 def qq_loop(acc, elt):
-    if types._list_Q(elt) and len(elt) == 2 and elt[0] == u'splice-unquote':
-        return types._list(types._symbol(u'concat'), elt[1], acc)
+    if types._list_Q(elt) \
+       and len(elt) == 2 \
+       and types._symbol_Q(elt[0]) \
+       and elt[0] == 'splice-unquote':
+        return types._list(types._symbol('concat'), elt[1], acc)
     else:
-        return types._list(types._symbol(u'cons'), quasiquote(elt), acc)
+        return types._list(types._symbol('cons'), quasiquote(elt), acc)
 
 def qq_foldr(seq):
     return functools.reduce(qq_loop, reversed(seq), types._list())
 
 def quasiquote(ast):
     if types._list_Q(ast):
-        if len(ast) == 2 and ast[0] == u'unquote':
+        if len(ast) == 2 \
+           and types._symbol_Q(ast[0]) \
+           and ast[0] == 'unquote':
             return ast[1]
         else:
             return qq_foldr(ast)
     elif types._hash_map_Q(ast) or types._symbol_Q(ast):
-        return types._list(types._symbol(u'quote'), ast)
-    elif types._vector_Q (ast):
-        return types._list(types._symbol(u'vec'), qq_foldr(ast))
+        return types._list(types._symbol('quote'), ast)
+    elif types._vector_Q(ast):
+        return types._list(types._symbol('vec'), qq_foldr(ast))
     else:
         return ast
 
 def EVAL(ast, env):
   while True:
 
-    dbgeval = env.get_or_nil('DEBUG-EVAL')
+    dbgeval = env.get(types._symbol('DEBUG-EVAL'), return_nil=True)
     if dbgeval is not None and dbgeval is not False:
         print('EVAL: ' + printer._pr_str(ast))
 
     if types._symbol_Q(ast):
         return env.get(ast)
     elif types._vector_Q(ast):
-        return types._vector(*map(lambda a: EVAL(a, env), ast))
+        return types.Vector(EVAL(a, env) for a in ast)
     elif types._hash_map_Q(ast):
         return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     elif not types._list_Q(ast):
@@ -54,6 +58,7 @@ def EVAL(ast, env):
         if len(ast) == 0: return ast
         a0 = ast[0]
 
+    if types._symbol_Q(a0):
         if "def!" == a0:
             a1, a2 = ast[1], ast[2]
             res = EVAL(a2, env)
@@ -61,52 +66,63 @@ def EVAL(ast, env):
         elif "let*" == a0:
             a1, a2 = ast[1], ast[2]
             let_env = Env(env)
-            for i in range(0, len(a1), 2):
-                let_env.set(a1[i], EVAL(a1[i+1], let_env))
+            for k, v in types.asPairs(a1):
+                let_env.set(k, EVAL(v, let_env))
             ast = a2
             env = let_env
-            # Continue loop (TCO)
+            continue # TCO
         elif "quote" == a0:
             return ast[1]
         elif "quasiquote" == a0:
-            ast = quasiquote(ast[1]);
-            # Continue loop (TCO)
+            ast = quasiquote(ast[1])
+            continue # TCO
         elif 'defmacro!' == a0:
-            func = types._clone(EVAL(ast[2], env))
+            func = EVAL(ast[2], env)
+            func = types._clone(func)
             func._ismacro_ = True
             return env.set(ast[1], func)
         elif "do" == a0:
             for i in range(1, len(ast)-1):
                 EVAL(ast[i], env)
             ast = ast[-1]
-            # Continue loop (TCO)
+            continue # TCO
         elif "if" == a0:
             a1, a2 = ast[1], ast[2]
             cond = EVAL(a1, env)
             if cond is None or cond is False:
-                if len(ast) > 3: ast = ast[3]
-                else:            ast = None
+                if len(ast) > 3:
+                    ast = ast[3]
+                    continue # TCO
+                else:
+                    return None
             else:
                 ast = a2
-            # Continue loop (TCO)
+                continue # TCO
         elif "fn*" == a0:
             a1, a2 = ast[1], ast[2]
-            return types._function(EVAL, Env, a2, env, a1)
-        else:
-            f = EVAL(a0, env)
+            def fn(*args):
+                return EVAL(a2, Env(env, a1, args))
+            fn.__ast__ = a2
+            fn.__gen_env__ = lambda args: Env(env, a1, args)
+            return fn
+
+    f = EVAL(a0, env)
+    if types._function_Q(f):
             args = ast[1:]
             if hasattr(f, '_ismacro_'):
                 ast = f(*args)
                 continue # TCO
             if hasattr(f, '__ast__'):
                 ast = f.__ast__
-                env = f.__gen_env__(types.List(EVAL(a, env) for a in args))
+                env = f.__gen_env__(EVAL(a, env) for a in args)
+                continue # TCO
             else:
                 return f(*(EVAL(a, env) for a in args))
+    else:
+        raise Exception('Can only apply functions')
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 repl_env = Env()
@@ -116,12 +132,16 @@ def REP(str):
 # core.py: defined using python
 for k, v in core.ns.items(): repl_env.set(types._symbol(k), v)
 repl_env.set(types._symbol('eval'), lambda ast: EVAL(ast, repl_env))
-repl_env.set(types._symbol('*ARGV*'), types._list(*sys.argv[2:]))
+repl_env.set(types._symbol('*ARGV*'), types.List(sys.argv[2:]))
 
 # core.mal: defined using the language itself
 REP("(def! not (fn* (a) (if a false true)))")
-REP("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))")
-REP("(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))")
+REP('(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) "\nnil)")))))')
+REP("""(defmacro! cond (fn* (& xs)
+  (if (> (count xs) 0)
+    (list 'if (first xs)
+      (if (> (count xs) 1) (nth xs 1) (throw "odd number of forms to cond"))
+      (cons 'cond (rest (rest xs)))))))""")
 
 if len(sys.argv) >= 2:
     REP('(load-file "' + sys.argv[1] + '")')
@@ -131,9 +151,11 @@ if len(sys.argv) >= 2:
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
-    except Exception as e:
-        print("".join(traceback.format_exception(*sys.exc_info())))
+    except Exception:
+        # See tests/step5_tco.mal in this directory.
+        print("".join(traceback.format_exception(*sys.exc_info())[0:100]))

--- a/impls/python/step9_try.py
+++ b/impls/python/step9_try.py
@@ -7,43 +7,47 @@ from env import Env
 import core
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
 def qq_loop(acc, elt):
-    if types._list_Q(elt) and len(elt) == 2 and elt[0] == u'splice-unquote':
-        return types._list(types._symbol(u'concat'), elt[1], acc)
+    if types._list_Q(elt) \
+       and len(elt) == 2 \
+       and types._symbol_Q(elt[0]) \
+       and elt[0] == 'splice-unquote':
+        return types._list(types._symbol('concat'), elt[1], acc)
     else:
-        return types._list(types._symbol(u'cons'), quasiquote(elt), acc)
+        return types._list(types._symbol('cons'), quasiquote(elt), acc)
 
 def qq_foldr(seq):
     return functools.reduce(qq_loop, reversed(seq), types._list())
 
 def quasiquote(ast):
     if types._list_Q(ast):
-        if len(ast) == 2 and ast[0] == u'unquote':
+        if len(ast) == 2 \
+           and types._symbol_Q(ast[0]) \
+           and ast[0] == 'unquote':
             return ast[1]
         else:
             return qq_foldr(ast)
     elif types._hash_map_Q(ast) or types._symbol_Q(ast):
-        return types._list(types._symbol(u'quote'), ast)
-    elif types._vector_Q (ast):
-        return types._list(types._symbol(u'vec'), qq_foldr(ast))
+        return types._list(types._symbol('quote'), ast)
+    elif types._vector_Q(ast):
+        return types._list(types._symbol('vec'), qq_foldr(ast))
     else:
         return ast
 
 def EVAL(ast, env):
   while True:
 
-    dbgeval = env.get_or_nil('DEBUG-EVAL')
+    dbgeval = env.get(types._symbol('DEBUG-EVAL'), return_nil=True)
     if dbgeval is not None and dbgeval is not False:
         print('EVAL: ' + printer._pr_str(ast))
 
     if types._symbol_Q(ast):
         return env.get(ast)
     elif types._vector_Q(ast):
-        return types._vector(*map(lambda a: EVAL(a, env), ast))
+        return types.Vector(EVAL(a, env) for a in ast)
     elif types._hash_map_Q(ast):
         return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     elif not types._list_Q(ast):
@@ -54,6 +58,7 @@ def EVAL(ast, env):
         if len(ast) == 0: return ast
         a0 = ast[0]
 
+    if types._symbol_Q(a0):
         if "def!" == a0:
             a1, a2 = ast[1], ast[2]
             res = EVAL(a2, env)
@@ -61,28 +66,27 @@ def EVAL(ast, env):
         elif "let*" == a0:
             a1, a2 = ast[1], ast[2]
             let_env = Env(env)
-            for i in range(0, len(a1), 2):
-                let_env.set(a1[i], EVAL(a1[i+1], let_env))
+            for k, v in types.asPairs(a1):
+                let_env.set(k, EVAL(v, let_env))
             ast = a2
             env = let_env
-            # Continue loop (TCO)
+            continue # TCO
         elif "quote" == a0:
             return ast[1]
         elif "quasiquote" == a0:
-            ast = quasiquote(ast[1]);
-            # Continue loop (TCO)
+            ast = quasiquote(ast[1])
+            continue # TCO
         elif 'defmacro!' == a0:
-            func = types._clone(EVAL(ast[2], env))
+            func = EVAL(ast[2], env)
+            func = types._clone(func)
             func._ismacro_ = True
             return env.set(ast[1], func)
-        elif "py!*" == a0:
-            exec(compile(ast[1], '', 'single'), globals())
-            return None
         elif "try*" == a0:
             if len(ast) < 3:
-                return EVAL(ast[1], env)
-            a1, a2 = ast[1], ast[2]
-            if a2[0] == "catch*":
+                ast = ast[1]
+                continue # TCO
+            else:
+                a1, a2 = ast[1], ast[2]
                 err = None
                 try:
                     return EVAL(a1, env)
@@ -91,41 +95,51 @@ def EVAL(ast, env):
                 except Exception as exc:
                     err = exc.args[0]
                 catch_env = Env(env, [a2[1]], [err])
-                return EVAL(a2[2], catch_env)
-            else:
-                return EVAL(a1, env);
+                ast = a2[2]
+                env = catch_env
+                continue # TCO
         elif "do" == a0:
             for i in range(1, len(ast)-1):
                 EVAL(ast[i], env)
             ast = ast[-1]
-            # Continue loop (TCO)
+            continue # TCO
         elif "if" == a0:
             a1, a2 = ast[1], ast[2]
             cond = EVAL(a1, env)
             if cond is None or cond is False:
-                if len(ast) > 3: ast = ast[3]
-                else:            ast = None
+                if len(ast) > 3:
+                    ast = ast[3]
+                    continue # TCO
+                else:
+                    return None
             else:
                 ast = a2
-            # Continue loop (TCO)
+                continue # TCO
         elif "fn*" == a0:
             a1, a2 = ast[1], ast[2]
-            return types._function(EVAL, Env, a2, env, a1)
-        else:
-            f = EVAL(a0, env)
+            def fn(*args):
+                return EVAL(a2, Env(env, a1, args))
+            fn.__ast__ = a2
+            fn.__gen_env__ = lambda args: Env(env, a1, args)
+            return fn
+
+    f = EVAL(a0, env)
+    if types._function_Q(f):
             args = ast[1:]
             if hasattr(f, '_ismacro_'):
                 ast = f(*args)
                 continue # TCO
             if hasattr(f, '__ast__'):
                 ast = f.__ast__
-                env = f.__gen_env__(types.List(EVAL(a, env) for a in args))
+                env = f.__gen_env__(EVAL(a, env) for a in args)
+                continue # TCO
             else:
                 return f(*(EVAL(a, env) for a in args))
+    else:
+        raise Exception('Can only apply functions')
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 repl_env = Env()
@@ -135,12 +149,16 @@ def REP(str):
 # core.py: defined using python
 for k, v in core.ns.items(): repl_env.set(types._symbol(k), v)
 repl_env.set(types._symbol('eval'), lambda ast: EVAL(ast, repl_env))
-repl_env.set(types._symbol('*ARGV*'), types._list(*sys.argv[2:]))
+repl_env.set(types._symbol('*ARGV*'), types.List(sys.argv[2:]))
 
 # core.mal: defined using the language itself
 REP("(def! not (fn* (a) (if a false true)))")
-REP("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))")
-REP("(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))")
+REP('(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) "\nnil)")))))')
+REP("""(defmacro! cond (fn* (& xs)
+  (if (> (count xs) 0)
+    (list 'if (first xs)
+      (if (> (count xs) 1) (nth xs 1) (throw "odd number of forms to cond"))
+      (cons 'cond (rest (rest xs)))))))""")
 
 if len(sys.argv) >= 2:
     REP('(load-file "' + sys.argv[1] + '")')
@@ -150,11 +168,13 @@ if len(sys.argv) >= 2:
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
     except types.MalException as e:
         print("Error:", printer._pr_str(e.object))
-    except Exception as e:
-        print("".join(traceback.format_exception(*sys.exc_info())))
+    except Exception:
+        # See tests/step5_tco.mal in this directory.
+        print("".join(traceback.format_exception(*sys.exc_info())[0:100]))

--- a/impls/python/stepA_mal.py
+++ b/impls/python/stepA_mal.py
@@ -7,43 +7,47 @@ from env import Env
 import core
 
 # read
-def READ(str):
-    return reader.read_str(str)
+READ = reader.read_str
 
 # eval
 def qq_loop(acc, elt):
-    if types._list_Q(elt) and len(elt) == 2 and elt[0] == u'splice-unquote':
-        return types._list(types._symbol(u'concat'), elt[1], acc)
+    if types._list_Q(elt) \
+       and len(elt) == 2 \
+       and types._symbol_Q(elt[0]) \
+       and elt[0] == 'splice-unquote':
+        return types._list(types._symbol('concat'), elt[1], acc)
     else:
-        return types._list(types._symbol(u'cons'), quasiquote(elt), acc)
+        return types._list(types._symbol('cons'), quasiquote(elt), acc)
 
 def qq_foldr(seq):
     return functools.reduce(qq_loop, reversed(seq), types._list())
 
 def quasiquote(ast):
     if types._list_Q(ast):
-        if len(ast) == 2 and ast[0] == u'unquote':
+        if len(ast) == 2 \
+           and types._symbol_Q(ast[0]) \
+           and ast[0] == 'unquote':
             return ast[1]
         else:
             return qq_foldr(ast)
     elif types._hash_map_Q(ast) or types._symbol_Q(ast):
-        return types._list(types._symbol(u'quote'), ast)
-    elif types._vector_Q (ast):
-        return types._list(types._symbol(u'vec'), qq_foldr(ast))
+        return types._list(types._symbol('quote'), ast)
+    elif types._vector_Q(ast):
+        return types._list(types._symbol('vec'), qq_foldr(ast))
     else:
         return ast
 
 def EVAL(ast, env):
   while True:
 
-    dbgeval = env.get_or_nil('DEBUG-EVAL')
+    dbgeval = env.get(types._symbol('DEBUG-EVAL'), return_nil=True)
     if dbgeval is not None and dbgeval is not False:
         print('EVAL: ' + printer._pr_str(ast))
 
     if types._symbol_Q(ast):
         return env.get(ast)
     elif types._vector_Q(ast):
-        return types._vector(*map(lambda a: EVAL(a, env), ast))
+        return types.Vector(EVAL(a, env) for a in ast)
     elif types._hash_map_Q(ast):
         return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     elif not types._list_Q(ast):
@@ -54,6 +58,7 @@ def EVAL(ast, env):
         if len(ast) == 0: return ast
         a0 = ast[0]
 
+    if types._symbol_Q(a0):
         if "def!" == a0:
             a1, a2 = ast[1], ast[2]
             res = EVAL(a2, env)
@@ -61,18 +66,19 @@ def EVAL(ast, env):
         elif "let*" == a0:
             a1, a2 = ast[1], ast[2]
             let_env = Env(env)
-            for i in range(0, len(a1), 2):
-                let_env.set(a1[i], EVAL(a1[i+1], let_env))
+            for k, v in types.asPairs(a1):
+                let_env.set(k, EVAL(v, let_env))
             ast = a2
             env = let_env
-            # Continue loop (TCO)
+            continue # TCO
         elif "quote" == a0:
             return ast[1]
         elif "quasiquote" == a0:
-            ast = quasiquote(ast[1]);
-            # Continue loop (TCO)
+            ast = quasiquote(ast[1])
+            continue # TCO
         elif 'defmacro!' == a0:
-            func = types._clone(EVAL(ast[2], env))
+            func = EVAL(ast[2], env)
+            func = types._clone(func)
             func._ismacro_ = True
             return env.set(ast[1], func)
         elif "py!*" == a0:
@@ -86,9 +92,10 @@ def EVAL(ast, env):
             return f(*el)
         elif "try*" == a0:
             if len(ast) < 3:
-                return EVAL(ast[1], env)
-            a1, a2 = ast[1], ast[2]
-            if a2[0] == "catch*":
+                ast = ast[1]
+                continue # TCO
+            else:
+                a1, a2 = ast[1], ast[2]
                 err = None
                 try:
                     return EVAL(a1, env)
@@ -97,41 +104,51 @@ def EVAL(ast, env):
                 except Exception as exc:
                     err = exc.args[0]
                 catch_env = Env(env, [a2[1]], [err])
-                return EVAL(a2[2], catch_env)
-            else:
-                return EVAL(a1, env);
+                ast = a2[2]
+                env = catch_env
+                continue # TCO
         elif "do" == a0:
             for i in range(1, len(ast)-1):
                 EVAL(ast[i], env)
             ast = ast[-1]
-            # Continue loop (TCO)
+            continue # TCO
         elif "if" == a0:
             a1, a2 = ast[1], ast[2]
             cond = EVAL(a1, env)
             if cond is None or cond is False:
-                if len(ast) > 3: ast = ast[3]
-                else:            ast = None
+                if len(ast) > 3:
+                    ast = ast[3]
+                    continue # TCO
+                else:
+                    return None
             else:
                 ast = a2
-            # Continue loop (TCO)
+                continue # TCO
         elif "fn*" == a0:
             a1, a2 = ast[1], ast[2]
-            return types._function(EVAL, Env, a2, env, a1)
-        else:
-            f = EVAL(a0, env)
+            def fn(*args):
+                return EVAL(a2, Env(env, a1, args))
+            fn.__ast__ = a2
+            fn.__gen_env__ = lambda args: Env(env, a1, args)
+            return fn
+
+    f = EVAL(a0, env)
+    if types._function_Q(f):
             args = ast[1:]
             if hasattr(f, '_ismacro_'):
                 ast = f(*args)
                 continue # TCO
             if hasattr(f, '__ast__'):
                 ast = f.__ast__
-                env = f.__gen_env__(types.List(EVAL(a, env) for a in args))
+                env = f.__gen_env__(EVAL(a, env) for a in args)
+                continue # TCO
             else:
                 return f(*(EVAL(a, env) for a in args))
+    else:
+        raise Exception('Can only apply functions')
 
 # print
-def PRINT(exp):
-    return printer._pr_str(exp)
+PRINT = printer._pr_str
 
 # repl
 repl_env = Env()
@@ -141,28 +158,34 @@ def REP(str):
 # core.py: defined using python
 for k, v in core.ns.items(): repl_env.set(types._symbol(k), v)
 repl_env.set(types._symbol('eval'), lambda ast: EVAL(ast, repl_env))
-repl_env.set(types._symbol('*ARGV*'), types._list(*sys.argv[2:]))
+repl_env.set(types._symbol('*ARGV*'), types.List(sys.argv[2:]))
 
 # core.mal: defined using the language itself
-REP("(def! *host-language* \"python\")")
+REP('(def! *host-language* "python")')
 REP("(def! not (fn* (a) (if a false true)))")
-REP("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))")
-REP("(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))")
+REP('(def! load-file (fn* (f) (eval (read-string (str "(do " (slurp f) "\nnil)")))))')
+REP("""(defmacro! cond (fn* (& xs)
+  (if (> (count xs) 0)
+    (list 'if (first xs)
+      (if (> (count xs) 1) (nth xs 1) (throw "odd number of forms to cond"))
+      (cons 'cond (rest (rest xs)))))))""")
 
 if len(sys.argv) >= 2:
     REP('(load-file "' + sys.argv[1] + '")')
     sys.exit(0)
 
 # repl loop
-REP("(println (str \"Mal [\" *host-language* \"]\"))")
+REP('(println (str "Mal [" *host-language* "]"))')
 while True:
     try:
         line = mal_readline.readline("user> ")
-        if line == None: break
-        if line == "": continue
         print(REP(line))
+    except EOFError:
+        print()
+        break
     except reader.Blank: continue
     except types.MalException as e:
         print("Error:", printer._pr_str(e.object))
-    except Exception as e:
-        print("".join(traceback.format_exception(*sys.exc_info())))
+    except Exception:
+        # See tests/step5_tco.mal in this directory.
+        print("".join(traceback.format_exception(*sys.exc_info())[0:100]))


### PR DESCRIPTION
python_MODE=python3 crashes on impls/python/tests/step5_tco.mal, but
it also does on the current head.

Replace some lambda constructs with more idiomatic generator
expressions, removing several temporary sequences (conversions,
contatenations, slices, arguments).

Remove obsolete coll_Q test and preservation of metadata by conj.

Use normal classes for functions in order to simplify cloning and
membership tests.

Close file open by 'slurp' after reading.

Derive List and Vector from tuple, which is more efficient than list
for immutable structures.  Remove the need for __getitem__ stuff.

Search in outer environments with a loop instead of a recursion.

Replace most python2/3 wrappers with code compatible with both
versions.  Use a non-printable ASCII characters instead of Unicode
characters (in order to avoid unicode in python2).

Follow Python style conventions:
* int(a/b)      -> a//b or floordiv(a, b)
* obj.__str__() -> str(obj)
* obj.__meta__  -> obj._meta
* f (args)      -> f(args)

Remove obviously backported stuff from first steps.

Let try* benefit from TCO.

Fix the detection of special forms (strings were accepted as well as
symbols).

Arguably improve readability:
* merge is_macro_call into macroexpand
* merge eval_ast into EVAL
(The two 'if not types._list_Q(ast)' tests in EVAL were redundant)