### PR TITLE
wasm: remove the now unneeded ENV_FIND environment method

### DIFF
--- a/impls/wasm/env.wam
+++ b/impls/wasm/env.wam
@@ -58,12 +58,13 @@
     $value
   )
 
-  (func $ENV_FIND (param $env i32 $key i32) (result i64)
+  (func $ENV_GET (param $env i32 $key i32) (result i32)
+    ;; Return 0 when the key is not found, but do not set THROW_STR.
+
     (local $found_res i64)
     (LET $res 0
          $data 0)
 
-    (block $done
       (loop $loop
         (local.set $data ($MEM_VAL0_ptr $env))
         (local.set $found_res ($HASHMAP_GET $data $key))
@@ -71,34 +72,13 @@
         (if (i32.wrap_i64 (i64.shr_u $found_res (i64.const 32)))
           (then
             (local.set $res (i32.wrap_i64 $found_res))
-            (br $done)))
+            (return ($INC_REF $res))))
         (local.set $env ($MEM_VAL1_ptr $env))
         (if (i32.eq $env (global.get $NIL))
           (then
-            (local.set $env 0)
-            (br $done)))
+            (return 0)))
         (br $loop)
       )
-    )
-
-    ;; combine res/env as hi 32/low 32 of i64
-    (i64.or
-      (i64.shl (i64.extend_i32_u $res) (i64.const 32))
-      (i64.extend_i32_u $env))
   )
 
-  (func $ENV_GET (param $env i32 $key i32) (result i32)
-    (local $res_env i64)
-    (LET $res 0)
-
-    (local.set $res_env ($ENV_FIND $env $key))
-    (local.set $env (i32.wrap_i64 $res_env))
-    (local.set $res (i32.wrap_i64 (i64.shr_u $res_env (i64.const 32))))
-
-    (if (i32.eqz $env)
-      (then
-        ($THROW_STR_1 "'%s' not found" ($to_String $key))
-        (return $res)))
-    (return ($INC_REF $res))
-  )
 )

