### PR TITLE
rpython: simplify and probably remove a performance bottleneck

### DIFF
--- a/impls/rpython/env.py
+++ b/impls/rpython/env.py
@@ -21,12 +21,6 @@ class Env():
                 else:
                     self.data[bind.value] = exprs[i]
 
-    def find(self, key):
-        assert isinstance(key, MalSym)
-        if key.value in self.data: return self
-        elif self.outer:           return self.outer.find(key)
-        else:                      return None
-
     def set(self, key, value):
         assert isinstance(key, MalSym)
         assert isinstance(value, MalType)
@@ -34,13 +28,10 @@ class Env():
         return value
 
     def get(self, key):
-        assert isinstance(key, MalSym)
-        env = self.find(key)
-        if not env: throw_str("'" + str(key.value) + "' not found")
-        return env.data[key.value]
-
-    def get_or_None(self, key):
-        assert isinstance(key, MalSym)
-        env = self.find(key)
-        if not env: return None
-        return env.data[key.value]
+        assert isinstance(key, unicode)
+        env = self
+        while True:
+            value = env.data.get(key, None)
+            if value is not None: return value
+            env = env.outer
+            if env is None: return None

--- a/impls/rpython/step2_eval.py
+++ b/impls/rpython/step2_eval.py
@@ -11,13 +11,6 @@ def READ(str):
     return reader.read_str(str)
 
 # eval
-def eval_ast(ast, env):
-    assert isinstance(ast, MalList)
-    res = []
-    for a in ast.values:
-        res.append(EVAL(a, env))
-    return MalList(res)
-
 def EVAL(ast, env):
     # print(u"EVAL: " + printer._pr_str(ast))
     if types._symbol_Q(ast):
@@ -41,10 +34,13 @@ def EVAL(ast, env):
     else:
         # apply list
         if len(ast) == 0: return ast
-        el = eval_ast(ast, env)
-        f = el.values[0]
+        f = EVAL(ast[0], env)
+        args_list = []
+        for i in range(1, len(ast)):
+            args_list.append(EVAL(ast[i], env))
+        args = MalList(args_list)
         if isinstance(f, MalFunc):
-            return f.apply(el.values[1:])
+            return f.apply(args)
         else:
             raise Exception("%s is not callable" % f)
 
@@ -53,7 +49,7 @@ def PRINT(exp):
     return printer._pr_str(exp)
 
 # repl
-repl_env = {} 
+repl_env = {}
 def REP(str, env):
     return PRINT(EVAL(READ(str), env))
 

--- a/impls/rpython/step4_if_fn_do.py
+++ b/impls/rpython/step4_if_fn_do.py
@@ -14,19 +14,15 @@ def READ(str):
     return reader.read_str(str)
 
 # eval
-def eval_ast(ast, env):
-    assert isinstance(ast, MalList)
-    res = []
-    for a in ast.values:
-        res.append(EVAL(a, env))
-    return MalList(res)
-
 def EVAL(ast, env):
-    if env.get_or_None(MalSym(u"DEBUG-EVAL")) not in (None, nil, false):
+    if env.get(u"DEBUG-EVAL") not in (None, nil, false):
         print(u"EVAL: " + printer._pr_str(ast))
     if types._symbol_Q(ast):
         assert isinstance(ast, MalSym)
-        return env.get(ast)
+        value = env.get(ast.value)
+        if value is None:
+            throw_str("'" + str(ast.value) + "' not found")
+        return value
     elif types._vector_Q(ast):
         res = []
         for a in ast.values:
@@ -59,8 +55,11 @@ def EVAL(ast, env):
                 let_env.set(a1[i], EVAL(a1[i+1], let_env))
             return EVAL(a2, let_env)
         elif u"do" == a0sym:
-            el = eval_ast(ast.rest(), env)
-            return el.values[-1]
+            if len(ast) == 0:
+                return nil
+            for i in range(1, len(ast) - 1):
+                EVAL(ast[i], env)
+            return EVAL(ast[-1], env)
         elif u"if" == a0sym:
             a1, a2 = ast[1], ast[2]
             cond = EVAL(a1, env)
@@ -73,10 +72,13 @@ def EVAL(ast, env):
             a1, a2 = ast[1], ast[2]
             return MalFunc(None, a2, env, a1, EVAL)
         else:
