### PR TITLE
Fix VBScript implementation self-hosting fails to start issue

### DIFF
--- a/IMPLS.yml
+++ b/IMPLS.yml
@@ -122,4 +122,4 @@ IMPL:
 # - {IMPL: swift4, NO_DOCKER: 1, OS: xcode10}}
   - {IMPL: swift5, NO_DOCKER: 1, OS: macos}
 
-  - {IMPL: vbs, NO_DOCKER: 1, OS: windows, NO_SELF_HOST: 1} # startup invoke failure
+  - {IMPL: vbs, NO_DOCKER: 1, OS: windows}

--- a/impls/vbs/run
+++ b/impls/vbs/run
@@ -1,4 +1,7 @@
 #!/bin/bash
+echo cscript.exe -nologo \"`wslpath -w "$(dirname $0)/${STEP:-stepA_mal}.vbs"`\" "${@}" >> debug2.txt
+implpath=\"`wslpath -w "$(dirname $0)/${STEP:-stepA_mal}.vbs"`\"
+echo $implpath >>implpath.txt
 MAL_VBS_IMPL_NO_STDERR=1 MAL_VBS_IMPL_ECHO_STDIN=1 \
 WSLENV=MAL_VBS_IMPL_NO_STDERR/w:MAL_VBS_IMPL_ECHO_STDIN/w \
-cscript.exe -nologo $(dirname $0)/${STEP:-stepA_mal}.vbs "${@}"
+cscript.exe -nologo \"`wslpath -w "$(dirname $0)/${STEP:-stepA_mal}.vbs"`\" "${@}"

--- a/impls/vbs/run
+++ b/impls/vbs/run
@@ -1,7 +1,4 @@
 #!/bin/bash
-echo cscript.exe -nologo \"`wslpath -w "$(dirname $0)/${STEP:-stepA_mal}.vbs"`\" "${@}" >> debug2.txt
-implpath=\"`wslpath -w "$(dirname $0)/${STEP:-stepA_mal}.vbs"`\"
-echo $implpath >>implpath.txt
 MAL_VBS_IMPL_NO_STDERR=1 MAL_VBS_IMPL_ECHO_STDIN=1 \
 WSLENV=MAL_VBS_IMPL_NO_STDERR/w:MAL_VBS_IMPL_ECHO_STDIN/w \
-cscript.exe -nologo \"`wslpath -w "$(dirname $0)/${STEP:-stepA_mal}.vbs"`\" "${@}"
+cscript.exe -nologo "`wslpath -w "$(dirname $0)/${STEP:-stepA_mal}.vbs"`" "${@}"


### PR DESCRIPTION
By checking the [logs](https://github.com/kanaka/mal/issues/662#issuecomment-2305841001) provided by @kanaka , I realize that the problem is caused by the different path specifications in `win` and `linux`.

There was no problem before because normal tests used relative paths, while self-hosted tests used absolute paths.