### PR TITLE
mal: implement DBGEVAL without assuming that a: is a valid symbol

### DIFF
--- a/impls/mal/step2_eval.mal
+++ b/impls/mal/step2_eval.mal
@@ -8,7 +8,7 @@
 
 ;; eval
 (def! EVAL (fn* [ast env]
-  ;; (do (prn 'EVAL: ast))
+  ;; (do (prn "EVAL:" ast))
   (try*
     (cond
       (symbol? ast)

--- a/impls/mal/step3_env.mal
+++ b/impls/mal/step3_env.mal
@@ -21,7 +21,7 @@
 (def! EVAL (fn* [ast env]
   (do
     (if (env-get-or-nil env 'DEBUG-EVAL)
-      (prn 'EVAL: ast (env-as-map env)))
+      (println "EVAL:" (pr-str ast (env-as-map env))))
     (try*
       (cond
         (symbol? ast)

--- a/impls/mal/step4_if_fn_do.mal
+++ b/impls/mal/step4_if_fn_do.mal
@@ -22,7 +22,7 @@
 (def! EVAL (fn* [ast env]
   (do
     (if (env-get-or-nil env 'DEBUG-EVAL)
-      (prn 'EVAL: ast (env-as-map env)))
+      (println "EVAL:" (pr-str ast (env-as-map env))))
     (try*
       (cond
         (symbol? ast)

--- a/impls/mal/step6_file.mal
+++ b/impls/mal/step6_file.mal
@@ -22,7 +22,7 @@
 (def! EVAL (fn* [ast env]
   (do
     (if (env-get-or-nil env 'DEBUG-EVAL)
-      (prn 'EVAL: ast (env-as-map env)))
+      (println "EVAL:" (pr-str ast (env-as-map env))))
     (try*
       (cond
         (symbol? ast)

--- a/impls/mal/step7_quote.mal
+++ b/impls/mal/step7_quote.mal
@@ -44,7 +44,7 @@
 (def! EVAL (fn* [ast env]
   (do
     (if (env-get-or-nil env 'DEBUG-EVAL)
-      (prn 'EVAL: ast (env-as-map env)))
+      (println "EVAL:" (pr-str ast (env-as-map env))))
     (try*
       (cond
         (symbol? ast)

--- a/impls/mal/step8_macros.mal
+++ b/impls/mal/step8_macros.mal
@@ -44,7 +44,7 @@
 (def! EVAL (fn* [ast env]
   (do
     (if (env-get-or-nil env 'DEBUG-EVAL)
-      (prn 'EVAL: ast (env-as-map env)))
+      (println "EVAL:" (pr-str ast (env-as-map env))))
     (try*
       (cond
         (symbol? ast)

--- a/impls/mal/step9_try.mal
+++ b/impls/mal/step9_try.mal
@@ -44,7 +44,7 @@
 (def! EVAL (fn* [ast env]
   (do
     (if (env-get-or-nil env 'DEBUG-EVAL)
-      (prn 'EVAL: ast (env-as-map env)))
+      (println "EVAL:" (pr-str ast (env-as-map env))))
     (try*
       (cond
         (symbol? ast)

--- a/impls/mal/stepA_mal.mal
+++ b/impls/mal/stepA_mal.mal
@@ -44,7 +44,7 @@
 (def! EVAL (fn* [ast env]
   (do
     (if (env-get-or-nil env 'DEBUG-EVAL)
-      (prn 'EVAL: ast (env-as-map env)))
+      (println "EVAL:" (pr-str ast (env-as-map env))))
     (try*
       (cond
         (symbol? ast)


### PR DESCRIPTION
This does not seem worth a test, but can currently break the self-hosting.