### PR TITLE
Stop evaluating map keys when it simplifies the implementation

### DIFF
--- a/impls/coffee/step2_eval.coffee
+++ b/impls/coffee/step2_eval.coffee
@@ -14,7 +14,7 @@ eval_ast = (ast, env) ->
     types._vector(ast.map((a) -> EVAL(a, env))...)
   else if types._hash_map_Q(ast)
     new_hm = {}
-    new_hm[k] = EVAL(ast[k],env) for k,v of ast
+    new_hm[k] = EVAL(v, env) for k,v of ast
     new_hm
   else ast
 

--- a/impls/coffee/step3_env.coffee
+++ b/impls/coffee/step3_env.coffee
@@ -15,7 +15,7 @@ eval_ast = (ast, env) ->
     types._vector(ast.map((a) -> EVAL(a, env))...)
   else if types._hash_map_Q(ast)
     new_hm = {}
-    new_hm[k] = EVAL(ast[k],env) for k,v of ast
+    new_hm[k] = EVAL(v, env) for k,v of ast
     new_hm
   else ast
 

--- a/impls/coffee/step4_if_fn_do.coffee
+++ b/impls/coffee/step4_if_fn_do.coffee
@@ -16,7 +16,7 @@ eval_ast = (ast, env) ->
     types._vector(ast.map((a) -> EVAL(a, env))...)
   else if types._hash_map_Q(ast)
     new_hm = {}
-    new_hm[k] = EVAL(ast[k],env) for k,v of ast
+    new_hm[k] = EVAL(v, env) for k,v of ast
     new_hm
   else ast
 

--- a/impls/coffee/step5_tco.coffee
+++ b/impls/coffee/step5_tco.coffee
@@ -16,7 +16,7 @@ eval_ast = (ast, env) ->
     types._vector(ast.map((a) -> EVAL(a, env))...)
   else if types._hash_map_Q(ast)
     new_hm = {}
-    new_hm[k] = EVAL(ast[k],env) for k,v of ast
+    new_hm[k] = EVAL(v, env) for k,v of ast
     new_hm
   else ast
 

--- a/impls/coffee/step6_file.coffee
+++ b/impls/coffee/step6_file.coffee
@@ -16,7 +16,7 @@ eval_ast = (ast, env) ->
     types._vector(ast.map((a) -> EVAL(a, env))...)
   else if types._hash_map_Q(ast)
     new_hm = {}
-    new_hm[k] = EVAL(ast[k],env) for k,v of ast
+    new_hm[k] = EVAL(v, env) for k,v of ast
     new_hm
   else ast
 

--- a/impls/coffee/step7_quote.coffee
+++ b/impls/coffee/step7_quote.coffee
@@ -32,7 +32,7 @@ eval_ast = (ast, env) ->
     types._vector(ast.map((a) -> EVAL(a, env))...)
   else if types._hash_map_Q(ast)
     new_hm = {}
-    new_hm[k] = EVAL(ast[k],env) for k,v of ast
+    new_hm[k] = EVAL(v, env) for k,v of ast
     new_hm
   else ast
 

--- a/impls/coffee/step8_macros.coffee
+++ b/impls/coffee/step8_macros.coffee
@@ -41,7 +41,7 @@ eval_ast = (ast, env) ->
     types._vector(ast.map((a) -> EVAL(a, env))...)
   else if types._hash_map_Q(ast)
     new_hm = {}
-    new_hm[k] = EVAL(ast[k],env) for k,v of ast
+    new_hm[k] = EVAL(v, env) for k,v of ast
     new_hm
   else ast
 

--- a/impls/coffee/step9_try.coffee
+++ b/impls/coffee/step9_try.coffee
@@ -41,7 +41,7 @@ eval_ast = (ast, env) ->
     types._vector(ast.map((a) -> EVAL(a, env))...)
   else if types._hash_map_Q(ast)
     new_hm = {}
-    new_hm[k] = EVAL(ast[k],env) for k,v of ast
+    new_hm[k] = EVAL(v, env) for k,v of ast
     new_hm
   else ast
 

--- a/impls/coffee/stepA_mal.coffee
+++ b/impls/coffee/stepA_mal.coffee
@@ -41,7 +41,7 @@ eval_ast = (ast, env) ->
     types._vector(ast.map((a) -> EVAL(a, env))...)
   else if types._hash_map_Q(ast)
     new_hm = {}
-    new_hm[k] = EVAL(ast[k],env) for k,v of ast
+    new_hm[k] = EVAL(v, env) for k,v of ast
     new_hm
   else ast
 

--- a/impls/common-lisp/src/step2_eval.lisp
+++ b/impls/common-lisp/src/step2_eval.lisp
@@ -55,7 +55,7 @@
   (let ((hash-map-value (mal-data-value hash-map))
         (new-hash-table (make-mal-value-hash-table)))
     (genhash:hashmap (lambda (key value)
-                       (setf (genhash:hashref (mal-eval key env) new-hash-table)
+                       (setf (genhash:hashref key new-hash-table)
                              (mal-eval value env)))
                      hash-map-value)
     (make-mal-hash-map new-hash-table)))

--- a/impls/common-lisp/src/step3_env.lisp
+++ b/impls/common-lisp/src/step3_env.lisp
@@ -56,7 +56,7 @@
   (let ((hash-map-value (mal-data-value hash-map))
         (new-hash-table (make-mal-value-hash-table)))
     (genhash:hashmap (lambda (key value)
-                       (setf (genhash:hashref (mal-eval key env) new-hash-table)
+                       (setf (genhash:hashref key new-hash-table)
                              (mal-eval value env)))
                      hash-map-value)
     (make-mal-hash-map new-hash-table)))

--- a/impls/common-lisp/src/step4_if_fn_do.lisp
+++ b/impls/common-lisp/src/step4_if_fn_do.lisp
@@ -39,7 +39,7 @@
   (let ((hash-map-value (mal-data-value hash-map))
         (new-hash-table (make-mal-value-hash-table)))
     (genhash:hashmap (lambda (key value)
-                       (setf (genhash:hashref (mal-eval key env) new-hash-table)
+                       (setf (genhash:hashref key new-hash-table)
                              (mal-eval value env)))
                      hash-map-value)
     (make-mal-hash-map new-hash-table)))

--- a/impls/common-lisp/src/step5_tco.lisp
+++ b/impls/common-lisp/src/step5_tco.lisp
@@ -39,7 +39,7 @@
   (let ((hash-map-value (mal-data-value hash-map))
         (new-hash-table (make-mal-value-hash-table)))
     (genhash:hashmap (lambda (key value)
-                       (setf (genhash:hashref (mal-eval key env) new-hash-table)
+                       (setf (genhash:hashref key new-hash-table)
                              (mal-eval value env)))
                      hash-map-value)
     (make-mal-hash-map new-hash-table)))

--- a/impls/common-lisp/src/step6_file.lisp
+++ b/impls/common-lisp/src/step6_file.lisp
@@ -39,7 +39,7 @@
   (let ((hash-map-value (mal-data-value hash-map))
         (new-hash-table (make-mal-value-hash-table)))
     (genhash:hashmap (lambda (key value)
-                       (setf (genhash:hashref (mal-eval key env) new-hash-table)
+                       (setf (genhash:hashref key new-hash-table)
                              (mal-eval value env)))
                      hash-map-value)
     (make-mal-hash-map new-hash-table)))

--- a/impls/common-lisp/src/step7_quote.lisp
+++ b/impls/common-lisp/src/step7_quote.lisp
@@ -47,7 +47,7 @@
   (let ((hash-map-value (mal-data-value hash-map))
         (new-hash-table (make-mal-value-hash-table)))
     (genhash:hashmap (lambda (key value)
-                       (setf (genhash:hashref (mal-eval key env) new-hash-table)
+                       (setf (genhash:hashref key new-hash-table)
                              (mal-eval value env)))
                      hash-map-value)
     (make-mal-hash-map new-hash-table)))

--- a/impls/common-lisp/src/step8_macros.lisp
+++ b/impls/common-lisp/src/step8_macros.lisp
@@ -61,7 +61,7 @@
   (let ((hash-map-value (mal-data-value hash-map))
         (new-hash-table (make-mal-value-hash-table)))
     (genhash:hashmap (lambda (key value)
-                       (setf (genhash:hashref (mal-eval key env) new-hash-table)
+                       (setf (genhash:hashref key new-hash-table)
                              (mal-eval value env)))
                      hash-map-value)
     (make-mal-hash-map new-hash-table)))

--- a/impls/common-lisp/src/step9_try.lisp
+++ b/impls/common-lisp/src/step9_try.lisp
@@ -64,7 +64,7 @@
   (let ((hash-map-value (mal-data-value hash-map))
         (new-hash-table (make-mal-value-hash-table)))
     (genhash:hashmap (lambda (key value)
-                       (setf (genhash:hashref (mal-eval key env) new-hash-table)
+                       (setf (genhash:hashref key new-hash-table)
                              (mal-eval value env)))
                      hash-map-value)
     (make-mal-hash-map new-hash-table)))

--- a/impls/common-lisp/src/stepA_mal.lisp
+++ b/impls/common-lisp/src/stepA_mal.lisp
@@ -63,7 +63,7 @@
   (let ((hash-map-value (mal-data-value hash-map))
         (new-hash-table (make-mal-value-hash-table)))
     (genhash:hashmap (lambda (key value)
-                       (setf (genhash:hashref (mal-eval key env) new-hash-table)
+                       (setf (genhash:hashref key new-hash-table)
                              (mal-eval value env)))
                      hash-map-value)
     (make-mal-hash-map new-hash-table)))

--- a/impls/elixir/lib/mix/tasks/step2_eval.ex
+++ b/impls/elixir/lib/mix/tasks/step2_eval.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Step2Eval do
 
   defp eval_ast({:map, ast, meta}, env) do
     map = for {key, value} <- ast, into: %{} do
-      {eval(key, env), eval(value, env)}
+      {key, eval(value, env)}
     end
 
     {:map, map, meta}

--- a/impls/elixir/lib/mix/tasks/step3_env.ex
+++ b/impls/elixir/lib/mix/tasks/step3_env.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Step3Env do
 
   defp eval_ast({:map, ast, meta}, env) do
     map = for {key, value} <- ast, into: %{} do
-      {eval(key, env), eval(value, env)}
+      {key, eval(value, env)}
     end
 
     {:map, map, meta}

--- a/impls/elixir/lib/mix/tasks/step4_if_fn_do.ex
+++ b/impls/elixir/lib/mix/tasks/step4_if_fn_do.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Step4IfFnDo do
 
   defp eval_ast({:map, ast, meta}, env) do
     map = for {key, value} <- ast, into: %{} do
-      {eval(key, env), eval(value, env)}
+      {key, eval(value, env)}
     end
 
     {:map, map, meta}

--- a/impls/elixir/lib/mix/tasks/step5_tco.ex
+++ b/impls/elixir/lib/mix/tasks/step5_tco.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Step5Tco do
 
   defp eval_ast({:map, ast, meta}, env) do
     map = for {key, value} <- ast, into: %{} do
-      {eval(key, env), eval(value, env)}
+      {key, eval(value, env)}
     end
 
     {:map, map, meta}

--- a/impls/elixir/lib/mix/tasks/step6_file.ex
+++ b/impls/elixir/lib/mix/tasks/step6_file.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Step6File do
 
   defp eval_ast({:map, ast, meta}, env) do
     map = for {key, value} <- ast, into: %{} do
-      {eval(key, env), eval(value, env)}
+      {key, eval(value, env)}
     end
 
     {:map, map, meta}

--- a/impls/elixir/lib/mix/tasks/step7_quote.ex
+++ b/impls/elixir/lib/mix/tasks/step7_quote.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Step7Quote do
 
   defp eval_ast({:map, ast, meta}, env) do
     map = for {key, value} <- ast, into: %{} do
