### PR TITLE
additional test

### DIFF
--- a/impls/tests/step9_try.mal
+++ b/impls/tests/step9_try.mal
@@ -396,3 +396,9 @@
 ;=>:abc
 (keyword? (first (keys {":abc" 123 ":def" 456})))
 ;=>false
+
+;; Testing that hashmaps don't alter function ast
+(def! bar (fn* [a] {:foo (get a :foo)}))
+(bar {:foo (fn* [x] x)})
+(bar {:foo 3})
+;; shouldn't give an error


### PR DESCRIPTION
This was a bug that took me a while to find in the self-hosting step. In my case, it had to do with javascript's object copying system.