--- a/impls/wasm/step3_env.wam
+++ b/impls/wasm/step3_env.wam
@@ -84,15 +84,12 @@
     ($MEM_VAL1_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr $ast)))))
 
   (func $ECHO_IF_DEBUG_EVAL (param $ast i32 $env i32)
-    (local $res_env i64 $value i32)
-    (local.set $res_env ($ENV_FIND $env (global.get $DEBUG_EVAL_S)))
-    (if (i32.wrap_i64 $res_env)
+    (LET $value ($ENV_GET $env (global.get $DEBUG_EVAL_S)))
+    (if (AND $value
+             (i32.ne $value (global.get $NIL))
+             (i32.ne $value (global.get $FALSE)))
       (then
-        (local.set $value (i32.wrap_i64 (i64.shr_u $res_env (i64.const 32))))
-        (if (AND (i32.ne $value (global.get $NIL))
-                 (i32.ne $value (global.get $FALSE)))
-          (then
-            ($PR_VALUE "EVAL: %s\n" $ast))))))
+        ($PR_VALUE "EVAL: %s\n" $ast))))
 
   (func $EVAL (param $ast i32 $env i32) (result i32)
     (LET $res 0
@@ -108,7 +105,10 @@
 
     (if (i32.eq $ast_type (global.get $SYMBOL_T))
       (then
-        (return ($ENV_GET $env $ast))))
+        (local.set $res ($ENV_GET $env $ast))
+        (if (i32.eqz $res)
+          ($THROW_STR_1 "'%s' not found" ($to_String $ast)))
+        (return $res)))
 
     (if (OR (i32.eq $ast_type (global.get $VECTOR_T))
             (i32.eq $ast_type (global.get $HASHMAP_T)))

--- a/impls/wasm/step4_if_fn_do.wam
+++ b/impls/wasm/step4_if_fn_do.wam
@@ -78,15 +78,12 @@
     ($MEM_VAL1_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr $ast)))))
 
   (func $ECHO_IF_DEBUG_EVAL (param $ast i32 $env i32)
-    (local $res_env i64 $value i32)
-    (local.set $res_env ($ENV_FIND $env (global.get $DEBUG_EVAL_S)))
-    (if (i32.wrap_i64 $res_env)
+    (LET $value ($ENV_GET $env (global.get $DEBUG_EVAL_S)))
+    (if (AND $value
+             (i32.ne $value (global.get $NIL))
+             (i32.ne $value (global.get $FALSE)))
       (then
-        (local.set $value (i32.wrap_i64 (i64.shr_u $res_env (i64.const 32))))
-        (if (AND (i32.ne $value (global.get $NIL))
-                 (i32.ne $value (global.get $FALSE)))
-          (then
-            ($PR_VALUE "EVAL: %s\n" $ast))))))
+        ($PR_VALUE "EVAL: %s\n" $ast))))
 
   (func $EVAL (param $ast i32 $env i32) (result i32)
     (LET $res 0 $el 0
@@ -102,7 +99,10 @@
 
     (if (i32.eq $ast_type (global.get $SYMBOL_T))
       (then
-        (return ($ENV_GET $env $ast))))
+        (local.set $res ($ENV_GET $env $ast))
+        (if (i32.eqz $res)
+          ($THROW_STR_1 "'%s' not found" ($to_String $ast)))
+        (return $res)))
 
     (if (OR (i32.eq $ast_type (global.get $VECTOR_T))
             (i32.eq $ast_type (global.get $HASHMAP_T)))

--- a/impls/wasm/step5_tco.wam
+++ b/impls/wasm/step5_tco.wam
@@ -80,15 +80,12 @@
     ($MEM_VAL1_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr $ast)))))
 
   (func $ECHO_IF_DEBUG_EVAL (param $ast i32 $env i32)
-    (local $res_env i64 $value i32)
-    (local.set $res_env ($ENV_FIND $env (global.get $DEBUG_EVAL_S)))
-    (if (i32.wrap_i64 $res_env)
+    (LET $value ($ENV_GET $env (global.get $DEBUG_EVAL_S)))
+    (if (AND $value
+             (i32.ne $value (global.get $NIL))
+             (i32.ne $value (global.get $FALSE)))
       (then
-        (local.set $value (i32.wrap_i64 (i64.shr_u $res_env (i64.const 32))))
-        (if (AND (i32.ne $value (global.get $NIL))
-                 (i32.ne $value (global.get $FALSE)))
-          (then
-            ($PR_VALUE "EVAL: %s\n" $ast))))))
+        ($PR_VALUE "EVAL: %s\n" $ast))))
 
   (func $EVAL (param $orig_ast i32 $orig_env i32) (result i32)
     (LET $ast $orig_ast
@@ -112,6 +109,8 @@
     (if (i32.eq $ast_type (global.get $SYMBOL_T))
       (then
         (local.set $res ($ENV_GET $env $ast))
+        (if (i32.eqz $res)
+          ($THROW_STR_1 "'%s' not found" ($to_String $ast)))
         (br $EVAL_return)))
 
     (if (OR (i32.eq $ast_type (global.get $VECTOR_T))

--- a/impls/wasm/step6_file.wam
+++ b/impls/wasm/step6_file.wam
@@ -80,15 +80,12 @@
     ($MEM_VAL1_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr $ast)))))
 
   (func $ECHO_IF_DEBUG_EVAL (param $ast i32 $env i32)
-    (local $res_env i64 $value i32)
-    (local.set $res_env ($ENV_FIND $env (global.get $DEBUG_EVAL_S)))
-    (if (i32.wrap_i64 $res_env)
+    (LET $value ($ENV_GET $env (global.get $DEBUG_EVAL_S)))
+    (if (AND $value
+             (i32.ne $value (global.get $NIL))
+             (i32.ne $value (global.get $FALSE)))
       (then
-        (local.set $value (i32.wrap_i64 (i64.shr_u $res_env (i64.const 32))))
-        (if (AND (i32.ne $value (global.get $NIL))
-                 (i32.ne $value (global.get $FALSE)))
-          (then
-            ($PR_VALUE "EVAL: %s\n" $ast))))))
+        ($PR_VALUE "EVAL: %s\n" $ast))))
 
   (func $EVAL (param $orig_ast i32 $orig_env i32) (result i32)
     (LET $ast $orig_ast
@@ -112,6 +109,8 @@
     (if (i32.eq $ast_type (global.get $SYMBOL_T))
       (then
         (local.set $res ($ENV_GET $env $ast))
+        (if (i32.eqz $res)
+          ($THROW_STR_1 "'%s' not found" ($to_String $ast)))
         (br $EVAL_return)))
 
     (if (OR (i32.eq $ast_type (global.get $VECTOR_T))

--- a/impls/wasm/step7_quote.wam
+++ b/impls/wasm/step7_quote.wam
@@ -160,15 +160,12 @@
     ($MEM_VAL1_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr $ast)))))
 
   (func $ECHO_IF_DEBUG_EVAL (param $ast i32 $env i32)
-    (local $res_env i64 $value i32)
-    (local.set $res_env ($ENV_FIND $env (global.get $DEBUG_EVAL_S)))
-    (if (i32.wrap_i64 $res_env)
+    (LET $value ($ENV_GET $env (global.get $DEBUG_EVAL_S)))
+    (if (AND $value
+             (i32.ne $value (global.get $NIL))
+             (i32.ne $value (global.get $FALSE)))
       (then
-        (local.set $value (i32.wrap_i64 (i64.shr_u $res_env (i64.const 32))))
-        (if (AND (i32.ne $value (global.get $NIL))
-                 (i32.ne $value (global.get $FALSE)))
-          (then
-            ($PR_VALUE "EVAL: %s\n" $ast))))))
+        ($PR_VALUE "EVAL: %s\n" $ast))))
 
   (func $EVAL (param $orig_ast i32 $orig_env i32) (result i32)
     (LET $ast $orig_ast
@@ -192,6 +189,8 @@
     (if (i32.eq $ast_type (global.get $SYMBOL_T))
       (then
         (local.set $res ($ENV_GET $env $ast))
+        (if (i32.eqz $res)
+          ($THROW_STR_1 "'%s' not found" ($to_String $ast)))
         (br $EVAL_return)))
 
     (if (OR (i32.eq $ast_type (global.get $VECTOR_T))

--- a/impls/wasm/step8_macros.wam
+++ b/impls/wasm/step8_macros.wam
@@ -160,15 +160,12 @@
     ($MEM_VAL1_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr $ast)))))
 
   (func $ECHO_IF_DEBUG_EVAL (param $ast i32 $env i32)
-    (local $res_env i64 $value i32)
-    (local.set $res_env ($ENV_FIND $env (global.get $DEBUG_EVAL_S)))
-    (if (i32.wrap_i64 $res_env)
+    (LET $value ($ENV_GET $env (global.get $DEBUG_EVAL_S)))
+    (if (AND $value
+             (i32.ne $value (global.get $NIL))
+             (i32.ne $value (global.get $FALSE)))
       (then
-        (local.set $value (i32.wrap_i64 (i64.shr_u $res_env (i64.const 32))))
-        (if (AND (i32.ne $value (global.get $NIL))
-                 (i32.ne $value (global.get $FALSE)))
-          (then
-            ($PR_VALUE "EVAL: %s\n" $ast))))))
+        ($PR_VALUE "EVAL: %s\n" $ast))))
 
   (func $EVAL (param $orig_ast i32 $orig_env i32) (result i32)
     (LET $ast $orig_ast
@@ -193,6 +190,8 @@
     (if (i32.eq $ast_type (global.get $SYMBOL_T))
       (then
         (local.set $res ($ENV_GET $env $ast))
+        (if (i32.eqz $res)
+          ($THROW_STR_1 "'%s' not found" ($to_String $ast)))
         (br $EVAL_return)))
 
     (if (OR (i32.eq $ast_type (global.get $VECTOR_T))

--- a/impls/wasm/step9_try.wam
+++ b/impls/wasm/step9_try.wam
@@ -160,15 +160,12 @@
     ($MEM_VAL1_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr $ast)))))
 
   (func $ECHO_IF_DEBUG_EVAL (param $ast i32 $env i32)
-    (local $res_env i64 $value i32)
-    (local.set $res_env ($ENV_FIND $env (global.get $DEBUG_EVAL_S)))
-    (if (i32.wrap_i64 $res_env)
+    (LET $value ($ENV_GET $env (global.get $DEBUG_EVAL_S)))
+    (if (AND $value
+             (i32.ne $value (global.get $NIL))
+             (i32.ne $value (global.get $FALSE)))
       (then
-        (local.set $value (i32.wrap_i64 (i64.shr_u $res_env (i64.const 32))))
-        (if (AND (i32.ne $value (global.get $NIL))
-                 (i32.ne $value (global.get $FALSE)))
-          (then
-            ($PR_VALUE "EVAL: %s\n" $ast))))))
+        ($PR_VALUE "EVAL: %s\n" $ast))))
 
   (func $EVAL (param $orig_ast i32 $orig_env i32) (result i32)
     (LET $ast $orig_ast
@@ -193,6 +190,8 @@
     (if (i32.eq $ast_type (global.get $SYMBOL_T))
       (then
         (local.set $res ($ENV_GET $env $ast))
+        (if (i32.eqz $res)
+          ($THROW_STR_1 "'%s' not found" ($to_String $ast)))
         (br $EVAL_return)))
 
     (if (OR (i32.eq $ast_type (global.get $VECTOR_T))

--- a/impls/wasm/stepA_mal.wam
+++ b/impls/wasm/stepA_mal.wam
@@ -160,15 +160,12 @@
     ($MEM_VAL1_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr ($MEM_VAL0_ptr $ast)))))
 
   (func $ECHO_IF_DEBUG_EVAL (param $ast i32 $env i32)
-    (local $res_env i64 $value i32)
-    (local.set $res_env ($ENV_FIND $env (global.get $DEBUG_EVAL_S)))
-    (if (i32.wrap_i64 $res_env)
+    (LET $value ($ENV_GET $env (global.get $DEBUG_EVAL_S)))
+    (if (AND $value
+             (i32.ne $value (global.get $NIL))
+             (i32.ne $value (global.get $FALSE)))
       (then
-        (local.set $value (i32.wrap_i64 (i64.shr_u $res_env (i64.const 32))))
-        (if (AND (i32.ne $value (global.get $NIL))
-                 (i32.ne $value (global.get $FALSE)))
-          (then
-            ($PR_VALUE "EVAL: %s\n" $ast))))))
+        ($PR_VALUE "EVAL: %s\n" $ast))))
 
   (func $EVAL (param $orig_ast i32 $orig_env i32) (result i32)
     (LET $ast $orig_ast
@@ -193,6 +190,8 @@
     (if (i32.eq $ast_type (global.get $SYMBOL_T))
       (then
         (local.set $res ($ENV_GET $env $ast))
+        (if (i32.eqz $res)
+          ($THROW_STR_1 "'%s' not found" ($to_String $ast)))
         (br $EVAL_return)))
 
     (if (OR (i32.eq $ast_type (global.get $VECTOR_T))


### PR DESCRIPTION
A trivial simplification lost during the merge of eval ast.