-      {eval(key, env), eval(value, env)}
+      {key, eval(value, env)}
     end
 
     {:map, map, meta}

--- a/impls/elixir/lib/mix/tasks/step8_macros.ex
+++ b/impls/elixir/lib/mix/tasks/step8_macros.ex
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.Step8Macros do
 
   defp eval_ast({:map, ast, meta}, env) do
     map = for {key, value} <- ast, into: %{} do
-      {eval(key, env), eval(value, env)}
+      {key, eval(value, env)}
     end
 
     {:map, map, meta}

--- a/impls/elixir/lib/mix/tasks/step9_try.ex
+++ b/impls/elixir/lib/mix/tasks/step9_try.ex
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.Step9Try do
 
   defp eval_ast({:map, ast, meta}, env) do
     map = for {key, value} <- ast, into: %{} do
-      {eval(key, env), eval(value, env)}
+      {key, eval(value, env)}
     end
 
     {:map, map, meta}

--- a/impls/elixir/lib/mix/tasks/stepA_mal.ex
+++ b/impls/elixir/lib/mix/tasks/stepA_mal.ex
@@ -80,7 +80,7 @@ defmodule Mix.Tasks.StepAMal do
 
   defp eval_ast({:map, ast, meta}, env) do
     map = for {key, value} <- ast, into: %{} do
-      {eval(key, env), eval(value, env)}
+      {key, eval(value, env)}
     end
 
     {:map, map, meta}