-            el = eval_ast(ast, env)
-            f = el.values[0]
+            f = EVAL(a0, env)
+            args_list = []
+            for i in range(1, len(ast)):
+                args_list.append(EVAL(ast[i], env))
+            args = MalList(args_list)
             if isinstance(f, MalFunc):
-                return f.apply(el.rest())
+                return f.apply(args)
             else:
                 raise Exception("%s is not callable" % f)
 

--- a/impls/rpython/step5_tco.py
+++ b/impls/rpython/step5_tco.py
@@ -14,20 +14,16 @@ def READ(str):
     return reader.read_str(str)
 
 # eval
-def eval_ast(ast, env):
-    assert isinstance(ast, MalList)
-    res = []
-    for a in ast.values:
-        res.append(EVAL(a, env))
-    return MalList(res)
-
 def EVAL(ast, env):
   while True:
-    if env.get_or_None(MalSym(u"DEBUG-EVAL")) not in (None, nil, false):
+    if env.get(u"DEBUG-EVAL") not in (None, nil, false):
         print(u"EVAL: " + printer._pr_str(ast))
     if types._symbol_Q(ast):
         assert isinstance(ast, MalSym)
-        return env.get(ast)
+        value = env.get(ast.value)
+        if value is None:
+            throw_str("'" + str(ast.value) + "' not found")
+        return value
     elif types._vector_Q(ast):
         res = []
         for a in ast.values:
@@ -63,8 +59,8 @@ def EVAL(ast, env):
         elif u"do" == a0sym:
             if len(ast) == 0:
                 return nil
-            elif len(ast) > 1:
-                eval_ast(ast.slice2(1, len(ast)-1), env)
+            for i in range(1, len(ast) - 1):
+                EVAL(ast[i], env)
             ast = ast[-1] # Continue loop (TCO)
         elif u"if" == a0sym:
             a1, a2 = ast[1], ast[2]
@@ -78,14 +74,17 @@ def EVAL(ast, env):
             a1, a2 = ast[1], ast[2]
             return MalFunc(None, a2, env, a1, EVAL)
         else:
-            el = eval_ast(ast, env)
-            f = el.values[0]
+            f = EVAL(a0, env)
+            args_list = []
+            for i in range(1, len(ast)):
+                args_list.append(EVAL(ast[i], env))
+            args = MalList(args_list)
             if isinstance(f, MalFunc):
                 if f.ast:
                     ast = f.ast
-                    env = f.gen_env(el.rest()) # Continue loop (TCO) 
+                    env = f.gen_env(args) # Continue loop (TCO)
                 else:
-                    return f.apply(el.rest())
+                    return f.apply(args)
             else:
                 raise Exception("%s is not callable" % f)
 

--- a/impls/rpython/step6_file.py
+++ b/impls/rpython/step6_file.py
@@ -14,20 +14,16 @@ def READ(str):
     return reader.read_str(str)
 
 # eval
-def eval_ast(ast, env):
-    assert isinstance(ast, MalList)
-    res = []
-    for a in ast.values:
-        res.append(EVAL(a, env))
-    return MalList(res)
-
 def EVAL(ast, env):
   while True:
-    if env.get_or_None(MalSym(u"DEBUG-EVAL")) not in (None, nil, false):
+    if env.get(u"DEBUG-EVAL") not in (None, nil, false):
         print(u"EVAL: " + printer._pr_str(ast))
     if types._symbol_Q(ast):
         assert isinstance(ast, MalSym)
-        return env.get(ast)
+        value = env.get(ast.value)
+        if value is None:
+            throw_str("'" + str(ast.value) + "' not found")
+        return value
     elif types._vector_Q(ast):
         res = []
         for a in ast.values:
@@ -63,8 +59,8 @@ def EVAL(ast, env):
         elif u"do" == a0sym:
             if len(ast) == 0:
                 return nil
-            elif len(ast) > 1:
-                eval_ast(ast.slice2(1, len(ast)-1), env)
+            for i in range(1, len(ast) - 1):
+                EVAL(ast[i], env)
             ast = ast[-1] # Continue loop (TCO)
         elif u"if" == a0sym:
             a1, a2 = ast[1], ast[2]
@@ -78,14 +74,17 @@ def EVAL(ast, env):
             a1, a2 = ast[1], ast[2]
             return MalFunc(None, a2, env, a1, EVAL)
         else:
