### PR TITLE
Suggestion: Remove package-lock.json from .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 .sbt
 .npm
 .node-gyp
-package-lock.json
 */experiments
 node_modules
 */notes

--- a/impls/.gitignore
+++ b/impls/.gitignore
@@ -11,7 +11,6 @@
 .sbt
 .npm
 .node-gyp
-package-lock.json
 .elm
 */experiments
 */node_modules


### PR DESCRIPTION
Hello and thanks for the great work on MAL! I've just started working through it and am really enjoying it so far. Something I found odd however is that `package-lock.json` appears in a few `.gitignore` files. Was this intentional?

AFAIK `package-lock.json` file is intended to be checked in to source control in order to make builds reproducible; without a `package-lock.json` file `npm install` becomes non-deterministic.

See e.g. https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json:

> package-lock.json is automatically generated for any operations where
> npm modifies either the node_modules tree, or package.json. It describes
> the exact tree that was generated, such that subsequent installs are
> able to generate identical trees, regardless of intermediate dependency
> updates.
>
> This file is intended to be committed into source repositories, and
> serves various purposes: [...]

As such, this PR removes `package-lock.json` from the `.gitignore` files in root and `impls`