--- a/impls/es6/step2_eval.mjs
+++ b/impls/es6/step2_eval.mjs
@@ -19,7 +19,7 @@ const eval_ast = (ast, env) => {
         return ast.map(x => EVAL(x, env))
     } else if (ast instanceof Map) {
         let new_hm = new Map()
-        ast.forEach((v, k) => new_hm.set(EVAL(k, env), EVAL(v, env)))
+        ast.forEach((v, k) => new_hm.set(k, EVAL(v, env)))
         return new_hm
     } else {
         return ast

--- a/impls/es6/step3_env.mjs
+++ b/impls/es6/step3_env.mjs
@@ -16,7 +16,7 @@ const eval_ast = (ast, env) => {
         return ast.map(x => EVAL(x, env))
     } else if (ast instanceof Map) {
         let new_hm = new Map()
-        ast.forEach((v, k) => new_hm.set(EVAL(k, env), EVAL(v, env)))
+        ast.forEach((v, k) => new_hm.set(k, EVAL(v, env)))
         return new_hm
     } else {
         return ast

--- a/impls/es6/step4_if_fn_do.mjs
+++ b/impls/es6/step4_if_fn_do.mjs
@@ -17,7 +17,7 @@ const eval_ast = (ast, env) => {
         return ast.map(x => EVAL(x, env))
     } else if (ast instanceof Map) {
         let new_hm = new Map()
-        ast.forEach((v, k) => new_hm.set(EVAL(k, env), EVAL(v, env)))
+        ast.forEach((v, k) => new_hm.set(k, EVAL(v, env)))
         return new_hm
     } else {
         return ast

--- a/impls/es6/step5_tco.mjs
+++ b/impls/es6/step5_tco.mjs
@@ -17,7 +17,7 @@ const eval_ast = (ast, env) => {
         return ast.map(x => EVAL(x, env))
     } else if (ast instanceof Map) {
         let new_hm = new Map()
-        ast.forEach((v, k) => new_hm.set(EVAL(k, env), EVAL(v, env)))
+        ast.forEach((v, k) => new_hm.set(k, EVAL(v, env)))
         return new_hm
     } else {
         return ast

--- a/impls/es6/step6_file.mjs
+++ b/impls/es6/step6_file.mjs
@@ -17,7 +17,7 @@ const eval_ast = (ast, env) => {
         return ast.map(x => EVAL(x, env))
     } else if (ast instanceof Map) {
         let new_hm = new Map()
-        ast.forEach((v, k) => new_hm.set(EVAL(k, env), EVAL(v, env)))
+        ast.forEach((v, k) => new_hm.set(k, EVAL(v, env)))
         return new_hm
     } else {
         return ast

--- a/impls/es6/step7_quote.mjs
+++ b/impls/es6/step7_quote.mjs
@@ -40,7 +40,7 @@ const eval_ast = (ast, env) => {
         return ast.map(x => EVAL(x, env))
     } else if (ast instanceof Map) {
         let new_hm = new Map()
-        ast.forEach((v, k) => new_hm.set(EVAL(k, env), EVAL(v, env)))
+        ast.forEach((v, k) => new_hm.set(k, EVAL(v, env)))
         return new_hm
     } else {
         return ast

--- a/impls/es6/step8_macros.mjs
+++ b/impls/es6/step8_macros.mjs
@@ -51,7 +51,7 @@ const eval_ast = (ast, env) => {
         return ast.map(x => EVAL(x, env))
     } else if (ast instanceof Map) {
         let new_hm = new Map()
-        ast.forEach((v, k) => new_hm.set(EVAL(k, env), EVAL(v, env)))
+        ast.forEach((v, k) => new_hm.set(k, EVAL(v, env)))
         return new_hm
     } else {
         return ast

--- a/impls/es6/step9_try.mjs
+++ b/impls/es6/step9_try.mjs
@@ -51,7 +51,7 @@ const eval_ast = (ast, env) => {
         return ast.map(x => EVAL(x, env))
     } else if (ast instanceof Map) {
         let new_hm = new Map()
-        ast.forEach((v, k) => new_hm.set(EVAL(k, env), EVAL(v, env)))
+        ast.forEach((v, k) => new_hm.set(k, EVAL(v, env)))
         return new_hm
     } else {
         return ast

--- a/impls/es6/stepA_mal.mjs
+++ b/impls/es6/stepA_mal.mjs
@@ -51,7 +51,7 @@ const eval_ast = (ast, env) => {
         return ast.map(x => EVAL(x, env))
     } else if (ast instanceof Map) {
         let new_hm = new Map()
-        ast.forEach((v, k) => new_hm.set(EVAL(k, env), EVAL(v, env)))
+        ast.forEach((v, k) => new_hm.set(k, EVAL(v, env)))
         return new_hm
     } else {
         return ast

--- a/impls/go/src/step2_eval/step2_eval.go
+++ b/impls/go/src/step2_eval/step2_eval.go
@@ -52,18 +52,11 @@ func eval_ast(ast MalType, env map[string]MalType) (MalType, error) {
 		m := ast.(HashMap)
 		new_hm := HashMap{map[string]MalType{}, nil}
 		for k, v := range m.Val {
-			ke, e1 := EVAL(k, env)
-			if e1 != nil {
-				return nil, e1
-			}
-			if _, ok := ke.(string); !ok {
-				return nil, errors.New("non string hash-map key")
-			}
 			kv, e2 := EVAL(v, env)
 			if e2 != nil {
 				return nil, e2
 			}
-			new_hm.Val[ke.(string)] = kv
+			new_hm.Val[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/impls/go/src/step3_env/step3_env.go
+++ b/impls/go/src/step3_env/step3_env.go
@@ -48,18 +48,11 @@ func eval_ast(ast MalType, env EnvType) (MalType, error) {
 		m := ast.(HashMap)
 		new_hm := HashMap{map[string]MalType{}, nil}
 		for k, v := range m.Val {
-			ke, e1 := EVAL(k, env)
-			if e1 != nil {
-				return nil, e1
-			}
-			if _, ok := ke.(string); !ok {
-				return nil, errors.New("non string hash-map key")
-			}
 			kv, e2 := EVAL(v, env)
 			if e2 != nil {
 				return nil, e2
 			}
-			new_hm.Val[ke.(string)] = kv
+			new_hm.Val[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/impls/go/src/step4_if_fn_do/step4_if_fn_do.go
+++ b/impls/go/src/step4_if_fn_do/step4_if_fn_do.go
@@ -49,18 +49,11 @@ func eval_ast(ast MalType, env EnvType) (MalType, error) {
 		m := ast.(HashMap)
 		new_hm := HashMap{map[string]MalType{}, nil}
 		for k, v := range m.Val {
-			ke, e1 := EVAL(k, env)
-			if e1 != nil {
-				return nil, e1
-			}
-			if _, ok := ke.(string); !ok {
-				return nil, errors.New("non string hash-map key")
-			}
 			kv, e2 := EVAL(v, env)
 			if e2 != nil {
 				return nil, e2
 			}
-			new_hm.Val[ke.(string)] = kv
+			new_hm.Val[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/impls/go/src/step5_tco/step5_tco.go
+++ b/impls/go/src/step5_tco/step5_tco.go
@@ -49,18 +49,11 @@ func eval_ast(ast MalType, env EnvType) (MalType, error) {
 		m := ast.(HashMap)
 		new_hm := HashMap{map[string]MalType{}, nil}
 		for k, v := range m.Val {
-			ke, e1 := EVAL(k, env)
-			if e1 != nil {
-				return nil, e1
-			}
-			if _, ok := ke.(string); !ok {
-				return nil, errors.New("non string hash-map key")
-			}
 			kv, e2 := EVAL(v, env)
 			if e2 != nil {
 				return nil, e2
 			}
-			new_hm.Val[ke.(string)] = kv
+			new_hm.Val[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/impls/go/src/step6_file/step6_file.go
+++ b/impls/go/src/step6_file/step6_file.go
@@ -50,18 +50,11 @@ func eval_ast(ast MalType, env EnvType) (MalType, error) {
 		m := ast.(HashMap)
 		new_hm := HashMap{map[string]MalType{}, nil}
 		for k, v := range m.Val {
-			ke, e1 := EVAL(k, env)
-			if e1 != nil {
-				return nil, e1
-			}
-			if _, ok := ke.(string); !ok {
-				return nil, errors.New("non string hash-map key")
-			}
 			kv, e2 := EVAL(v, env)
 			if e2 != nil {
 				return nil, e2
 			}
-			new_hm.Val[ke.(string)] = kv
+			new_hm.Val[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/impls/go/src/step7_quote/step7_quote.go
+++ b/impls/go/src/step7_quote/step7_quote.go
@@ -95,18 +95,11 @@ func eval_ast(ast MalType, env EnvType) (MalType, error) {
 		m := ast.(HashMap)
 		new_hm := HashMap{map[string]MalType{}, nil}
 		for k, v := range m.Val {
-			ke, e1 := EVAL(k, env)
-			if e1 != nil {
-				return nil, e1
-			}
-			if _, ok := ke.(string); !ok {
-				return nil, errors.New("non string hash-map key")
-			}
 			kv, e2 := EVAL(v, env)
 			if e2 != nil {
 				return nil, e2
 			}
-			new_hm.Val[ke.(string)] = kv
+			new_hm.Val[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/impls/go/src/step8_macros/step8_macros.go
+++ b/impls/go/src/step8_macros/step8_macros.go
@@ -134,18 +134,11 @@ func eval_ast(ast MalType, env EnvType) (MalType, error) {
 		m := ast.(HashMap)
 		new_hm := HashMap{map[string]MalType{}, nil}
 		for k, v := range m.Val {
-			ke, e1 := EVAL(k, env)
-			if e1 != nil {
-				return nil, e1
-			}
-			if _, ok := ke.(string); !ok {
-				return nil, errors.New("non string hash-map key")
-			}
 			kv, e2 := EVAL(v, env)
 			if e2 != nil {
 				return nil, e2
 			}
-			new_hm.Val[ke.(string)] = kv
+			new_hm.Val[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/impls/go/src/step9_try/step9_try.go
+++ b/impls/go/src/step9_try/step9_try.go
@@ -134,18 +134,11 @@ func eval_ast(ast MalType, env EnvType) (MalType, error) {
 		m := ast.(HashMap)
 		new_hm := HashMap{map[string]MalType{}, nil}
 		for k, v := range m.Val {
-			ke, e1 := EVAL(k, env)
-			if e1 != nil {
-				return nil, e1
-			}
-			if _, ok := ke.(string); !ok {
-				return nil, errors.New("non string hash-map key")
-			}
 			kv, e2 := EVAL(v, env)
 			if e2 != nil {
 				return nil, e2
 			}
-			new_hm.Val[ke.(string)] = kv
+			new_hm.Val[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/impls/go/src/stepA_mal/stepA_mal.go
+++ b/impls/go/src/stepA_mal/stepA_mal.go
@@ -134,18 +134,11 @@ func eval_ast(ast MalType, env EnvType) (MalType, error) {
 		m := ast.(HashMap)
 		new_hm := HashMap{map[string]MalType{}, nil}
 		for k, v := range m.Val {
-			ke, e1 := EVAL(k, env)
-			if e1 != nil {
-				return nil, e1
-			}
-			if _, ok := ke.(string); !ok {
-				return nil, errors.New("non string hash-map key")
-			}
 			kv, e2 := EVAL(v, env)
 			if e2 != nil {
 				return nil, e2
 			}
-			new_hm.Val[ke.(string)] = kv
+			new_hm.Val[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/impls/groovy/step2_eval.groovy
+++ b/impls/groovy/step2_eval.groovy
@@ -22,7 +22,7 @@ eval_ast = { ast, env ->
         case Map:
             def new_hm = [:]
             ast.each { k,v ->
-                new_hm[EVAL(k, env)] = EVAL(v, env)
+                new_hm[k] = EVAL(v, env)
             }
             return new_hm
         default:

--- a/impls/groovy/step3_env.groovy
+++ b/impls/groovy/step3_env.groovy
@@ -19,7 +19,7 @@ eval_ast = { ast, env ->
                             ast.collect { EVAL(it,env) }
         case Map:       def new_hm = [:]
                         ast.each { k,v ->
-                            new_hm[EVAL(k, env)] = EVAL(v, env)
+                            new_hm[k] = EVAL(v, env)
                         }
                         return new_hm
         default:        return ast

--- a/impls/groovy/step4_if_fn_do.groovy
+++ b/impls/groovy/step4_if_fn_do.groovy
@@ -21,7 +21,7 @@ eval_ast = { ast, env ->
                             ast.collect { EVAL(it,env) }
         case Map:       def new_hm = [:]
                         ast.each { k,v ->
-                            new_hm[EVAL(k, env)] = EVAL(v, env)
+                            new_hm[k] = EVAL(v, env)
                         }
                         return new_hm
         default:        return ast

--- a/impls/groovy/step5_tco.groovy
+++ b/impls/groovy/step5_tco.groovy
@@ -21,7 +21,7 @@ eval_ast = { ast, env ->
                             ast.collect { EVAL(it,env) }
         case Map:       def new_hm = [:]
                         ast.each { k,v ->
-                            new_hm[EVAL(k, env)] = EVAL(v, env)
+                            new_hm[k] = EVAL(v, env)
                         }
                         return new_hm
         default:        return ast

--- a/impls/groovy/step6_file.groovy
+++ b/impls/groovy/step6_file.groovy
@@ -21,7 +21,7 @@ eval_ast = { ast, env ->
                             ast.collect { EVAL(it,env) }
         case Map:       def new_hm = [:]
                         ast.each { k,v ->
-                            new_hm[EVAL(k, env)] = EVAL(v, env)
+                            new_hm[k] = EVAL(v, env)
                         }
                         return new_hm
         default:        return ast

--- a/impls/groovy/step7_quote.groovy
+++ b/impls/groovy/step7_quote.groovy
@@ -54,7 +54,7 @@ eval_ast = { ast, env ->
                             ast.collect { EVAL(it,env) }
         case Map:       def new_hm = [:]
                         ast.each { k,v ->
-                            new_hm[EVAL(k, env)] = EVAL(v, env)
+                            new_hm[k] = EVAL(v, env)
                         }
                         return new_hm
         default:        return ast

--- a/impls/groovy/step8_macros.groovy
+++ b/impls/groovy/step8_macros.groovy
@@ -74,7 +74,7 @@ eval_ast = { ast, env ->
                             ast.collect { EVAL(it,env) }
         case Map:       def new_hm = [:]
                         ast.each { k,v ->
-                            new_hm[EVAL(k, env)] = EVAL(v, env)
+                            new_hm[k] = EVAL(v, env)
                         }
                         return new_hm
         default:        return ast

--- a/impls/groovy/step9_try.groovy
+++ b/impls/groovy/step9_try.groovy
@@ -74,7 +74,7 @@ eval_ast = { ast, env ->
                             ast.collect { EVAL(it,env) }
         case Map:       def new_hm = [:]
                         ast.each { k,v ->
-                            new_hm[EVAL(k, env)] = EVAL(v, env)
+                            new_hm[k] = EVAL(v, env)
                         }
                         return new_hm
         default:        return ast

--- a/impls/groovy/stepA_mal.groovy
+++ b/impls/groovy/stepA_mal.groovy
@@ -74,7 +74,7 @@ eval_ast = { ast, env ->
                             ast.collect { EVAL(it,env) }
         case Map:       def new_hm = [:]
                         ast.each { k,v ->
-                            new_hm[EVAL(k, env)] = EVAL(v, env)
+                            new_hm[k] = EVAL(v, env)
                         }
                         return new_hm
         default:        return ast

--- a/impls/hy/step2_eval.hy
+++ b/impls/hy/step2_eval.hy
@@ -14,7 +14,7 @@
     (symbol? ast)         (if (.has_key env ast) (get env ast)
                               (raise (Exception (+ ast " not found"))))
     (instance? dict ast)  (dict (map (fn [k]
-                                       [(EVAL k env) (EVAL (get ast k) env)])
+                                       [k (EVAL (get ast k) env)])
                                      ast))
     (instance? tuple ast) (tuple (map (fn [x] (EVAL x env)) ast))
     (instance? list ast)  (list (map (fn [x] (EVAL x env)) ast))

--- a/impls/hy/step3_env.hy
+++ b/impls/hy/step3_env.hy
@@ -16,7 +16,7 @@
   (if
     (symbol? ast)         (env-get env ast)
     (instance? dict ast)  (dict (map (fn [k]
-                                       [(EVAL k env) (EVAL (get ast k) env)])
+                                       [k (EVAL (get ast k) env)])
                                      ast))
     (instance? tuple ast) (tuple (map (fn [x] (EVAL x env)) ast))
     (instance? list ast)  (list (map (fn [x] (EVAL x env)) ast))

--- a/impls/hy/step4_if_fn_do.hy
+++ b/impls/hy/step4_if_fn_do.hy
@@ -18,7 +18,7 @@
   (if
     (symbol? ast)         (env-get env ast)
     (instance? dict ast)  (dict (map (fn [k]
-                                       [(EVAL k env) (EVAL (get ast k) env)])
+                                       [k (EVAL (get ast k) env)])
                                      ast))
     (instance? tuple ast) (tuple (map (fn [x] (EVAL x env)) ast))
     (instance? list ast)  (list (map (fn [x] (EVAL x env)) ast))

--- a/impls/hy/step5_tco.hy
+++ b/impls/hy/step5_tco.hy
@@ -18,7 +18,7 @@
   (if
     (symbol? ast)         (env-get env ast)
     (instance? dict ast)  (dict (map (fn [k]
-                                       [(EVAL k env) (EVAL (get ast k) env)])
+                                       [k (EVAL (get ast k) env)])
                                      ast))
     (instance? tuple ast) (tuple (map (fn [x] (EVAL x env)) ast))
     (instance? list ast)  (list (map (fn [x] (EVAL x env)) ast))

--- a/impls/hy/step6_file.hy
+++ b/impls/hy/step6_file.hy
@@ -18,7 +18,7 @@
   (if
     (symbol? ast)         (env-get env ast)
     (instance? dict ast)  (dict (map (fn [k]
-                                       [(EVAL k env) (EVAL (get ast k) env)])
+                                       [k (EVAL (get ast k) env)])
                                      ast))
     (instance? tuple ast) (tuple (map (fn [x] (EVAL x env)) ast))
     (instance? list ast)  (list (map (fn [x] (EVAL x env)) ast))

--- a/impls/hy/step7_quote.hy
+++ b/impls/hy/step7_quote.hy
@@ -36,7 +36,7 @@
   (if
     (symbol? ast)         (env-get env ast)
     (instance? dict ast)  (dict (map (fn [k]
-                                       [(EVAL k env) (EVAL (get ast k) env)])
+                                       [k (EVAL (get ast k) env)])
                                      ast))
     (instance? tuple ast) (tuple (map (fn [x] (EVAL x env)) ast))
     (instance? list ast)  (list (map (fn [x] (EVAL x env)) ast))

--- a/impls/hy/step8_macros.hy
+++ b/impls/hy/step8_macros.hy
@@ -52,7 +52,7 @@
   (if
     (symbol? ast)         (env-get env ast)
     (instance? dict ast)  (dict (map (fn [k]
-                                       [(EVAL k env) (EVAL (get ast k) env)])
+                                       [k (EVAL (get ast k) env)])
                                      ast))
     (instance? tuple ast) (tuple (map (fn [x] (EVAL x env)) ast))
     (instance? list ast)  (list (map (fn [x] (EVAL x env)) ast))

--- a/impls/hy/step9_try.hy
+++ b/impls/hy/step9_try.hy
@@ -52,7 +52,7 @@
   (if
     (symbol? ast)         (env-get env ast)
     (instance? dict ast)  (dict (map (fn [k]
-                                       [(EVAL k env) (EVAL (get ast k) env)])
+                                       [k (EVAL (get ast k) env)])
                                      ast))
     (instance? tuple ast) (tuple (map (fn [x] (EVAL x env)) ast))
     (instance? list ast)  (list (map (fn [x] (EVAL x env)) ast))

--- a/impls/hy/stepA_mal.hy
+++ b/impls/hy/stepA_mal.hy
@@ -52,7 +52,7 @@
   (if
     (symbol? ast)         (env-get env ast)
     (instance? dict ast)  (dict (map (fn [k]
-                                       [(EVAL k env) (EVAL (get ast k) env)])
+                                       [k (EVAL (get ast k) env)])
                                      ast))
     (instance? tuple ast) (tuple (map (fn [x] (EVAL x env)) ast))
     (instance? list ast)  (list (map (fn [x] (EVAL x env)) ast))

--- a/impls/io/step2_eval.io
+++ b/impls/io/step2_eval.io
@@ -11,8 +11,7 @@ eval_ast := method(ast, env,
        "MalMap",
            m := MalMap clone
            ast foreach(k, v,
-               keyObj := MalMap keyToObj(k)
-               m atPut(MalMap objToKey(EVAL(keyObj, env)), EVAL(v, env))
+               m atPut(k, EVAL(v, env))
            )
            m,
        ast

--- a/impls/io/step3_env.io
+++ b/impls/io/step3_env.io
@@ -11,8 +11,7 @@ eval_ast := method(ast, env,
        "MalMap",
            m := MalMap clone
            ast foreach(k, v,
-               keyObj := MalMap keyToObj(k)
-               m atPut(MalMap objToKey(EVAL(keyObj, env)), EVAL(v, env))
+               m atPut(k, EVAL(v, env))
            )
            m,
        ast

--- a/impls/io/step4_if_fn_do.io
+++ b/impls/io/step4_if_fn_do.io
@@ -11,8 +11,7 @@ eval_ast := method(ast, env,
        "MalMap",
            m := MalMap clone
            ast foreach(k, v,
-               keyObj := MalMap keyToObj(k)
-               m atPut(MalMap objToKey(EVAL(keyObj, env)), EVAL(v, env))
+               m atPut(k, EVAL(v, env))
            )
            m,
        ast

--- a/impls/io/step5_tco.io
+++ b/impls/io/step5_tco.io
@@ -11,8 +11,7 @@ eval_ast := method(ast, env,
        "MalMap",
            m := MalMap clone
            ast foreach(k, v,
-               keyObj := MalMap keyToObj(k)
-               m atPut(MalMap objToKey(EVAL(keyObj, env)), EVAL(v, env))
+               m atPut(k, EVAL(v, env))
            )
            m,
        ast

--- a/impls/io/step6_file.io
+++ b/impls/io/step6_file.io
@@ -11,8 +11,7 @@ eval_ast := method(ast, env,
        "MalMap",
            m := MalMap clone
            ast foreach(k, v,
-               keyObj := MalMap keyToObj(k)
-               m atPut(MalMap objToKey(EVAL(keyObj, env)), EVAL(v, env))
+               m atPut(k, EVAL(v, env))
            )
            m,
        ast

--- a/impls/io/step7_quote.io
+++ b/impls/io/step7_quote.io
@@ -28,8 +28,7 @@ eval_ast := method(ast, env,
        "MalMap",
            m := MalMap clone
            ast foreach(k, v,
-               keyObj := MalMap keyToObj(k)
-               m atPut(MalMap objToKey(EVAL(keyObj, env)), EVAL(v, env))
+               m atPut(k, EVAL(v, env))
            )
            m,
        ast

--- a/impls/io/step8_macros.io
+++ b/impls/io/step8_macros.io
@@ -45,8 +45,7 @@ eval_ast := method(ast, env,
        "MalMap",
            m := MalMap clone
            ast foreach(k, v,
-               keyObj := MalMap keyToObj(k)
-               m atPut(MalMap objToKey(EVAL(keyObj, env)), EVAL(v, env))
+               m atPut(k, EVAL(v, env))
            )
            m,
        ast

--- a/impls/io/step9_try.io
+++ b/impls/io/step9_try.io
@@ -45,8 +45,7 @@ eval_ast := method(ast, env,
        "MalMap",
            m := MalMap clone
            ast foreach(k, v,
-               keyObj := MalMap keyToObj(k)
-               m atPut(MalMap objToKey(EVAL(keyObj, env)), EVAL(v, env))
+               m atPut(k, EVAL(v, env))
            )
            m,
        ast

--- a/impls/io/stepA_mal.io
+++ b/impls/io/stepA_mal.io
@@ -45,8 +45,7 @@ eval_ast := method(ast, env,
        "MalMap",
            m := MalMap clone
            ast foreach(k, v,
-               keyObj := MalMap keyToObj(k)
-               m atPut(MalMap objToKey(EVAL(keyObj, env)), EVAL(v, env))
+               m atPut(k, EVAL(v, env))
            )
            m,
        ast

--- a/impls/js/step2_eval.js
+++ b/impls/js/step2_eval.js
@@ -27,7 +27,7 @@ function eval_ast(ast, env) {
     } else if (types._hash_map_Q(ast)) {
         var new_hm = {};
         for (k in ast) {
-            new_hm[EVAL(k, env)] = EVAL(ast[k], env);
+            new_hm[k] = EVAL(ast[k], env);
         }
         return new_hm;
     } else {

--- a/impls/js/step3_env.js
+++ b/impls/js/step3_env.js
@@ -24,7 +24,7 @@ function eval_ast(ast, env) {
     } else if (types._hash_map_Q(ast)) {
         var new_hm = {};
         for (k in ast) {
-            new_hm[EVAL(k, env)] = EVAL(ast[k], env);
+            new_hm[k] = EVAL(ast[k], env);
         }
         return new_hm;
     } else {

--- a/impls/js/step4_if_fn_do.js
+++ b/impls/js/step4_if_fn_do.js
@@ -25,7 +25,7 @@ function eval_ast(ast, env) {
     } else if (types._hash_map_Q(ast)) {
         var new_hm = {};
         for (k in ast) {
-            new_hm[EVAL(k, env)] = EVAL(ast[k], env);
+            new_hm[k] = EVAL(ast[k], env);
         }
         return new_hm;
     } else {

--- a/impls/js/step5_tco.js
+++ b/impls/js/step5_tco.js
@@ -25,7 +25,7 @@ function eval_ast(ast, env) {
     } else if (types._hash_map_Q(ast)) {
         var new_hm = {};
         for (k in ast) {
-            new_hm[EVAL(k, env)] = EVAL(ast[k], env);
+            new_hm[k] = EVAL(ast[k], env);
         }
         return new_hm;
     } else {

--- a/impls/js/step6_file.js
+++ b/impls/js/step6_file.js
@@ -25,7 +25,7 @@ function eval_ast(ast, env) {
     } else if (types._hash_map_Q(ast)) {
         var new_hm = {};
         for (k in ast) {
-            new_hm[EVAL(k, env)] = EVAL(ast[k], env);
+            new_hm[k] = EVAL(ast[k], env);
         }
         return new_hm;
     } else {

--- a/impls/js/step7_quote.js
+++ b/impls/js/step7_quote.js
@@ -48,7 +48,7 @@ function eval_ast(ast, env) {
     } else if (types._hash_map_Q(ast)) {
         var new_hm = {};
         for (k in ast) {
-            new_hm[EVAL(k, env)] = EVAL(ast[k], env);
+            new_hm[k] = EVAL(ast[k], env);
         }
         return new_hm;
     } else {

--- a/impls/js/step8_macros.js
+++ b/impls/js/step8_macros.js
@@ -63,7 +63,7 @@ function eval_ast(ast, env) {
     } else if (types._hash_map_Q(ast)) {
         var new_hm = {};
         for (k in ast) {
-            new_hm[EVAL(k, env)] = EVAL(ast[k], env);
+            new_hm[k] = EVAL(ast[k], env);
         }
         return new_hm;
     } else {

--- a/impls/js/step9_try.js
+++ b/impls/js/step9_try.js
@@ -63,7 +63,7 @@ function eval_ast(ast, env) {
     } else if (types._hash_map_Q(ast)) {
         var new_hm = {};
         for (k in ast) {
-            new_hm[EVAL(k, env)] = EVAL(ast[k], env);
+            new_hm[k] = EVAL(ast[k], env);
         }
         return new_hm;
     } else {

--- a/impls/js/stepA_mal.js
+++ b/impls/js/stepA_mal.js
@@ -63,7 +63,7 @@ function eval_ast(ast, env) {
     } else if (types._hash_map_Q(ast)) {
         var new_hm = {};
         for (k in ast) {
-            new_hm[EVAL(k, env)] = EVAL(ast[k], env);
+            new_hm[k] = EVAL(ast[k], env);
         }
         return new_hm;
     } else {

--- a/impls/julia/step2_eval.jl
+++ b/impls/julia/step2_eval.jl
@@ -17,7 +17,7 @@ function eval_ast(ast, env)
     elseif isa(ast, Array) || isa(ast, Tuple)
         map((x) -> EVAL(x,env), ast)
     elseif isa(ast, Dict)
-        [EVAL(x[1],env) => EVAL(x[2], env) for x=ast]
+        [x[1] => EVAL(x[2], env) for x=ast]
     else
         ast
     end

--- a/impls/julia/step3_env.jl
+++ b/impls/julia/step3_env.jl
@@ -18,7 +18,7 @@ function eval_ast(ast, env)
     elseif isa(ast, Array) || isa(ast, Tuple)
         map((x) -> EVAL(x,env), ast)
     elseif isa(ast, Dict)
-        [EVAL(x[1],env) => EVAL(x[2], env) for x=ast]
+        [x[1] => EVAL(x[2], env) for x=ast]
     else
         ast
     end

--- a/impls/julia/step4_if_fn_do.jl
+++ b/impls/julia/step4_if_fn_do.jl
@@ -19,7 +19,7 @@ function eval_ast(ast, env)
     elseif isa(ast, Array) || isa(ast, Tuple)
         map((x) -> EVAL(x,env), ast)
     elseif isa(ast, Dict)
-        [EVAL(x[1],env) => EVAL(x[2], env) for x=ast]
+        [x[1] => EVAL(x[2], env) for x=ast]
     else
         ast
     end

--- a/impls/julia/step5_tco.jl
+++ b/impls/julia/step5_tco.jl
@@ -20,7 +20,7 @@ function eval_ast(ast, env)
     elseif isa(ast, Array) || isa(ast, Tuple)
         map((x) -> EVAL(x,env), ast)
     elseif isa(ast, Dict)
-        [EVAL(x[1],env) => EVAL(x[2], env) for x=ast]
+        [x[1] => EVAL(x[2], env) for x=ast]
     else
         ast
     end

--- a/impls/julia/step6_file.jl
+++ b/impls/julia/step6_file.jl
@@ -20,7 +20,7 @@ function eval_ast(ast, env)
     elseif isa(ast, Array) || isa(ast, Tuple)
         map((x) -> EVAL(x,env), ast)
     elseif isa(ast, Dict)
-        [EVAL(x[1],env) => EVAL(x[2], env) for x=ast]
+        [x[1] => EVAL(x[2], env) for x=ast]
     else
         ast
     end

--- a/impls/julia/step7_quote.jl
+++ b/impls/julia/step7_quote.jl
@@ -49,7 +49,7 @@ function eval_ast(ast, env)
     elseif isa(ast, Array) || isa(ast, Tuple)
         map((x) -> EVAL(x,env), ast)
     elseif isa(ast, Dict)
-        [EVAL(x[1],env) => EVAL(x[2], env) for x=ast]
+        [x[1] => EVAL(x[2], env) for x=ast]
     else
         ast
     end

--- a/impls/julia/step8_macros.jl
+++ b/impls/julia/step8_macros.jl
@@ -66,7 +66,7 @@ function eval_ast(ast, env)
     elseif isa(ast, Array) || isa(ast, Tuple)
         map((x) -> EVAL(x,env), ast)
     elseif isa(ast, Dict)
-        [EVAL(x[1],env) => EVAL(x[2], env) for x=ast]
+        [x[1] => EVAL(x[2], env) for x=ast]
     else
         ast
     end

--- a/impls/julia/step9_try.jl
+++ b/impls/julia/step9_try.jl
@@ -66,7 +66,7 @@ function eval_ast(ast, env)
     elseif isa(ast, Array) || isa(ast, Tuple)
         map((x) -> EVAL(x,env), ast)
     elseif isa(ast, Dict)
-        [EVAL(x[1],env) => EVAL(x[2], env) for x=ast]
+        [x[1] => EVAL(x[2], env) for x=ast]
     else
         ast
     end

--- a/impls/julia/stepA_mal.jl
+++ b/impls/julia/stepA_mal.jl
@@ -66,7 +66,7 @@ function eval_ast(ast, env)
     elseif isa(ast, Array) || isa(ast, Tuple)
         map((x) -> EVAL(x,env), ast)
     elseif isa(ast, Dict)
-        [EVAL(x[1],env) => EVAL(x[2], env) for x=ast]
+        [x[1] => EVAL(x[2], env) for x=ast]
     else
         ast
     end

--- a/impls/lua/step2_eval.lua
+++ b/impls/lua/step2_eval.lua
@@ -28,7 +28,7 @@ function eval_ast(ast, env)
     elseif types._hash_map_Q(ast) then
         local new_hm = {}
         for k,v in pairs(ast) do
-            new_hm[EVAL(k, env)] = EVAL(v, env)
+            new_hm[k] = EVAL(v, env)
         end
         return HashMap:new(new_hm)
     else

--- a/impls/lua/step3_env.lua
+++ b/impls/lua/step3_env.lua
@@ -26,7 +26,7 @@ function eval_ast(ast, env)
     elseif types._hash_map_Q(ast) then
         local new_hm = {}
         for k,v in pairs(ast) do
-            new_hm[EVAL(k, env)] = EVAL(v, env)
+            new_hm[k] = EVAL(v, env)
         end
         return HashMap:new(new_hm)
     else

--- a/impls/lua/step4_if_fn_do.lua
+++ b/impls/lua/step4_if_fn_do.lua
@@ -27,7 +27,7 @@ function eval_ast(ast, env)
     elseif types._hash_map_Q(ast) then
         local new_hm = {}
         for k,v in pairs(ast) do
-            new_hm[EVAL(k, env)] = EVAL(v, env)
+            new_hm[k] = EVAL(v, env)
         end
         return HashMap:new(new_hm)
     else

--- a/impls/lua/step5_tco.lua
+++ b/impls/lua/step5_tco.lua
@@ -27,7 +27,7 @@ function eval_ast(ast, env)
     elseif types._hash_map_Q(ast) then
         local new_hm = {}
         for k,v in pairs(ast) do
-            new_hm[EVAL(k, env)] = EVAL(v, env)
+            new_hm[k] = EVAL(v, env)
         end
         return HashMap:new(new_hm)
     else

--- a/impls/lua/step6_file.lua
+++ b/impls/lua/step6_file.lua
@@ -27,7 +27,7 @@ function eval_ast(ast, env)
     elseif types._hash_map_Q(ast) then
         local new_hm = {}
         for k,v in pairs(ast) do
-            new_hm[EVAL(k, env)] = EVAL(v, env)
+            new_hm[k] = EVAL(v, env)
         end
         return HashMap:new(new_hm)
     else

--- a/impls/lua/step7_quote.lua
+++ b/impls/lua/step7_quote.lua
@@ -60,7 +60,7 @@ function eval_ast(ast, env)
     elseif types._hash_map_Q(ast) then
         local new_hm = {}
         for k,v in pairs(ast) do
-            new_hm[EVAL(k, env)] = EVAL(v, env)
+            new_hm[k] = EVAL(v, env)
         end
         return HashMap:new(new_hm)
     else

--- a/impls/lua/step8_macros.lua
+++ b/impls/lua/step8_macros.lua
@@ -77,7 +77,7 @@ function eval_ast(ast, env)
     elseif types._hash_map_Q(ast) then
         local new_hm = {}
         for k,v in pairs(ast) do
-            new_hm[EVAL(k, env)] = EVAL(v, env)
+            new_hm[k] = EVAL(v, env)
         end
         return HashMap:new(new_hm)
     else

--- a/impls/lua/step9_try.lua
+++ b/impls/lua/step9_try.lua
@@ -77,7 +77,7 @@ function eval_ast(ast, env)
     elseif types._hash_map_Q(ast) then
         local new_hm = {}
         for k,v in pairs(ast) do
-            new_hm[EVAL(k, env)] = EVAL(v, env)
+            new_hm[k] = EVAL(v, env)
         end
         return HashMap:new(new_hm)
     else

--- a/impls/lua/stepA_mal.lua
+++ b/impls/lua/stepA_mal.lua
@@ -78,7 +78,7 @@ function eval_ast(ast, env)
     elseif types._hash_map_Q(ast) then
         local new_hm = {}
         for k,v in pairs(ast) do
-            new_hm[EVAL(k, env)] = EVAL(v, env)
+            new_hm[k] = EVAL(v, env)
         end
         return HashMap:new(new_hm)
     else

--- a/impls/matlab/step2_eval.m
+++ b/impls/matlab/step2_eval.m
@@ -25,7 +25,7 @@ function ret = eval_ast(ast, env)
         ks = ast.keys();
         for i=1:length(ks)
             k = ks{i};
-            ret.set(EVAL(k, env), EVAL(ast.get(k), env));
+            ret.set(k, EVAL(ast.get(k), env));
         end
     otherwise
         ret = ast;

--- a/impls/matlab/step3_env.m
+++ b/impls/matlab/step3_env.m
@@ -25,7 +25,7 @@ function ret = eval_ast(ast, env)
         ks = ast.keys();
         for i=1:length(ks)
             k = ks{i};
-            ret.set(EVAL(k, env), EVAL(ast.get(k), env));
+            ret.set(k, EVAL(ast.get(k), env));
         end
     otherwise
         ret = ast;

--- a/impls/matlab/step4_if_fn_do.m
+++ b/impls/matlab/step4_if_fn_do.m
@@ -25,7 +25,7 @@ function ret = eval_ast(ast, env)
         ks = ast.keys();
         for i=1:length(ks)
             k = ks{i};
-            ret.set(EVAL(k, env), EVAL(ast.get(k), env));
+            ret.set(k, EVAL(ast.get(k), env));
         end
     otherwise
         ret = ast;

--- a/impls/matlab/step5_tco.m
+++ b/impls/matlab/step5_tco.m
@@ -25,7 +25,7 @@ function ret = eval_ast(ast, env)
         ks = ast.keys();
         for i=1:length(ks)
             k = ks{i};
-            ret.set(EVAL(k, env), EVAL(ast.get(k), env));
+            ret.set(k, EVAL(ast.get(k), env));
         end
     otherwise
         ret = ast;

--- a/impls/matlab/step6_file.m
+++ b/impls/matlab/step6_file.m
@@ -25,7 +25,7 @@ function ret = eval_ast(ast, env)
         ks = ast.keys();
         for i=1:length(ks)
             k = ks{i};
-            ret.set(EVAL(k, env), EVAL(ast.get(k), env));
+            ret.set(k, EVAL(ast.get(k), env));
         end
     otherwise
         ret = ast;

--- a/impls/matlab/step7_quote.m
+++ b/impls/matlab/step7_quote.m
@@ -62,7 +62,7 @@ function ret = eval_ast(ast, env)
         ks = ast.keys();
         for i=1:length(ks)
             k = ks{i};
-            ret.set(EVAL(k, env), EVAL(ast.get(k), env));
+            ret.set(k, EVAL(ast.get(k), env));
         end
     otherwise
         ret = ast;

--- a/impls/matlab/step8_macros.m
+++ b/impls/matlab/step8_macros.m
@@ -81,7 +81,7 @@ function ret = eval_ast(ast, env)
         ks = ast.keys();
         for i=1:length(ks)
             k = ks{i};
-            ret.set(EVAL(k, env), EVAL(ast.get(k), env));
+            ret.set(k, EVAL(ast.get(k), env));
         end
     otherwise
         ret = ast;

--- a/impls/matlab/step9_try.m
+++ b/impls/matlab/step9_try.m
@@ -81,7 +81,7 @@ function ret = eval_ast(ast, env)
         ks = ast.keys();
         for i=1:length(ks)
             k = ks{i};
-            ret.set(EVAL(k, env), EVAL(ast.get(k), env));
+            ret.set(k, EVAL(ast.get(k), env));
         end
     otherwise
         ret = ast;

--- a/impls/matlab/stepA_mal.m
+++ b/impls/matlab/stepA_mal.m
@@ -81,7 +81,7 @@ function ret = eval_ast(ast, env)
         ks = ast.keys();
         for i=1:length(ks)
             k = ks{i};
-            ret.set(EVAL(k, env), EVAL(ast.get(k), env));
+            ret.set(k, EVAL(ast.get(k), env));
         end
     otherwise
         ret = ast;

--- a/impls/miniMAL/step2_eval.json
+++ b/impls/miniMAL/step2_eval.json
@@ -22,7 +22,7 @@
     ["let", ["new-hm", ["hash-map"]],
       ["do",
         ["map", ["fn", ["k"], ["set", "new-hm",
-                                ["EVAL", "k", "env"],
+                                "k",
                                 ["EVAL", ["get", "ast", "k"], "env"]]],
                 ["keys", "ast"]],
         "new-hm"]],

--- a/impls/miniMAL/step3_env.json
+++ b/impls/miniMAL/step3_env.json
@@ -20,7 +20,7 @@
     ["let", ["new-hm", ["hash-map"]],
       ["do",
         ["map", ["fn", ["k"], ["set", "new-hm",
-                                ["EVAL", "k", "env"],
+                                "k",
                                 ["EVAL", ["get", "ast", "k"], "env"]]],
                 ["keys", "ast"]],
         "new-hm"]],

--- a/impls/miniMAL/step4_if_fn_do.json
+++ b/impls/miniMAL/step4_if_fn_do.json
@@ -20,7 +20,7 @@
     ["let", ["new-hm", ["hash-map"]],
       ["do",
         ["map", ["fn", ["k"], ["set", "new-hm",
-                                ["EVAL", "k", "env"],
+                                "k",
                                 ["EVAL", ["get", "ast", "k"], "env"]]],
                 ["keys", "ast"]],
         "new-hm"]],

--- a/impls/miniMAL/step5_tco.json
+++ b/impls/miniMAL/step5_tco.json
@@ -20,7 +20,7 @@
     ["let", ["new-hm", ["hash-map"]],
       ["do",
         ["map", ["fn", ["k"], ["set", "new-hm",
-                                ["EVAL", "k", "env"],
+                                "k",
                                 ["EVAL", ["get", "ast", "k"], "env"]]],
                 ["keys", "ast"]],
         "new-hm"]],

--- a/impls/miniMAL/step6_file.json
+++ b/impls/miniMAL/step6_file.json
@@ -20,7 +20,7 @@
     ["let", ["new-hm", ["hash-map"]],
       ["do",
         ["map", ["fn", ["k"], ["set", "new-hm",
-                                ["EVAL", "k", "env"],
+                                "k",
                                 ["EVAL", ["get", "ast", "k"], "env"]]],
                 ["keys", "ast"]],
         "new-hm"]],

--- a/impls/miniMAL/step7_quote.json
+++ b/impls/miniMAL/step7_quote.json
@@ -47,7 +47,7 @@
     ["let", ["new-hm", ["hash-map"]],
       ["do",
         ["map", ["fn", ["k"], ["set", "new-hm",
-                                ["EVAL", "k", "env"],
+                                "k",
                                 ["EVAL", ["get", "ast", "k"], "env"]]],
                 ["keys", "ast"]],
         "new-hm"]],

--- a/impls/miniMAL/step8_macros.json
+++ b/impls/miniMAL/step8_macros.json
@@ -61,7 +61,7 @@
     ["let", ["new-hm", ["hash-map"]],
       ["do",
         ["map", ["fn", ["k"], ["set", "new-hm",
-                                ["EVAL", "k", "env"],
+                                "k",
                                 ["EVAL", ["get", "ast", "k"], "env"]]],
                 ["keys", "ast"]],
         "new-hm"]],

--- a/impls/miniMAL/step9_try.json
+++ b/impls/miniMAL/step9_try.json
@@ -61,7 +61,7 @@
     ["let", ["new-hm", ["hash-map"]],
       ["do",
         ["map", ["fn", ["k"], ["set", "new-hm",
-                                ["EVAL", "k", "env"],
+                                "k",
                                 ["EVAL", ["get", "ast", "k"], "env"]]],
                 ["keys", "ast"]],
         "new-hm"]],

--- a/impls/miniMAL/stepA_mal.json
+++ b/impls/miniMAL/stepA_mal.json
@@ -61,7 +61,7 @@
     ["let", ["new-hm", ["hash-map"]],
       ["do",
         ["map", ["fn", ["k"], ["set", "new-hm",
-                                ["EVAL", "k", "env"],
+                                "k",
                                 ["EVAL", ["get", "ast", "k"], "env"]]],
                 ["keys", "ast"]],
         "new-hm"]],

--- a/impls/ocaml/step2_eval.ml
+++ b/impls/ocaml/step2_eval.ml
@@ -35,7 +35,7 @@ let rec eval_ast ast env =
       -> T.Map {T.meta = meta;
                 T.value = (Types.MalMap.fold
                              (fun k v m
-                              -> Types.MalMap.add (eval k env) (eval v env) m)
+                              -> Types.MalMap.add k (eval v env) m)
                              xs
                              Types.MalMap.empty)}
     | _ -> ast

--- a/impls/ocaml/step3_env.ml
+++ b/impls/ocaml/step3_env.ml
@@ -27,7 +27,7 @@ let rec eval_ast ast env =
       -> T.Map {T.meta = meta;
                 T.value = (Types.MalMap.fold
                              (fun k v m
-                              -> Types.MalMap.add (eval k env) (eval v env) m)
+                              -> Types.MalMap.add k (eval v env) m)
                              xs
                              Types.MalMap.empty)}
     | _ -> ast

--- a/impls/ocaml/step4_if_fn_do.ml
+++ b/impls/ocaml/step4_if_fn_do.ml
@@ -15,7 +15,7 @@ let rec eval_ast ast env =
       -> T.Map {T.meta = meta;
                 T.value = (Types.MalMap.fold
                              (fun k v m
-                              -> Types.MalMap.add (eval k env) (eval v env) m)
+                              -> Types.MalMap.add k (eval v env) m)
                              xs
                              Types.MalMap.empty)}
     | _ -> ast

--- a/impls/ocaml/step6_file.ml
+++ b/impls/ocaml/step6_file.ml
@@ -15,7 +15,7 @@ let rec eval_ast ast env =
       -> T.Map {T.meta = meta;
                 T.value = (Types.MalMap.fold
                              (fun k v m
-                              -> Types.MalMap.add (eval k env) (eval v env) m)
+                              -> Types.MalMap.add k (eval v env) m)
                              xs
                              Types.MalMap.empty)}
     | _ -> ast

--- a/impls/ocaml/step7_quote.ml
+++ b/impls/ocaml/step7_quote.ml
@@ -29,7 +29,7 @@ let rec eval_ast ast env =
       -> T.Map {T.meta = meta;
                 T.value = (Types.MalMap.fold
                              (fun k v m
-                              -> Types.MalMap.add (eval k env) (eval v env) m)
+                              -> Types.MalMap.add k (eval v env) m)
                              xs
                              Types.MalMap.empty)}
     | _ -> ast

--- a/impls/ocaml/step8_macros.ml
+++ b/impls/ocaml/step8_macros.ml
@@ -48,7 +48,7 @@ let rec eval_ast ast env =
       -> T.Map {T.meta = meta;
                 T.value = (Types.MalMap.fold
                              (fun k v m
-                              -> Types.MalMap.add (eval k env) (eval v env) m)
+                              -> Types.MalMap.add k (eval v env) m)
                              xs
                              Types.MalMap.empty)}
     | _ -> ast

--- a/impls/ocaml/step9_try.ml
+++ b/impls/ocaml/step9_try.ml
@@ -48,7 +48,7 @@ let rec eval_ast ast env =
       -> T.Map {T.meta = meta;
                 T.value = (Types.MalMap.fold
                              (fun k v m
-                              -> Types.MalMap.add (eval k env) (eval v env) m)
+                              -> Types.MalMap.add k (eval v env) m)
                              xs
                              Types.MalMap.empty)}
     | _ -> ast

--- a/impls/ocaml/stepA_mal.ml
+++ b/impls/ocaml/stepA_mal.ml
@@ -48,7 +48,7 @@ let rec eval_ast ast env =
       -> T.Map {T.meta = meta;
                 T.value = (Types.MalMap.fold
                              (fun k v m
-                              -> Types.MalMap.add (eval k env) (eval v env) m)
+                              -> Types.MalMap.add k (eval v env) m)
                              xs
                              Types.MalMap.empty)}
     | _ -> ast

--- a/impls/python/step2_eval.py
+++ b/impls/python/step2_eval.py
@@ -19,11 +19,7 @@ def eval_ast(ast, env):
     elif types._vector_Q(ast):
         return types._vector(*map(lambda a: EVAL(a, env), ast))
     elif types._hash_map_Q(ast):
-        keyvals = []
-        for k in ast.keys():
-            keyvals.append(EVAL(k, env))
-            keyvals.append(EVAL(ast[k], env))
-        return types._hash_map(*keyvals)
+        return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     else:
         return ast  # primitive value, return unchanged
 

--- a/impls/python/step3_env.py
+++ b/impls/python/step3_env.py
@@ -17,11 +17,7 @@ def eval_ast(ast, env):
     elif types._vector_Q(ast):
         return types._vector(*map(lambda a: EVAL(a, env), ast))
     elif types._hash_map_Q(ast):
-        keyvals = []
-        for k in ast.keys():
-            keyvals.append(EVAL(k, env))
-            keyvals.append(EVAL(ast[k], env))
-        return types._hash_map(*keyvals)
+        return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     else:
         return ast  # primitive value, return unchanged
 

--- a/impls/python/step4_if_fn_do.py
+++ b/impls/python/step4_if_fn_do.py
@@ -18,11 +18,7 @@ def eval_ast(ast, env):
     elif types._vector_Q(ast):
         return types._vector(*map(lambda a: EVAL(a, env), ast))
     elif types._hash_map_Q(ast):
-        keyvals = []
-        for k in ast.keys():
-            keyvals.append(EVAL(k, env))
-            keyvals.append(EVAL(ast[k], env))
-        return types._hash_map(*keyvals)
+        return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     else:
         return ast  # primitive value, return unchanged
 

--- a/impls/python/step5_tco.py
+++ b/impls/python/step5_tco.py
@@ -18,11 +18,7 @@ def eval_ast(ast, env):
     elif types._vector_Q(ast):
         return types._vector(*map(lambda a: EVAL(a, env), ast))
     elif types._hash_map_Q(ast):
-        keyvals = []
-        for k in ast.keys():
-            keyvals.append(EVAL(k, env))
-            keyvals.append(EVAL(ast[k], env))
-        return types._hash_map(*keyvals)
+        return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     else:
         return ast  # primitive value, return unchanged
 

--- a/impls/python/step6_file.py
+++ b/impls/python/step6_file.py
@@ -18,11 +18,7 @@ def eval_ast(ast, env):
     elif types._vector_Q(ast):
         return types._vector(*map(lambda a: EVAL(a, env), ast))
     elif types._hash_map_Q(ast):
-        keyvals = []
-        for k in ast.keys():
-            keyvals.append(EVAL(k, env))
-            keyvals.append(EVAL(ast[k], env))
-        return types._hash_map(*keyvals)
+        return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     else:
         return ast  # primitive value, return unchanged
 

--- a/impls/python/step7_quote.py
+++ b/impls/python/step7_quote.py
@@ -41,11 +41,7 @@ def eval_ast(ast, env):
     elif types._vector_Q(ast):
         return types._vector(*map(lambda a: EVAL(a, env), ast))
     elif types._hash_map_Q(ast):
-        keyvals = []
-        for k in ast.keys():
-            keyvals.append(EVAL(k, env))
-            keyvals.append(EVAL(ast[k], env))
-        return types._hash_map(*keyvals)
+        return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     else:
         return ast  # primitive value, return unchanged
 

--- a/impls/python/step8_macros.py
+++ b/impls/python/step8_macros.py
@@ -53,11 +53,7 @@ def eval_ast(ast, env):
     elif types._vector_Q(ast):
         return types._vector(*map(lambda a: EVAL(a, env), ast))
     elif types._hash_map_Q(ast):
-        keyvals = []
-        for k in ast.keys():
-            keyvals.append(EVAL(k, env))
-            keyvals.append(EVAL(ast[k], env))
-        return types._hash_map(*keyvals)
+        return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     else:
         return ast  # primitive value, return unchanged
 

--- a/impls/python/step9_try.py
+++ b/impls/python/step9_try.py
@@ -53,11 +53,7 @@ def eval_ast(ast, env):
     elif types._vector_Q(ast):
         return types._vector(*map(lambda a: EVAL(a, env), ast))
     elif types._hash_map_Q(ast):
-        keyvals = []
-        for k in ast.keys():
-            keyvals.append(EVAL(k, env))
-            keyvals.append(EVAL(ast[k], env))
-        return types._hash_map(*keyvals)
+        return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     else:
         return ast  # primitive value, return unchanged
 

--- a/impls/python/stepA_mal.py
+++ b/impls/python/stepA_mal.py
@@ -53,11 +53,7 @@ def eval_ast(ast, env):
     elif types._vector_Q(ast):
         return types._vector(*map(lambda a: EVAL(a, env), ast))
     elif types._hash_map_Q(ast):
-        keyvals = []
-        for k in ast.keys():
-            keyvals.append(EVAL(k, env))
-            keyvals.append(EVAL(ast[k], env))
-        return types._hash_map(*keyvals)
+        return types.Hash_Map((k, EVAL(v, env)) for k, v in ast.items())
     else:
         return ast  # primitive value, return unchanged
 

--- a/impls/ruby/step2_eval.rb
+++ b/impls/ruby/step2_eval.rb
@@ -20,7 +20,7 @@ def eval_ast(ast, env)
             Vector.new ast.map{|a| EVAL(a, env)}
         when Hash
             new_hm = {}
-            ast.each{|k,v| new_hm[EVAL(k,env)] = EVAL(v, env)}
+            ast.each{|k,v| new_hm[k] = EVAL(v, env)}
             new_hm
         else 
             ast

--- a/impls/ruby/step3_env.rb
+++ b/impls/ruby/step3_env.rb
@@ -20,7 +20,7 @@ def eval_ast(ast, env)
             Vector.new ast.map{|a| EVAL(a, env)}
         when Hash
             new_hm = {}
-            ast.each{|k,v| new_hm[EVAL(k,env)] = EVAL(v, env)}
+            ast.each{|k,v| new_hm[k] = EVAL(v, env)}
             new_hm
         else 
             ast

--- a/impls/ruby/step4_if_fn_do.rb
+++ b/impls/ruby/step4_if_fn_do.rb
@@ -21,7 +21,7 @@ def eval_ast(ast, env)
             Vector.new ast.map{|a| EVAL(a, env)}
         when Hash
             new_hm = {}
-            ast.each{|k,v| new_hm[EVAL(k,env)] = EVAL(v, env)}
+            ast.each{|k,v| new_hm[k] = EVAL(v, env)}
             new_hm
         else 
             ast

--- a/impls/ruby/step5_tco.rb
+++ b/impls/ruby/step5_tco.rb
@@ -21,7 +21,7 @@ def eval_ast(ast, env)
             Vector.new ast.map{|a| EVAL(a, env)}
         when Hash
             new_hm = {}
-            ast.each{|k,v| new_hm[EVAL(k,env)] = EVAL(v, env)}
+            ast.each{|k,v| new_hm[k] = EVAL(v, env)}
             new_hm
         else 
             ast

--- a/impls/ruby/step6_file.rb
+++ b/impls/ruby/step6_file.rb
@@ -21,7 +21,7 @@ def eval_ast(ast, env)
             Vector.new ast.map{|a| EVAL(a, env)}
         when Hash
             new_hm = {}
-            ast.each{|k,v| new_hm[EVAL(k,env)] = EVAL(v, env)}
+            ast.each{|k,v| new_hm[k] = EVAL(v, env)}
             new_hm
         else 
             ast

--- a/impls/ruby/step7_quote.rb
+++ b/impls/ruby/step7_quote.rb
@@ -52,7 +52,7 @@ def eval_ast(ast, env)
             Vector.new ast.map{|a| EVAL(a, env)}
         when Hash
             new_hm = {}
-            ast.each{|k,v| new_hm[EVAL(k,env)] = EVAL(v, env)}
+            ast.each{|k,v| new_hm[k] = EVAL(v, env)}
             new_hm
         else 
             ast

--- a/impls/ruby/step8_macros.rb
+++ b/impls/ruby/step8_macros.rb
@@ -72,7 +72,7 @@ def eval_ast(ast, env)
             Vector.new ast.map{|a| EVAL(a, env)}
         when Hash
             new_hm = {}
-            ast.each{|k,v| new_hm[EVAL(k,env)] = EVAL(v, env)}
+            ast.each{|k,v| new_hm[k] = EVAL(v, env)}
             new_hm
         else 
             ast

--- a/impls/ruby/step9_try.rb
+++ b/impls/ruby/step9_try.rb
@@ -72,7 +72,7 @@ def eval_ast(ast, env)
             Vector.new ast.map{|a| EVAL(a, env)}
         when Hash
             new_hm = {}
-            ast.each{|k,v| new_hm[EVAL(k,env)] = EVAL(v, env)}
+            ast.each{|k,v| new_hm[k] = EVAL(v, env)}
             new_hm
         else 
             ast

--- a/impls/ruby/stepA_mal.rb
+++ b/impls/ruby/stepA_mal.rb
@@ -72,7 +72,7 @@ def eval_ast(ast, env)
             Vector.new ast.map{|a| EVAL(a, env)}
         when Hash
             new_hm = {}
-            ast.each{|k,v| new_hm[EVAL(k,env)] = EVAL(v, env)}
+            ast.each{|k,v| new_hm[k] = EVAL(v, env)}
             new_hm
         else 
             ast

--- a/impls/skew/step2_eval.sk
+++ b/impls/skew/step2_eval.sk
@@ -16,7 +16,7 @@ def eval_ast(ast MalVal, env StringMap<MalVal>) MalVal {
   } else if ast is MalHashMap {
     var result List<MalVal> = []
     (ast as MalHashMap).val.each((k string, v MalVal) => {
-      result.append(EVAL(MalVal.fromHashKey(k), env))
+      result.append(MalVal.fromHashKey(k))
       result.append(EVAL(v, env))
     })
     return MalHashMap.fromList(result)

--- a/impls/skew/step3_env.sk
+++ b/impls/skew/step3_env.sk
@@ -12,7 +12,7 @@ def eval_ast(ast MalVal, env Env) MalVal {
   } else if ast is MalHashMap {
     var result List<MalVal> = []
     (ast as MalHashMap).val.each((k string, v MalVal) => {
-      result.append(EVAL(MalVal.fromHashKey(k), env))
+      result.append(MalVal.fromHashKey(k))
       result.append(EVAL(v, env))
     })
     return MalHashMap.fromList(result)

--- a/impls/skew/step4_if_fn_do.sk
+++ b/impls/skew/step4_if_fn_do.sk
@@ -12,7 +12,7 @@ def eval_ast(ast MalVal, env Env) MalVal {
   } else if ast is MalHashMap {
     var result List<MalVal> = []
     (ast as MalHashMap).val.each((k string, v MalVal) => {
-      result.append(EVAL(MalVal.fromHashKey(k), env))
+      result.append(MalVal.fromHashKey(k))
       result.append(EVAL(v, env))
     })
     return MalHashMap.fromList(result)

--- a/impls/skew/step5_tco.sk
+++ b/impls/skew/step5_tco.sk
@@ -12,7 +12,7 @@ def eval_ast(ast MalVal, env Env) MalVal {
   } else if ast is MalHashMap {
     var result List<MalVal> = []
     (ast as MalHashMap).val.each((k string, v MalVal) => {
-      result.append(EVAL(MalVal.fromHashKey(k), env))
+      result.append(MalVal.fromHashKey(k))
       result.append(EVAL(v, env))
     })
     return MalHashMap.fromList(result)

--- a/impls/skew/step6_file.sk
+++ b/impls/skew/step6_file.sk
@@ -12,7 +12,7 @@ def eval_ast(ast MalVal, env Env) MalVal {
   } else if ast is MalHashMap {
     var result List<MalVal> = []
     (ast as MalHashMap).val.each((k string, v MalVal) => {
-      result.append(EVAL(MalVal.fromHashKey(k), env))
+      result.append(MalVal.fromHashKey(k))
       result.append(EVAL(v, env))
     })
     return MalHashMap.fromList(result)

--- a/impls/skew/step7_quote.sk
+++ b/impls/skew/step7_quote.sk
@@ -43,7 +43,7 @@ def eval_ast(ast MalVal, env Env) MalVal {
   } else if ast is MalHashMap {
     var result List<MalVal> = []
     (ast as MalHashMap).val.each((k string, v MalVal) => {
-      result.append(EVAL(MalVal.fromHashKey(k), env))
+      result.append(MalVal.fromHashKey(k))
       result.append(EVAL(v, env))
     })
     return MalHashMap.fromList(result)

--- a/impls/skew/step8_macros.sk
+++ b/impls/skew/step8_macros.sk
@@ -65,7 +65,7 @@ def eval_ast(ast MalVal, env Env) MalVal {
   } else if ast is MalHashMap {
     var result List<MalVal> = []
     (ast as MalHashMap).val.each((k string, v MalVal) => {
-      result.append(EVAL(MalVal.fromHashKey(k), env))
+      result.append(MalVal.fromHashKey(k))
       result.append(EVAL(v, env))
     })
     return MalHashMap.fromList(result)

--- a/impls/skew/step9_try.sk
+++ b/impls/skew/step9_try.sk
@@ -65,7 +65,7 @@ def eval_ast(ast MalVal, env Env) MalVal {
   } else if ast is MalHashMap {
     var result List<MalVal> = []
     (ast as MalHashMap).val.each((k string, v MalVal) => {
-      result.append(EVAL(MalVal.fromHashKey(k), env))
+      result.append(MalVal.fromHashKey(k))
       result.append(EVAL(v, env))
     })
     return MalHashMap.fromList(result)

--- a/impls/skew/stepA_mal.sk
+++ b/impls/skew/stepA_mal.sk
@@ -65,7 +65,7 @@ def eval_ast(ast MalVal, env Env) MalVal {
   } else if ast is MalHashMap {
     var result List<MalVal> = []
     (ast as MalHashMap).val.each((k string, v MalVal) => {
-      result.append(EVAL(MalVal.fromHashKey(k), env))
+      result.append(MalVal.fromHashKey(k))
       result.append(EVAL(v, env))
     })
     return MalHashMap.fromList(result)

--- a/impls/sml/step2_eval.sml
+++ b/impls/sml/step2_eval.sml
@@ -12,7 +12,7 @@ and evalAst e ast = case ast of
     SYMBOL s       => (case lookup e s of SOME v => v | NONE => raise NotDefined ("unable to resolve symbol '" ^ s ^ "'"))
     | LIST (l,_)   => LIST (List.map (eval e) l, NO_META)
     | VECTOR (v,_) => VECTOR (List.map (eval e) v, NO_META)
-    | MAP (m,_)    => MAP (List.map (fn (k, v) => (eval e k, eval e v)) m, NO_META)
+    | MAP (m,_)    => MAP (List.map (fn (k, v) => (k, eval e v)) m, NO_META)
     | _            => ast
 
 and evalApply e ast = case evalAst e ast of

--- a/impls/sml/step3_env.sml
+++ b/impls/sml/step3_env.sml
@@ -7,7 +7,7 @@ fun read s =
 fun eval e (LIST (a::args,_)) = (case specialEval a of SOME special => special e args | _ => evalApply e (eval e a) args)
   | eval e (SYMBOL s)         = evalSymbol e s
   | eval e (VECTOR (v,_))     = VECTOR (map (eval e) v, NO_META)
-  | eval e (MAP (m,_))        = MAP (List.map (fn (k, v) => (eval e k, eval e v)) m, NO_META)
+  | eval e (MAP (m,_))        = MAP (List.map (fn (k, v) => (k, eval e v)) m, NO_META)
   | eval e ast                = ast
 
 and specialEval (SYMBOL "def!") = SOME evalDef

--- a/impls/sml/step4_if_fn_do.sml
+++ b/impls/sml/step4_if_fn_do.sml
@@ -4,7 +4,7 @@ fun read s =
 fun eval e (LIST (a::args,_)) = (case specialEval a of SOME special => special e args | _ => evalApply e (eval e a) args)
   | eval e (SYMBOL s)         = evalSymbol e s
   | eval e (VECTOR (v,_))     = VECTOR (map (eval e) v, NO_META)
-  | eval e (MAP (m,_))        = MAP (List.map (fn (k, v) => (eval e k, eval e v)) m, NO_META)
+  | eval e (MAP (m,_))        = MAP (List.map (fn (k, v) => (k, eval e v)) m, NO_META)
   | eval e ast                = ast
 
 and specialEval (SYMBOL "def!") = SOME evalDef

--- a/impls/sml/step6_file.sml
+++ b/impls/sml/step6_file.sml
@@ -4,7 +4,7 @@ fun read s =
 fun eval e (LIST (a::args,_)) = (case specialEval a of SOME special => special e args | _ => evalApply e (eval e a) args)
   | eval e (SYMBOL s)         = evalSymbol e s
   | eval e (VECTOR (v,_))     = VECTOR (map (eval e) v, NO_META)
-  | eval e (MAP (m,_))        = MAP (List.map (fn (k, v) => (eval e k, eval e v)) m, NO_META)
+  | eval e (MAP (m,_))        = MAP (List.map (fn (k, v) => (k, eval e v)) m, NO_META)
   | eval e ast                = ast
 
 and specialEval (SYMBOL "def!") = SOME evalDef

--- a/impls/sml/step7_quote.sml
+++ b/impls/sml/step7_quote.sml
@@ -4,7 +4,7 @@ fun read s =
 fun eval e (LIST (a::args,_)) = (case specialEval a of SOME special => special e args | _ => evalApply e (eval e a) args)
   | eval e (SYMBOL s)         = evalSymbol e s
   | eval e (VECTOR (v,_))     = VECTOR (map (eval e) v, NO_META)
-  | eval e (MAP (m,_))        = MAP (List.map (fn (k, v) => (eval e k, eval e v)) m, NO_META)
+  | eval e (MAP (m,_))        = MAP (List.map (fn (k, v) => (k, eval e v)) m, NO_META)
   | eval e ast                = ast
 
 and specialEval (SYMBOL "def!")             = SOME evalDef

--- a/impls/sml/step8_macros.sml
+++ b/impls/sml/step8_macros.sml
@@ -6,7 +6,7 @@ fun eval e ast = eval' e (expandMacro e [ast])
 and eval' e (LIST (a::args,_)) = (case specialEval a of SOME special => special e args | _ => evalApply e (eval e a) args)
   | eval' e (SYMBOL s)         = evalSymbol e s
   | eval' e (VECTOR (v,_))     = VECTOR (map (eval e) v, NO_META)
-  | eval' e (MAP (m,_))        = MAP (List.map (fn (k, v) => (eval e k, eval e v)) m, NO_META)
+  | eval' e (MAP (m,_))        = MAP (List.map (fn (k, v) => (k, eval e v)) m, NO_META)
   | eval' e ast                = ast
 
 and specialEval (SYMBOL "def!")             = SOME evalDef

--- a/impls/sml/step9_try.sml
+++ b/impls/sml/step9_try.sml
@@ -6,7 +6,7 @@ fun eval e ast = eval' e (expandMacro e [ast])
 and eval' e (LIST (a::args, _)) = (case specialEval a of SOME special => special e args | _ => evalApply e (eval e a) args)
   | eval' e (SYMBOL s)          = evalSymbol e s
   | eval' e (VECTOR (v,_))      = VECTOR (map (eval e) v, NO_META)
-  | eval' e (MAP (m,_))         = MAP (List.map (fn (k, v) => (eval e k, eval e v)) m, NO_META)
+  | eval' e (MAP (m,_))         = MAP (List.map (fn (k, v) => (k, eval e v)) m, NO_META)
   | eval' e ast                 = ast
 
 and specialEval (SYMBOL "def!")             = SOME evalDef

--- a/impls/sml/stepA_mal.sml
+++ b/impls/sml/stepA_mal.sml
@@ -6,7 +6,7 @@ fun eval e ast = eval' e (expandMacro e [ast])
 and eval' e (LIST (a::args, _)) = (case specialEval a of SOME special => special e args | _ => evalApply e (eval e a) args)
   | eval' e (SYMBOL s)          = evalSymbol e s
   | eval' e (VECTOR (v,_))      = VECTOR (map (eval e) v, NO_META)
-  | eval' e (MAP (m,_))         = MAP (List.map (fn (k, v) => (eval e k, eval e v)) m, NO_META)
+  | eval' e (MAP (m,_))         = MAP (List.map (fn (k, v) => (k, eval e v)) m, NO_META)
   | eval' e ast                 = ast
 
 and specialEval (SYMBOL "def!")             = SOME evalDef

--- a/impls/vimscript/step2_eval.vim
+++ b/impls/vimscript/step2_eval.vim
@@ -21,11 +21,8 @@ function EvalAst(ast, env)
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)
-      let keyobj = HashParseKey(k)
-      let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
-      let keystring = HashMakeKey(newkey)
-      let ret[keystring] = newval
+      let ret[k] = newval
     endfor
     return HashNew(ret)
   else

--- a/impls/vimscript/step3_env.vim
+++ b/impls/vimscript/step3_env.vim
@@ -19,11 +19,8 @@ function EvalAst(ast, env)
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)
-      let keyobj = HashParseKey(k)
-      let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
-      let keystring = HashMakeKey(newkey)
-      let ret[keystring] = newval
+      let ret[k] = newval
     endfor
     return HashNew(ret)
   else

--- a/impls/vimscript/step4_if_fn_do.vim
+++ b/impls/vimscript/step4_if_fn_do.vim
@@ -20,11 +20,8 @@ function EvalAst(ast, env)
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)
-      let keyobj = HashParseKey(k)
-      let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
-      let keystring = HashMakeKey(newkey)
-      let ret[keystring] = newval
+      let ret[k] = newval
     endfor
     return HashNew(ret)
   else

--- a/impls/vimscript/step5_tco.vim
+++ b/impls/vimscript/step5_tco.vim
@@ -20,11 +20,8 @@ function EvalAst(ast, env)
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)
-      let keyobj = HashParseKey(k)
-      let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
-      let keystring = HashMakeKey(newkey)
-      let ret[keystring] = newval
+      let ret[k] = newval
     endfor
     return HashNew(ret)
   else

--- a/impls/vimscript/step6_file.vim
+++ b/impls/vimscript/step6_file.vim
@@ -20,11 +20,8 @@ function EvalAst(ast, env)
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)
-      let keyobj = HashParseKey(k)
-      let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
-      let keystring = HashMakeKey(newkey)
-      let ret[keystring] = newval
+      let ret[k] = newval
     endfor
     return HashNew(ret)
   else

--- a/impls/vimscript/step7_quote.vim
+++ b/impls/vimscript/step7_quote.vim
@@ -55,11 +55,8 @@ function EvalAst(ast, env)
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)
-      let keyobj = HashParseKey(k)
-      let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
-      let keystring = HashMakeKey(newkey)
-      let ret[keystring] = newval
+      let ret[k] = newval
     endfor
     return HashNew(ret)
   else

--- a/impls/vimscript/step8_macros.vim
+++ b/impls/vimscript/step8_macros.vim
@@ -80,11 +80,8 @@ function EvalAst(ast, env)
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)
-      let keyobj = HashParseKey(k)
-      let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
-      let keystring = HashMakeKey(newkey)
-      let ret[keystring] = newval
+      let ret[k] = newval
     endfor
     return HashNew(ret)
   else

--- a/impls/vimscript/step9_try.vim
+++ b/impls/vimscript/step9_try.vim
@@ -82,11 +82,8 @@ function EvalAst(ast, env)
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)
-      let keyobj = HashParseKey(k)
-      let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
-      let keystring = HashMakeKey(newkey)
-      let ret[keystring] = newval
+      let ret[k] = newval
     endfor
     return HashNew(ret)
   else

--- a/impls/vimscript/stepA_mal.vim
+++ b/impls/vimscript/stepA_mal.vim
@@ -82,11 +82,8 @@ function EvalAst(ast, env)
   elseif HashQ(a:ast)
     let ret = {}
     for [k,v] in items(a:ast.val)
-      let keyobj = HashParseKey(k)
-      let newkey = EVAL(keyobj, a:env)
       let newval = EVAL(v, a:env)
-      let keystring = HashMakeKey(newkey)
-      let ret[keystring] = newval
+      let ret[k] = newval
     endfor
     return HashNew(ret)
   else

--- a/impls/yorick/step2_eval.i
+++ b/impls/yorick/step2_eval.i
@@ -40,11 +40,9 @@ func eval_ast(ast, env)
     if (numberof(*h.keys) == 0) return ast
     res = hash_new()
     for (i = 1; i <= numberof(*h.keys); ++i) {
-      new_key = EVAL(hashmap_key_to_obj((*h.keys)(i)), env)
-      if (structof(new_key) == MalError) return new_key
       new_val = EVAL(*((*h.vals)(i)), env)
       if (structof(new_val) == MalError) return new_val
-      hash_set, res, hashmap_obj_to_key(new_key), new_val
+      hash_set, res, (*h.keys)(i), new_val
     }
     return MalHashmap(val=&res)
   } else return ast

--- a/impls/yorick/step3_env.i
+++ b/impls/yorick/step3_env.i
@@ -39,11 +39,9 @@ func eval_ast(ast, env)
     if (numberof(*h.keys) == 0) return ast
     res = hash_new()
     for (i = 1; i <= numberof(*h.keys); ++i) {
-      new_key = EVAL(hashmap_key_to_obj((*h.keys)(i)), env)
-      if (structof(new_key) == MalError) return new_key
       new_val = EVAL(*((*h.vals)(i)), env)
       if (structof(new_val) == MalError) return new_val
-      hash_set, res, hashmap_obj_to_key(new_key), new_val
+      hash_set, res, (*h.keys)(i), new_val
     }
     return MalHashmap(val=&res)
   } else return ast

--- a/impls/yorick/step4_if_fn_do.i
+++ b/impls/yorick/step4_if_fn_do.i
@@ -39,11 +39,9 @@ func eval_ast(ast, env)
     if (numberof(*h.keys) == 0) return ast
     res = hash_new()
     for (i = 1; i <= numberof(*h.keys); ++i) {
-      new_key = EVAL(hashmap_key_to_obj((*h.keys)(i)), env)
-      if (structof(new_key) == MalError) return new_key
       new_val = EVAL(*((*h.vals)(i)), env)
       if (structof(new_val) == MalError) return new_val
-      hash_set, res, hashmap_obj_to_key(new_key), new_val
+      hash_set, res, (*h.keys)(i), new_val
     }
     return MalHashmap(val=&res)
   } else return ast

--- a/impls/yorick/step5_tco.i
+++ b/impls/yorick/step5_tco.i
@@ -39,11 +39,9 @@ func eval_ast(ast, env)
     if (numberof(*h.keys) == 0) return ast
     res = hash_new()
     for (i = 1; i <= numberof(*h.keys); ++i) {
-      new_key = EVAL(hashmap_key_to_obj((*h.keys)(i)), env)
-      if (structof(new_key) == MalError) return new_key
       new_val = EVAL(*((*h.vals)(i)), env)
       if (structof(new_val) == MalError) return new_val
-      hash_set, res, hashmap_obj_to_key(new_key), new_val
+      hash_set, res, (*h.keys)(i), new_val
     }
     return MalHashmap(val=&res)
   } else return ast

--- a/impls/yorick/step6_file.i
+++ b/impls/yorick/step6_file.i
@@ -39,11 +39,9 @@ func eval_ast(ast, env)
     if (numberof(*h.keys) == 0) return ast
     res = hash_new()
     for (i = 1; i <= numberof(*h.keys); ++i) {
-      new_key = EVAL(hashmap_key_to_obj((*h.keys)(i)), env)
-      if (structof(new_key) == MalError) return new_key
       new_val = EVAL(*((*h.vals)(i)), env)
       if (structof(new_val) == MalError) return new_val
-      hash_set, res, hashmap_obj_to_key(new_key), new_val
+      hash_set, res, (*h.keys)(i), new_val
     }
     return MalHashmap(val=&res)
   } else return ast

--- a/impls/yorick/step7_quote.i
+++ b/impls/yorick/step7_quote.i
@@ -77,11 +77,9 @@ func eval_ast(ast, env)
     if (numberof(*h.keys) == 0) return ast
     res = hash_new()
     for (i = 1; i <= numberof(*h.keys); ++i) {
-      new_key = EVAL(hashmap_key_to_obj((*h.keys)(i)), env)
-      if (structof(new_key) == MalError) return new_key
       new_val = EVAL(*((*h.vals)(i)), env)
       if (structof(new_val) == MalError) return new_val
-      hash_set, res, hashmap_obj_to_key(new_key), new_val
+      hash_set, res, (*h.keys)(i), new_val
     }
     return MalHashmap(val=&res)
   } else return ast

--- a/impls/yorick/step8_macros.i
+++ b/impls/yorick/step8_macros.i
@@ -102,11 +102,9 @@ func eval_ast(ast, env)
     if (numberof(*h.keys) == 0) return ast
     res = hash_new()
     for (i = 1; i <= numberof(*h.keys); ++i) {
-      new_key = EVAL(hashmap_key_to_obj((*h.keys)(i)), env)
-      if (structof(new_key) == MalError) return new_key
       new_val = EVAL(*((*h.vals)(i)), env)
       if (structof(new_val) == MalError) return new_val
-      hash_set, res, hashmap_obj_to_key(new_key), new_val
+      hash_set, res, (*h.keys)(i), new_val
     }
     return MalHashmap(val=&res)
   } else return ast

--- a/impls/yorick/step9_try.i
+++ b/impls/yorick/step9_try.i
@@ -102,11 +102,9 @@ func eval_ast(ast, env)
     if (numberof(*h.keys) == 0) return ast
     res = hash_new()
     for (i = 1; i <= numberof(*h.keys); ++i) {
-      new_key = EVAL(hashmap_key_to_obj((*h.keys)(i)), env)
-      if (structof(new_key) == MalError) return new_key
       new_val = EVAL(*((*h.vals)(i)), env)
       if (structof(new_val) == MalError) return new_val
-      hash_set, res, hashmap_obj_to_key(new_key), new_val
+      hash_set, res, (*h.keys)(i), new_val
     }
     return MalHashmap(val=&res)
   } else return ast

--- a/impls/yorick/stepA_mal.i
+++ b/impls/yorick/stepA_mal.i
@@ -102,11 +102,9 @@ func eval_ast(ast, env)
     if (numberof(*h.keys) == 0) return ast
     res = hash_new()
     for (i = 1; i <= numberof(*h.keys); ++i) {
-      new_key = EVAL(hashmap_key_to_obj((*h.keys)(i)), env)
-      if (structof(new_key) == MalError) return new_key
       new_val = EVAL(*((*h.vals)(i)), env)
       if (structof(new_val) == MalError) return new_val
-      hash_set, res, hashmap_obj_to_key(new_key), new_val
+      hash_set, res, (*h.keys)(i), new_val
     }
     return MalHashmap(val=&res)
   } else return ast

--- a/process/guide.md
+++ b/process/guide.md
@@ -592,6 +592,9 @@ You now have a simple prefix notation calculator!
   * If `ast` is a hash-map: return a new hash-map which consists of key-value
     pairs where the key is a key from the hash-map and the value is the result
     of calling `EVAL` on the corresponding value.
+    Depending on the implementation of maps, it may be convenient to
+    also call `EVAL` on keys.  The result is the same because keys are
+    not affected by evaluation.
 
 
 <a name="step3"></a>


### PR DESCRIPTION
Neither keywords nor strings are modified by evaluation, so evaluating
map keys is a no-op.  Document this in the guide.