### PR TITLE
io: Update Dockerfile

### DIFF
--- a/impls/io/Dockerfile
+++ b/impls/io/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:24.04 AS base
 MAINTAINER Joel Martin <github@martintribe.org>
 
 ##########################################################
@@ -9,25 +9,49 @@ MAINTAINER Joel Martin <github@martintribe.org>
 RUN apt-get -y update
 
 # Required for running tests
-RUN apt-get -y install make python
+RUN apt-get -y install make python3
+RUN ln -fs /usr/bin/python3 /usr/local/bin/python
 
 # Some typical implementation and test requirements
 RUN apt-get -y install curl libreadline-dev libedit-dev
+
+RUN apt-get -y install libpcre3-dev
 
 RUN mkdir -p /mal
 WORKDIR /mal
 
 ##########################################################
+# Compile the io interpreter
+##########################################################
+
+FROM base AS builder
+
+RUN apt-get -y install git cmake gcc
+
+RUN cd /tmp \
+    && git clone --recursive -q --depth=1 https://github.com/IoLanguage/io.git \
+    && cd /tmp/io \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=release .. && make && make install
+
+# Force eerie (Io package manager) to install itself and the packages in /opt/.eerie
+ENV HOME=/opt
+
+RUN cd /tmp/io/eerie \
+    && mkdir -p /opt \
+    && . ./install_unix.sh --notouch \
+    && eerie install https://github.com/IoLanguage/Range.git \
+    && eerie install https://github.com/IoLanguage/ReadLine.git \
+    && eerie install https://github.com/IoLanguage/Regex.git
+
+##########################################################
 # Specific implementation requirements
 ##########################################################
 
-# Zip
-RUN apt-get -y install unzip
+FROM base AS io
 
-RUN cd /tmp && curl -O -J -L http://iobin.suspended-chord.info/linux/iobin-linux-x64-deb-current.zip \
-    && unzip iobin-linux-x64-deb-current.zip IoLanguage-2013.11.04-Linux-x64.deb \
-    && dpkg -i IoLanguage-2013.11.04-Linux-x64.deb \
-    && ldconfig \
-    && rm -f iobin-linux-x64-deb-current.zip IoLanguage-2013.11.04-Linux-x64.deb
+COPY --from=builder /usr/local/lib/ /usr/lib/
+COPY --from=builder /usr/local/bin/ /usr/bin/
+COPY --from=builder /opt/.eerie/ /opt/.eerie/
 
-ENV HOME /mal
+ENV HOME=/mal

--- a/impls/io/Makefile
+++ b/impls/io/Makefile
@@ -1,4 +1,11 @@
-all:
-	@true
+STEPS = step0_repl.io step1_read_print.io step2_eval.io step3_env.io step4_if_fn_do.io step5_tco.io \
+        step6_file.io step7_quote.io step8_macros.io step9_try.io stepA_mal.io
+
+all: eerie
+
+eerie:
+	ln -s /opt/.eerie eerie
+
+$(STEPS): eerie
 
 clean:

--- a/impls/io/run
+++ b/impls/io/run
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-# Io prints the line "Registering Regex: Regex" when loading the Regex module
-# for the first time, and there's no way to suppress it.  To avoid polluting
-# the Mal script output, we swallow the first 25 bytes.
-io $(dirname $0)/${STEP:-stepA_mal}.io "$@" | (read -N 25 -t 10 ; cat)
+io $(dirname $0)/${STEP:-stepA_mal}.io "$@"


### PR DESCRIPTION
Build Io interpreter and packages from source in latest Ubuntu.

The interpreter looks for packages under `eerie` in the current directory, so create the symlink in the Makefile that is "building" each step.

Now the Regex package no longer prints a message when loaded, so no need for the special treatment in `run`.

----

Pull request requirements:

- [ ] Commits are well written and well organized.
- [x] Commits for a specific implementation should be prefixed with
  the implementation name.
- [x] Github Actions CI passes all checks (including self-host)