-            el = eval_ast(ast, env)
-            f = el.values[0]
+            f = EVAL(a0, env)
+            args_list = []
+            for i in range(1, len(ast)):
+                args_list.append(EVAL(ast[i], env))
+            args = MalList(args_list)
             if isinstance(f, MalFunc):
                 if f.ast:
                     ast = f.ast
-                    env = f.gen_env(el.rest()) # Continue loop (TCO) 
+                    env = f.gen_env(args) # Continue loop (TCO)
                 else:
-                    return f.apply(el.rest())
+                    return f.apply(args)
             else:
                 raise Exception("%s is not callable" % f)
 

--- a/impls/rpython/step7_quote.py
+++ b/impls/rpython/step7_quote.py
@@ -41,20 +41,16 @@ def quasiquote(ast):
     else:
         return ast
 
-def eval_ast(ast, env):
-    assert isinstance(ast, MalList)
-    res = []
-    for a in ast.values:
-        res.append(EVAL(a, env))
-    return MalList(res)
-
 def EVAL(ast, env):
   while True:
-    if env.get_or_None(MalSym(u"DEBUG-EVAL")) not in (None, nil, false):
+    if env.get(u"DEBUG-EVAL") not in (None, nil, false):
         print(u"EVAL: " + printer._pr_str(ast))
     if types._symbol_Q(ast):
         assert isinstance(ast, MalSym)
-        return env.get(ast)
+        value = env.get(ast.value)
+        if value is None:
+            throw_str("'" + str(ast.value) + "' not found")
+        return value
     elif types._vector_Q(ast):
         res = []
         for a in ast.values:
@@ -94,8 +90,8 @@ def EVAL(ast, env):
         elif u"do" == a0sym:
             if len(ast) == 0:
                 return nil
-            elif len(ast) > 1:
-                eval_ast(ast.slice2(1, len(ast)-1), env)
+            for i in range(1, len(ast) - 1):
+                EVAL(ast[i], env)
             ast = ast[-1] # Continue loop (TCO)
         elif u"if" == a0sym:
             a1, a2 = ast[1], ast[2]
@@ -109,14 +105,17 @@ def EVAL(ast, env):
             a1, a2 = ast[1], ast[2]
             return MalFunc(None, a2, env, a1, EVAL)
         else:
-            el = eval_ast(ast, env)
-            f = el.values[0]
+            f = EVAL(a0, env)
+            args_list = []
+            for i in range(1, len(ast)):
+                args_list.append(EVAL(ast[i], env))
+            args = MalList(args_list)
             if isinstance(f, MalFunc):
                 if f.ast:
                     ast = f.ast
-                    env = f.gen_env(el.rest()) # Continue loop (TCO)
+                    env = f.gen_env(args) # Continue loop (TCO)
                 else:
-                    return f.apply(el.rest())
+                    return f.apply(args)
             else:
                 raise Exception("%s is not callable" % f)
 

--- a/impls/rpython/step8_macros.py
+++ b/impls/rpython/step8_macros.py
@@ -41,20 +41,16 @@ def quasiquote(ast):
     else:
         return ast
 
-def eval_ast(ast, env):
-    assert isinstance(ast, MalList)
-    res = []
-    for a in ast.values:
-        res.append(EVAL(a, env))
-    return MalList(res)
-
 def EVAL(ast, env):
   while True:
-    if env.get_or_None(MalSym(u"DEBUG-EVAL")) not in (None, nil, false):
+    if env.get(u"DEBUG-EVAL") not in (None, nil, false):
         print(u"EVAL: " + printer._pr_str(ast))
     if types._symbol_Q(ast):
         assert isinstance(ast, MalSym)
-        return env.get(ast)
+        value = env.get(ast.value)
+        if value is None:
+            throw_str("'" + str(ast.value) + "' not found")
+        return value
     elif types._vector_Q(ast):
         res = []
         for a in ast.values:
@@ -100,8 +96,8 @@ def EVAL(ast, env):
         elif u"do" == a0sym:
             if len(ast) == 0:
                 return nil
-            elif len(ast) > 1:
-                eval_ast(ast.slice2(1, len(ast)-1), env)
+            for i in range(1, len(ast) - 1):
+                EVAL(ast[i], env)
             ast = ast[-1] # Continue loop (TCO)
         elif u"if" == a0sym:
             a1, a2 = ast[1], ast[2]
@@ -119,7 +115,10 @@ def EVAL(ast, env):
             if f.ismacro:
                 ast = f.apply(ast.rest()) # Continue loop (TCO)
                 continue
