### PR TITLE
Update Scheme implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,16 +1026,15 @@ scala -classpath target/scala*/classes stepX_YYY
 
 ### Scheme (R7RS) ###
 
-The Scheme implementation of mal has been tested with Chibi-Scheme
-0.7.3, Kawa 2.4, Gauche 0.9.5, CHICKEN 4.11.0, Sagittarius 0.8.3,
-Cyclone 0.6.3 (Git version) and Foment 0.4 (Git version).  You should
+The Scheme implementation of MAL has been tested with Chibi-Scheme
+0.10, Kawa 3.1.1, Gauche 0.9.6, CHICKEN 5.1.0, Sagittarius 0.9.7,
+Cyclone 0.32.0 (Git version) and Foment 0.4 (Git version).  You should
 be able to get it running on other conforming R7RS implementations
 after figuring out how libraries are loaded and adjusting the
 `Makefile` and `run` script accordingly.
 
 ```
 cd impls/scheme
-make symlinks
 # chibi
 scheme_MODE=chibi ./run
 # kawa

--- a/impls/scheme/Dockerfile
+++ b/impls/scheme/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal
 MAINTAINER Joel Martin <github@martintribe.org>
 
 ##########################################################
@@ -23,6 +23,7 @@ WORKDIR /mal
 
 # Prepackaged Scheme implementations
 RUN apt-get -y install gauche chicken-bin
+RUN chicken-install r7rs
 
 # Chibi
 RUN apt-get -y install bison gcc g++ flex

--- a/impls/scheme/Dockerfile
+++ b/impls/scheme/Dockerfile
@@ -24,33 +24,31 @@ WORKDIR /mal
 # Prepackaged Scheme implementations
 RUN apt-get -y install gauche chicken-bin
 RUN chicken-install r7rs
+# Dev tools
+RUN apt-get -y install gcc g++ bison flex groff make cmake pkg-config git
 
 # Chibi
-RUN apt-get -y install bison gcc g++ flex
-RUN cd /tmp && curl -Lo chibi-0.7.3.tar.gz https://github.com/ashinn/chibi-scheme/archive/0.7.3.tar.gz \
-    && tar xvzf chibi-0.7.3.tar.gz && cd chibi-scheme-0.7.3 \
+RUN cd /tmp && curl -Lo chibi-0.10.tar.gz https://github.com/ashinn/chibi-scheme/archive/0.10.tar.gz \
+    && tar xvzf chibi-0.10.tar.gz && cd chibi-scheme-0.10 \
     && make && make install && rm -rf /tmp/chibi-*
 
 # Kawa
-RUN apt-get -y install openjdk-8-jdk-headless groff
-RUN cd /tmp && curl -O http://ftp.gnu.org/pub/gnu/kawa/kawa-2.4.tar.gz \
-    && tar xvzf kawa-2.4.tar.gz && cd kawa-2.4 \
-    && ./configure && make && make install && rm -rf /tmp/kawa-2.4*
+RUN apt-get -y install openjdk-8-jdk-headless
+RUN cd /tmp && curl -O http://ftp.gnu.org/pub/gnu/kawa/kawa-3.1.1.tar.gz \
+    && tar xvzf kawa-3.1.1.tar.gz && cd kawa-3.1.1 \
+    && ./configure && make && make install && rm -rf /tmp/kawa-3.1.1*
 
 # Sagittarius
-RUN apt-get -y install cmake libgc-dev zlib1g-dev libffi-dev
-RUN cd /tmp && curl -LO https://bitbucket.org/ktakashi/sagittarius-scheme/downloads/sagittarius-0.8.3.tar.gz \
-    && tar xvzf sagittarius-0.8.3.tar.gz && cd sagittarius-0.8.3 \
-    && cmake . && make && make install && rm -rf /tmp/sagittarius-0.8.3*
+RUN apt-get -y install libgc-dev zlib1g-dev libffi-dev libssl-dev
+RUN cd /tmp && curl -LO https://bitbucket.org/ktakashi/sagittarius-scheme/downloads/sagittarius-0.9.7.tar.gz \
+    && tar xvzf sagittarius-0.9.7.tar.gz && cd sagittarius-0.9.7 \
+    && cmake . && make && make install && rm -rf /tmp/sagittarius-0.9.7*
 
 # Cyclone
-RUN apt-get -y install git libtommath-dev
-RUN cd /tmp && curl -O http://concurrencykit.org/releases/ck-0.6.0.tar.gz \
-    && tar xvzf ck-0.6.0.tar.gz && cd ck-0.6.0 && ./configure PREFIX=/usr \
-    && make all && make install && ldconfig && rm -rf /tmp/ck-0.6.0*
+RUN apt-get -y install libck-dev libtommath-dev
 RUN cd /tmp && git clone https://github.com/justinethier/cyclone-bootstrap \
-    && cd cyclone-bootstrap && make CFLAGS="-O2 -fPIC -rdynamic -Wall -Iinclude -L." \
-    && make install && rm -rf /tmp/cyclone-bootstrap
+    && cd cyclone-bootstrap \
+    && make && make install && rm -rf /tmp/cyclone-bootstrap
 
 # Foment
 RUN cd /tmp && git clone https://github.com/leftmike/foment \

--- a/impls/scheme/Makefile
+++ b/impls/scheme/Makefile
@@ -14,10 +14,9 @@ KAWA_STEP1_DEPS = out/lib/util.class out/lib/reader.class \
                   out/lib/printer.class out/lib/types.class
 KAWA_STEP3_DEPS = $(KAWA_STEP1_DEPS) out/lib/env.class
 KAWA_STEP4_DEPS = $(KAWA_STEP3_DEPS) out/lib/core.class
-CHICKEN_STEP1_DEPS = eggs/lib.util.so eggs/lib.types.so \
-                     eggs/lib.reader.so eggs/lib.printer.so
-CHICKEN_STEP3_DEPS = $(CHICKEN_STEP1_DEPS) eggs/lib.env.so
-CHICKEN_STEP4_DEPS = $(CHICKEN_STEP3_DEPS) eggs/lib.core.so
+CHICKEN_STEP1_DEPS = lib.util.so lib.types.so lib.reader.so lib.printer.so
+CHICKEN_STEP3_DEPS = $(CHICKEN_STEP1_DEPS) lib.env.so
+CHICKEN_STEP4_DEPS = $(CHICKEN_STEP3_DEPS) lib.core.so
 CYCLONE_STEP1_DEPS = lib/util.so lib/reader.so lib/printer.so lib/types.so
 CYCLONE_STEP3_DEPS = $(CYCLONE_STEP1_DEPS) lib/env.so
 CYCLONE_STEP4_DEPS = $(CYCLONE_STEP3_DEPS) lib/core.so
@@ -34,8 +33,8 @@ STEP4_DEPS = $(if $(filter kawa,$(scheme_MODE)),$(KAWA_STEP4_DEPS),\
 
 KAWALIB = kawa --r7rs --no-warn-unused -d out -C
 KAWA = kawa --r7rs --no-warn-unused -d out --main -C
-CHICKEN = CHICKEN_REPOSITORY=$(CURDIR)/eggs csc -O3 -R r7rs
-CHICKENLIB = $(CHICKEN) -sJ
+CHICKEN = csc -setup-mode -host -O3 -R r7rs
+CHICKENLIB = $(CHICKEN) -D compiling-extension -J -s -regenerate-import-libraries
 CYCLONELIB = cyclone -O2
 CYCLONE = $(CYCLONELIB)
 
@@ -54,16 +53,9 @@ RMR = rm -rf
 all: $(STEPS)
 
 .PHONY: clean
-.PRECIOUS: lib/%.scm eggs/lib.%.scm
-
-eggs/r7rs.so:
-	chicken-install -init eggs
-	CHICKEN_REPOSITORY=$(CURDIR)/eggs chicken-install r7rs
+.PRECIOUS: lib/%.scm
 
 lib/%.scm: lib/%.sld
-	$(SYMLINK) $< $@
-
-eggs/lib.%.scm: lib/%.sld
 	$(SYMLINK) $< $@
 
 out/lib/%.class: lib/%.scm
@@ -72,8 +64,8 @@ out/lib/%.class: lib/%.scm
 out/%.class: %.scm
 	$(SCM) $<
 
-eggs/lib.%.so: eggs/lib.%.scm
-	$(SCMLIB) $<
+lib.%.so: lib/%.sld
+	$(SCMLIB) $< -o $@
 
 lib/%.so: lib/%.sld
 	$(SCMLIB) $<
@@ -85,14 +77,11 @@ out/step1_read_print.class out/step2_eval.class: $(STEP1_DEPS)
 out/step3_env.class: $(STEP3_DEPS)
 out/step4_if_fn_do.class out/step5_tco.class out/step6_file.class out/step7_quote.class out/step8_macros.class out/step9_try.class out/stepA_mal.class: $(STEP4_DEPS)
 
-step0_repl: $(if $(filter chicken,$(scheme_MODE)),eggs/r7rs.so,)
-
 step1_read_print.scm step2_eval.scm: $(STEP1_DEPS)
 step3_env.scm: $(STEP3_DEPS)
 step4_if_fn_do.scm step5_tco.scm step6_file.scm step7_quote.scm step8_macros.scm step9_try.scm stepA_mal.scm: $(STEP4_DEPS)
 
 clean:
 	$(RM) lib/*.scm lib/*.so lib/*.c lib/*.o lib/*.meta
-	$(RM) lib.*.scm *.so *.c *.o $(BINS)
-	$(RM) eggs/*
+	$(RM) lib.*.scm *.build.sh *.install.sh *.link *.so *.c *.o $(BINS)
 	$(RMR) out

--- a/impls/scheme/Makefile
+++ b/impls/scheme/Makefile
@@ -14,9 +14,6 @@ KAWA_STEP1_DEPS = out/lib/util.class out/lib/reader.class \
                   out/lib/printer.class out/lib/types.class
 KAWA_STEP3_DEPS = $(KAWA_STEP1_DEPS) out/lib/env.class
 KAWA_STEP4_DEPS = $(KAWA_STEP3_DEPS) out/lib/core.class
-GAUCHE_STEP1_DEPS = lib/util.scm lib/reader.scm lib/printer.scm lib/types.scm
-GAUCHE_STEP3_DEPS = $(GAUCHE_STEP1_DEPS) lib/env.scm
-GAUCHE_STEP4_DEPS = $(GAUCHE_STEP3_DEPS) lib/core.scm
 CHICKEN_STEP1_DEPS = eggs/lib.util.so eggs/lib.types.so \
                      eggs/lib.reader.so eggs/lib.printer.so
 CHICKEN_STEP3_DEPS = $(CHICKEN_STEP1_DEPS) eggs/lib.env.so
@@ -26,17 +23,14 @@ CYCLONE_STEP3_DEPS = $(CYCLONE_STEP1_DEPS) lib/env.so
 CYCLONE_STEP4_DEPS = $(CYCLONE_STEP3_DEPS) lib/core.so
 
 STEP1_DEPS = $(if $(filter kawa,$(scheme_MODE)),$(KAWA_STEP1_DEPS),\
-             $(if $(filter gauche,$(scheme_MODE)),$(GAUCHE_STEP1_DEPS),\
              $(if $(filter chicken,$(scheme_MODE)),$(CHICKEN_STEP1_DEPS),\
-             $(if $(filter cyclone,$(scheme_MODE)),$(CYCLONE_STEP1_DEPS)))))
+             $(if $(filter cyclone,$(scheme_MODE)),$(CYCLONE_STEP1_DEPS))))
 STEP3_DEPS = $(if $(filter kawa,$(scheme_MODE)),$(KAWA_STEP3_DEPS),\
-             $(if $(filter gauche,$(scheme_MODE)),$(GAUCHE_STEP3_DEPS),\
              $(if $(filter chicken,$(scheme_MODE)),$(CHICKEN_STEP3_DEPS),\
-             $(if $(filter cyclone,$(scheme_MODE)),$(CYCLONE_STEP3_DEPS)))))
+             $(if $(filter cyclone,$(scheme_MODE)),$(CYCLONE_STEP3_DEPS))))
 STEP4_DEPS = $(if $(filter kawa,$(scheme_MODE)),$(KAWA_STEP4_DEPS),\
-             $(if $(filter gauche,$(scheme_MODE)),$(GAUCHE_STEP4_DEPS),\
              $(if $(filter chicken,$(scheme_MODE)),$(CHICKEN_STEP4_DEPS),\
-             $(if $(filter cyclone,$(scheme_MODE)),$(CYCLONE_STEP4_DEPS)))))
+             $(if $(filter cyclone,$(scheme_MODE)),$(CYCLONE_STEP4_DEPS))))
 
 KAWALIB = kawa --r7rs --no-warn-unused -d out -C
 KAWA = kawa --r7rs --no-warn-unused -d out --main -C


### PR DESCRIPTION
CHICKEN has had a new major version for a while now. I've taken the chance to do the following changes:

- Bump the Docker image to Ubuntu Focal (the latest stable version with C5)
- Adapt the Makefile to C5
- Update all other Scheme installations
- Update the README

What's left is for @kanaka to trigger a Docker image rebuild and see whether it works on Travis.