-            args = eval_ast(ast.rest(), env)
+            args_list = []
+            for i in range(1, len(ast)):
+                args_list.append(EVAL(ast[i], env))
+            args = MalList(args_list)
             if isinstance(f, MalFunc):
                 if f.ast:
                     ast = f.ast

--- a/impls/rpython/step9_try.py
+++ b/impls/rpython/step9_try.py
@@ -41,20 +41,16 @@ def quasiquote(ast):
     else:
         return ast
 
-def eval_ast(ast, env):
-    assert isinstance(ast, MalList)
-    res = []
-    for a in ast.values:
-        res.append(EVAL(a, env))
-    return MalList(res)
-
 def EVAL(ast, env):
   while True:
-    if env.get_or_None(MalSym(u"DEBUG-EVAL")) not in (None, nil, false):
+    if env.get(u"DEBUG-EVAL") not in (None, nil, false):
         print(u"EVAL: " + printer._pr_str(ast))
     if types._symbol_Q(ast):
         assert isinstance(ast, MalSym)
-        return env.get(ast)
+        value = env.get(ast.value)
+        if value is None:
+            throw_str("'" + str(ast.value) + "' not found")
+        return value
     elif types._vector_Q(ast):
         res = []
         for a in ast.values:
@@ -118,8 +114,8 @@ def EVAL(ast, env):
         elif u"do" == a0sym:
             if len(ast) == 0:
                 return nil
-            elif len(ast) > 1:
-                eval_ast(ast.slice2(1, len(ast)-1), env)
+            for i in range(1, len(ast) - 1):
+                EVAL(ast[i], env)
             ast = ast[-1] # Continue loop (TCO)
         elif u"if" == a0sym:
             a1, a2 = ast[1], ast[2]
@@ -137,7 +133,10 @@ def EVAL(ast, env):
             if f.ismacro:
                 ast = f.apply(ast.rest()) # Continue loop (TCO)
                 continue
-            args = eval_ast(ast.rest(), env)
+            args_list = []
+            for i in range(1, len(ast)):
+                args_list.append(EVAL(ast[i], env))
+            args = MalList(args_list)
             if isinstance(f, MalFunc):
                 if f.ast:
                     ast = f.ast

--- a/impls/rpython/stepA_mal.py
+++ b/impls/rpython/stepA_mal.py
@@ -50,20 +50,16 @@ def quasiquote(ast):
     else:
         return ast
 
-def eval_ast(ast, env):
-    assert isinstance(ast, MalList)
-    res = []
-    for a in ast.values:
-        res.append(EVAL(a, env))
-    return MalList(res)
-
 def EVAL(ast, env):
   while True:
-    if env.get_or_None(MalSym(u"DEBUG-EVAL")) not in (None, nil, false):
+    if env.get(u"DEBUG-EVAL") not in (None, nil, false):
         print(u"EVAL: " + printer._pr_str(ast))
     if types._symbol_Q(ast):
         assert isinstance(ast, MalSym)
-        return env.get(ast)
+        value = env.get(ast.value)
+        if value is None:
+            throw_str("'" + str(ast.value) + "' not found")
+        return value
     elif types._vector_Q(ast):
         res = []
         for a in ast.values:
@@ -127,8 +123,8 @@ def EVAL(ast, env):
         elif u"do" == a0sym:
             if len(ast) == 0:
                 return nil
-            elif len(ast) > 1:
-                eval_ast(ast.slice2(1, len(ast)-1), env)
+            for i in range(1, len(ast) - 1):
+                EVAL(ast[i], env)
             ast = ast[-1] # Continue loop (TCO)
         elif u"if" == a0sym:
             a1, a2 = ast[1], ast[2]
@@ -146,7 +142,10 @@ def EVAL(ast, env):
             if f.ismacro:
                 ast = f.apply(ast.rest()) # Continue loop (TCO)
                 continue
-            args = eval_ast(ast.rest(), env)
+            args_list = []
+            for i in range(1, len(ast)):
+                args_list.append(EVAL(ast[i], env))
+            args = MalList(args_list)
             if isinstance(f, MalFunc):
                 if f.ast:
                     ast = f.ast


### PR DESCRIPTION
Traverse environments without recursion.  Unwrap the key once. Do not wrap DEBUG-EVAL on each evaluation.
Spare two intermediate MalLists for the 'do' special form.