### PR TITLE
vbs: merge {macro,quasiquote}expand into EVAL, add DEBUG-EVAL

### DIFF
--- a/impls/vbs/core.vbs
+++ b/impls/vbs/core.vbs
@@ -38,7 +38,7 @@ Function MAdd(objArgs, objEnv)
 	Set MAdd = NewMalNum( _
 		objArgs.Item(1).Value + objArgs.Item(2).Value)
 End Function
-objNS.Add NewMalSym("+"), NewVbsProc("MAdd", False)
+objNS.Add "+", NewVbsProc("MAdd", False)
 
 Function MSub(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -47,7 +47,7 @@ Function MSub(objArgs, objEnv)
 	Set MSub = NewMalNum( _
 		objArgs.Item(1).Value - objArgs.Item(2).Value)
 End Function
-objNS.Add NewMalSym("-"), NewVbsProc("MSub", False)
+objNS.Add "-", NewVbsProc("MSub", False)
 
 Function MMul(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -56,7 +56,7 @@ Function MMul(objArgs, objEnv)
 	Set MMul = NewMalNum( _
 		objArgs.Item(1).Value * objArgs.Item(2).Value)
 End Function
-objNS.Add NewMalSym("*"), NewVbsProc("MMul", False)
+objNS.Add "*", NewVbsProc("MMul", False)
 
 Function MDiv(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -65,7 +65,7 @@ Function MDiv(objArgs, objEnv)
 	Set MDiv = NewMalNum( _
 		objArgs.Item(1).Value \ objArgs.Item(2).Value)
 End Function
-objNS.Add NewMalSym("/"), NewVbsProc("MDiv", False)
+objNS.Add "/", NewVbsProc("MDiv", False)
 
 Function MList(objArgs, objEnv)
 	Dim varRet
@@ -76,14 +76,14 @@ Function MList(objArgs, objEnv)
 	Next
 	Set MList = varRet
 End Function
-objNS.Add NewMalSym("list"), NewVbsProc("MList", False)
+objNS.Add "list", NewVbsProc("MList", False)
 
 Function MIsList(objArgs, objEnv)
 	CheckArgNum objArgs, 1
 
 	Set MIsList = NewMalBool(objArgs.Item(1).Type = TYPES.LIST)
 End Function
-objNS.Add NewMalSym("list?"), NewVbsProc("MIsList", False)
+objNS.Add "list?", NewVbsProc("MIsList", False)
 
 Function MIsEmpty(objArgs, objEnv)
 	CheckArgNum objArgs, 1
@@ -91,7 +91,7 @@ Function MIsEmpty(objArgs, objEnv)
 
 	Set MIsEmpty = NewMalBool(objArgs.Item(1).Count = 0)
 End Function
-objNS.Add NewMalSym("empty?"), NewVbsProc("MIsEmpty", False)
+objNS.Add "empty?", NewVbsProc("MIsEmpty", False)
 
 Function MCount(objArgs, objEnv)
 	CheckArgNum objArgs, 1
@@ -102,7 +102,7 @@ Function MCount(objArgs, objEnv)
 		Set MCount = NewMalNum(objArgs.Item(1).Count)
 	End If
 End Function
-objNS.Add NewMalSym("count"), NewVbsProc("MCount", False)
+objNS.Add "count", NewVbsProc("MCount", False)
 
 Function MEqual(objArgs, objEnv)
 	Dim varRet
@@ -159,7 +159,7 @@ Function MEqual(objArgs, objEnv)
 
 	Set MEqual = varRet
 End Function
-objNS.Add NewMalSym("="), NewVbsProc("MEqual", False)
+objNS.Add "=", NewVbsProc("MEqual", False)
 
 Function MGreater(objArgs, objEnv)
 	Dim varRet
@@ -170,7 +170,7 @@ Function MGreater(objArgs, objEnv)
 		objArgs.Item(1).Value > objArgs.Item(2).Value)
 	Set MGreater = varRet
 End Function
-objNS.Add NewMalSym(">"), NewVbsProc("MGreater", False)
+objNS.Add ">", NewVbsProc("MGreater", False)
 
 Function MPrStr(objArgs, objEnv)
 	Dim varRet
@@ -187,7 +187,7 @@ Function MPrStr(objArgs, objEnv)
 	Set varRet = NewMalStr(strRet)
 	Set MPrStr = varRet
 End Function
-objNS.Add NewMalSym("pr-str"), NewVbsProc("MPrStr", False)
+objNS.Add "pr-str", NewVbsProc("MPrStr", False)
 
 Function MStr(objArgs, objEnv)
 	Dim varRet
@@ -201,7 +201,7 @@ Function MStr(objArgs, objEnv)
 	Set varRet = NewMalStr(strRet)
 	Set MStr = varRet
 End Function
-objNS.Add NewMalSym("str"), NewVbsProc("MStr", False)
+objNS.Add "str", NewVbsProc("MStr", False)
 
 Function MPrn(objArgs, objEnv)
 	Dim varRet
@@ -211,7 +211,7 @@ Function MPrn(objArgs, objEnv)
 	Set varRet = NewMalNil()
 	Set MPrn = varRet
 End Function
-objNS.Add NewMalSym("prn"), NewVbsProc("MPrn", False)
+objNS.Add "prn", NewVbsProc("MPrn", False)
 
 Function MPrintln(objArgs, objEnv)
 	Dim varRet
@@ -229,7 +229,7 @@ Function MPrintln(objArgs, objEnv)
 	Set varRet = NewMalNil()
 	Set MPrintln = varRet
 End Function
-objNS.Add NewMalSym("println"), NewVbsProc("MPrintln", False)
+objNS.Add "println", NewVbsProc("MPrintln", False)
 
 Sub InitBuiltIn()
 	REP "(def! not (fn* [bool] (if bool false true)))"
@@ -257,7 +257,7 @@ Function MReadStr(objArgs, objEnv)
 	End If
 	Set MReadStr = varRes
 End Function
-objNS.Add NewMalSym("read-string"), NewVbsProc("MReadStr", False)
+objNS.Add "read-string", NewVbsProc("MReadStr", False)
 
 Function MSlurp(objArgs, objEnv)
 	Dim varRes
@@ -275,7 +275,7 @@ Function MSlurp(objArgs, objEnv)
 	Set varRes = NewMalStr(strRes)
 	Set MSlurp = varRes
 End Function
-objNS.Add NewMalSym("slurp"), NewVbsProc("MSlurp", False)
+objNS.Add "slurp", NewVbsProc("MSlurp", False)
 
 Function MAtom(objArgs, objEnv)
 	Dim varRes
@@ -284,7 +284,7 @@ Function MAtom(objArgs, objEnv)
 	Set varRes = NewMalAtom(objArgs.Item(1))
 	Set MAtom = varRes
 End Function
-objNS.Add NewMalSym("atom"), NewVbsProc("MAtom", False)
+objNS.Add "atom", NewVbsProc("MAtom", False)
 
 Function MIsAtom(objArgs, objEnv)
 	Dim varRes
@@ -293,7 +293,7 @@ Function MIsAtom(objArgs, objEnv)
 	Set varRes = NewMalBool(objArgs.Item(1).Type = TYPES.ATOM)
 	Set MIsAtom = varRes
 End Function
-objNS.Add NewMalSym("atom?"), NewVbsProc("MIsAtom", False)
+objNS.Add "atom?", NewVbsProc("MIsAtom", False)
 
 Function MDeref(objArgs, objEnv)
 	Dim varRes
@@ -303,7 +303,7 @@ Function MDeref(objArgs, objEnv)
 	Set varRes = objArgs.Item(1).Value
 	Set MDeref = varRes
 End Function
-objNS.Add NewMalSym("deref"), NewVbsProc("MDeref", False)
+objNS.Add "deref", NewVbsProc("MDeref", False)
 
 Function MReset(objArgs, objEnv)
 	Dim varRes
@@ -314,7 +314,7 @@ Function MReset(objArgs, objEnv)
 	Set varRes = objArgs.Item(2)
 	Set MReset = varRes
 End Function
-objNS.Add NewMalSym("reset!"), NewVbsProc("MReset", False)
+objNS.Add "reset!", NewVbsProc("MReset", False)
 
 Function MSwap(objArgs, objEnv)
 	Dim varRes
@@ -341,7 +341,7 @@ Function MSwap(objArgs, objEnv)
 	Set varRes = objAtom.Value
 	Set MSwap = varRes
 End Function
-objNS.Add NewMalSym("swap!"), NewVbsProc("MSwap", False)
+objNS.Add "swap!", NewVbsProc("MSwap", False)
 
 Function MConcat(objArgs, objEnv)
 	Dim varRes
@@ -359,7 +359,7 @@ Function MConcat(objArgs, objEnv)
 	Next
 	Set MConcat = varRes
 End Function
-objNS.Add NewMalSym("concat"), NewVbsProc("MConcat", False)
+objNS.Add "concat", NewVbsProc("MConcat", False)
 
 Function MVec(objArgs, objEnv)
 	Dim varRes
@@ -372,7 +372,7 @@ Function MVec(objArgs, objEnv)
 	Next
 	Set MVec = varRes
 End Function
-objNS.Add NewMalSym("vec"), NewVbsProc("MVec", False)
+objNS.Add "vec", NewVbsProc("MVec", False)
 
 Function MNth(objArgs, objEnv)
 	Dim varRes
@@ -389,7 +389,7 @@ Function MNth(objArgs, objEnv)
 
 	Set MNth = varRes
 End Function
-objNS.Add NewMalSym("nth"), NewVbsProc("MNth", False)
+objNS.Add "nth", NewVbsProc("MNth", False)
 
 Function MFirst(objArgs, objEnv)
 	Dim varRes
@@ -411,7 +411,7 @@ Function MFirst(objArgs, objEnv)
 
 	Set MFirst = varRes
 End Function
-objNS.Add NewMalSym("first"), NewVbsProc("MFirst", False)
+objNS.Add "first", NewVbsProc("MFirst", False)
 
 Function MRest(objArgs, objEnv)
 	Dim varRes
@@ -435,7 +435,7 @@ Function MRest(objArgs, objEnv)
 	
 	Set MRest = varRes
 End Function
-objNS.Add NewMalSym("rest"), NewVbsProc("MRest", False)
+objNS.Add "rest", NewVbsProc("MRest", False)
 
 Sub InitMacro()
 	REP "(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw ""odd number of forms to cond"")) (cons'cond (rest (rest xs)))))))"
@@ -475,7 +475,7 @@ Function MThrow(objArgs, objEnv)
 	Err.Raise vbObjectError, _
 		"MThrow", strRnd
 End Function
-objNS.Add NewMalSym("throw"), NewVbsProc("MThrow", False)
+objNS.Add "throw", NewVbsProc("MThrow", False)
 
 Function MApply(objArgs, objEnv)
 	Dim varRes
@@ -510,7 +510,7 @@ Function MApply(objArgs, objEnv)
 	Set varRes = objFn.ApplyWithoutEval(objAST, objEnv)
 	Set MApply = varRes
 End Function
-objNS.Add NewMalSym("apply"), NewVbsProc("MApply", False)
+objNS.Add "apply", NewVbsProc("MApply", False)
 
 Function MMap(objArgs, objEnv)
 	Dim varRes
@@ -534,7 +534,7 @@ Function MMap(objArgs, objEnv)
 
 	Set MMap = varRes
 End Function
-objNS.Add NewMalSym("map"), NewVbsProc("MMap", False)
+objNS.Add "map", NewVbsProc("MMap", False)
 
 Function MIsSymbol(objArgs, objEnv)
 	Dim varRes
@@ -542,7 +542,7 @@ Function MIsSymbol(objArgs, objEnv)
 	Set varRes = NewMalBool(objArgs.Item(1).Type = TYPES.SYMBOL)
 	Set MIsSymbol = varRes
 End Function
-objNS.Add NewMalSym("symbol?"), NewVbsProc("MIsSymbol", False)
+objNS.Add "symbol?", NewVbsProc("MIsSymbol", False)
 
 Function MSymbol(objArgs, objEnv)
 	Dim varRes
@@ -551,7 +551,7 @@ Function MSymbol(objArgs, objEnv)
 	Set varRes = NewMalSym(objArgs.Item(1).Value)
 	Set MSymbol = varRes
 End Function
-objNS.Add NewMalSym("symbol"), NewVbsProc("MSymbol", False)
+objNS.Add "symbol", NewVbsProc("MSymbol", False)
 
 Function MKeyword(objArgs, objEnv)
 	Dim varRes
@@ -567,7 +567,7 @@ Function MKeyword(objArgs, objEnv)
 	End Select
 	Set MKeyword = varRes
 End Function
-objNS.Add NewMalSym("keyword"), NewVbsProc("MKeyword", False)
+objNS.Add "keyword", NewVbsProc("MKeyword", False)
 
 Function MIsKeyword(objArgs, objEnv)
 	Dim varRes
@@ -575,7 +575,7 @@ Function MIsKeyword(objArgs, objEnv)
 	Set varRes = NewMalBool(objArgs.Item(1).Type = TYPES.KEYWORD)
 	Set MIsKeyword = varRes
 End Function
-objNS.Add NewMalSym("keyword?"), NewVbsProc("MIsKeyword", False)
+objNS.Add "keyword?", NewVbsProc("MIsKeyword", False)
 
 Function MIsSeq(objArgs, objEnv)
 	Dim varRes
@@ -585,7 +585,7 @@ Function MIsSeq(objArgs, objEnv)
 		objArgs.Item(1).Type = TYPES.VECTOR)
 	Set MIsSeq = varRes
 End Function
-objNS.Add NewMalSym("sequential?"), NewVbsProc("MIsSeq", False)
+objNS.Add "sequential?", NewVbsProc("MIsSeq", False)
 
 Function MIsVec(objArgs, objEnv)
 	Dim varRes
@@ -593,7 +593,7 @@ Function MIsVec(objArgs, objEnv)
 	Set varRes = NewMalBool(objArgs.Item(1).Type = TYPES.VECTOR)
 	Set MIsVec = varRes
 End Function
-objNS.Add NewMalSym("vector?"), NewVbsProc("MIsVec", False)
+objNS.Add "vector?", NewVbsProc("MIsVec", False)
 
 Function MIsMap(objArgs, objEnv)
 	Dim varRes
@@ -601,7 +601,7 @@ Function MIsMap(objArgs, objEnv)
 	Set varRes = NewMalBool(objArgs.Item(1).Type = TYPES.HASHMAP)
 	Set MIsMap = varRes
 End Function
-objNS.Add NewMalSym("map?"), NewVbsProc("MIsMap", False)
+objNS.Add "map?", NewVbsProc("MIsMap", False)
 
 Function MHashMap(objArgs, objEnv)
 	Dim varRes
@@ -616,7 +616,7 @@ Function MHashMap(objArgs, objEnv)
 	Next
 	Set MHashMap = varRes
 End Function
-objNS.Add NewMalSym("hash-map"), NewVbsProc("MHashMap", False)
+objNS.Add "hash-map", NewVbsProc("MHashMap", False)
 
 Function MAssoc(objArgs, objEnv)
 	Dim varRes
@@ -639,7 +639,7 @@ Function MAssoc(objArgs, objEnv)
 	Next
 	Set MAssoc = varRes
 End Function
-objNS.Add NewMalSym("assoc"), NewVbsProc("MAssoc", False)
+objNS.Add "assoc", NewVbsProc("MAssoc", False)
 
 Function MGet(objArgs, objEnv)
 	Dim varRes
@@ -658,7 +658,7 @@ Function MGet(objArgs, objEnv)
 	
 	Set MGet = varRes
 End Function
-objNS.Add NewMalSym("get"), NewVbsProc("MGet", False)
+objNS.Add "get", NewVbsProc("MGet", False)
 
 Function MDissoc(objArgs, objEnv)
 	Dim varRes
@@ -688,14 +688,14 @@ Function MDissoc(objArgs, objEnv)
 
 	Set MDissoc = varRes
 End Function
-objNS.Add NewMalSym("dissoc"), NewVbsProc("MDissoc", False)
+objNS.Add "dissoc", NewVbsProc("MDissoc", False)
 
 Function MKeys(objArgs, objEnv)
 	CheckArgNum objArgs, 1
 	CheckType objArgs.Item(1), TYPES.HASHMAP
 	Set MKeys = NewMalList(objArgs.Item(1).Keys)
 End Function
-objNS.Add NewMalSym("keys"), NewVbsProc("MKeys", False)
+objNS.Add "keys", NewVbsProc("MKeys", False)
 
 Function MIsContains(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -703,7 +703,7 @@ Function MIsContains(objArgs, objEnv)
 
 	Set MIsContains = NewMalBool(objArgs.Item(1).Exists(objArgs.Item(2)))
 End Function
-objNS.Add NewMalSym("contains?"), NewVbsProc("MIsContains", False)
+objNS.Add "contains?", NewVbsProc("MIsContains", False)
 
 Function MReadLine(objArgs, objEnv)
 	Dim varRes
@@ -722,24 +722,24 @@ Function MReadLine(objArgs, objEnv)
 	On Error Goto 0
 	Set MReadLine = varRes
 End Function
-objNS.Add NewMalSym("readline"), NewVbsProc("MReadLine", False)
+objNS.Add "readline", NewVbsProc("MReadLine", False)
 
 Function MTimeMs(objArgs, objEnv)
 	Set MTimeMs = NewMalNum(CLng(Timer * 1000))
 End Function
-objNS.Add NewMalSym("time-ms"), NewVbsProc("MTimeMs", False)
+objNS.Add "time-ms", NewVbsProc("MTimeMs", False)
 
 Function MIsStr(objArgs, objEnv)
 	CheckArgNum objArgs, 1
 	Set MIsStr = NewMalBool(objArgs.Item(1).Type = TYPES.STRING)
 End Function
-objNS.Add NewMalSym("string?"), NewVbsProc("MIsStr", False)
+objNS.Add "string?", NewVbsProc("MIsStr", False)
 
 Function MIsNum(objArgs, objEnv)
 	CheckArgNum objArgs, 1
 	Set MIsNum = NewMalBool(objArgs.Item(1).Type = TYPES.NUMBER)
 End Function
-objNS.Add NewMalSym("number?"), NewVbsProc("MIsNum", False)
+objNS.Add "number?", NewVbsProc("MIsNum", False)
 
 Function MIsFn(objArgs, objEnv)
 	CheckArgNum objArgs, 1
@@ -752,7 +752,7 @@ Function MIsFn(objArgs, objEnv)
 	
 	Set MIsFn = NewMalBool(varRes)
 End Function
-objNS.Add NewMalSym("fn?"), NewVbsProc("MIsFn", False)
+objNS.Add "fn?", NewVbsProc("MIsFn", False)
 
 
 Function MIsMacro(objArgs, objEnv)
@@ -766,7 +766,7 @@ Function MIsMacro(objArgs, objEnv)
 	
 	Set MIsMacro = NewMalBool(varRes)
 End Function
-objNS.Add NewMalSym("macro?"), NewVbsProc("MIsMacro", False)
+objNS.Add "macro?", NewVbsProc("MIsMacro", False)
 
 
 Function MMeta(objArgs, objEnv)
@@ -777,7 +777,7 @@ Function MMeta(objArgs, objEnv)
 	Set varRes = GetMeta(objArgs.Item(1))
 	Set MMeta = varRes
 End Function
-objNS.Add NewMalSym("meta"), NewVbsProc("MMeta", False)
+objNS.Add "meta", NewVbsProc("MMeta", False)
 
 Function MWithMeta(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -787,7 +787,7 @@ Function MWithMeta(objArgs, objEnv)
 	Set varRes = SetMeta(objArgs.Item(1), objArgs.Item(2))
 	Set MWithMeta = varRes
 End Function
-objNS.Add NewMalSym("with-meta"), NewVbsProc("MWithMeta", False)
+objNS.Add "with-meta", NewVbsProc("MWithMeta", False)
 
 Function MConj(objArgs, objEnv)
 	If objArgs.Count - 1 < 1 Then
@@ -821,7 +821,7 @@ Function MConj(objArgs, objEnv)
 	End Select
 	Set MConj = varRes
 End Function
-objNS.Add NewMalSym("conj"), NewVbsProc("MConj", False)
+objNS.Add "conj", NewVbsProc("MConj", False)
 
 Function MSeq(objArgs, objEnv)
 	CheckArgNum objArgs, 1
@@ -862,5 +862,5 @@ Function MSeq(objArgs, objEnv)
 	End Select
 	Set MSeq = varRes
 End Function
-objNS.Add NewMalSym("seq"), NewVbsProc("MSeq", False)
+objNS.Add "seq", NewVbsProc("MSeq", False)
 

--- a/impls/vbs/env.vbs
+++ b/impls/vbs/env.vbs
@@ -41,8 +41,7 @@ Class Environment
 			If TypeName(objOuter) <> "Nothing" Then
 				Set varRet = objOuter.Find(varKey)
 			Else
-				Err.Raise vbObjectError, _
-					"Environment", "'" + varKey + "' not found"
+				Set varRet = Nothing
 			End If
 		End If
 
@@ -55,7 +54,11 @@ Class Environment
 		If objEnv Is objSelf Then
 			Set varRet = objBinds(varKey)
 		Else
+		  If TypeName(objEnv) <> "Nothing" Then
 			Set varRet = objEnv.Get(varKey)
+		  Else
+			Set varRet = Nothing
+		  End If
 		End If
 		
 		Set [Get] = varRet

--- a/impls/vbs/env.vbs
+++ b/impls/vbs/env.vbs
@@ -1,66 +1,41 @@
 Option Explicit
 
 Function NewEnv(objOuter)
-	Dim varRet
-	Set varRet = New Environment
-	Set varRet.Self = varRet
-	Set varRet.Outer = objOuter
-	Set NewEnv = varRet
+	Set NewEnv = New Environment
+	Set NewEnv.Outer = objOuter
 End Function
 
 Class Environment
-	Private objOuter, objSelf
-	Private objBinds
+	Public objOuter
+	Public objBinds
 	Private Sub Class_Initialize()
 		Set objBinds = CreateObject("Scripting.Dictionary")
 		Set objOuter = Nothing
-		Set objSelf = Nothing
 	End Sub
 	
 	Public Property Set Outer(objEnv)
 		Set objOuter = objEnv
 	End Property
 
-	Public Property Get Outer()
-		Set Outer = objOuter
-	End Property
-
-	Public Property Set Self(objEnv)
-		Set objSelf = objEnv
-	End Property
-	
 	Public Sub Add(varKey, varValue)
 		Set objBinds.Item(varKey) = varValue
 	End Sub
 
-	Public Function Find(varKey)
-		Dim varRet
-		If objBinds.Exists(varKey) Then
-			Set varRet = objSelf
-		Else
-			If TypeName(objOuter) <> "Nothing" Then
-				Set varRet = objOuter.Find(varKey)
-			Else
-				Set varRet = Nothing
-			End If
-		End If
-
-		Set Find = varRet
-	End Function
-	
 	Public Function [Get](varKey)
 		Dim objEnv, varRet
-		Set objEnv = Find(varKey)
-		If objEnv Is objSelf Then
-			Set varRet = objBinds(varKey)
-		Else
-		  If TypeName(objEnv) <> "Nothing" Then
-			Set varRet = objEnv.Get(varKey)
-		  Else
-			Set varRet = Nothing
-		  End If
-		End If
-		
+		Set objEnv = Me
+		Do
+			If objEnv.objBinds.Exists(varKey) Then
+				Set varRet = objEnv.objBinds(varKey)
+				Exit Do
+			End If
+			Set objEnv = objEnv.objOuter
+			If TypeName(objEnv) = "Nothing" Then
+				Set varRet = Nothing
+				Exit Do
+			End If
+		Loop
+
 		Set [Get] = varRet
 	End Function
 End Class

--- a/impls/vbs/env.vbs
+++ b/impls/vbs/env.vbs
@@ -30,7 +30,7 @@ Class Environment
 	End Property
 	
 	Public Sub Add(varKey, varValue)
-		Set objBinds.Item(varKey.Value) = varValue
+		Set objBinds.Item(varKey) = varValue
 	End Sub
 
 	Public Function Find(varKey)

--- a/impls/vbs/env.vbs
+++ b/impls/vbs/env.vbs
@@ -35,14 +35,14 @@ Class Environment
 
 	Public Function Find(varKey)
 		Dim varRet
-		If objBinds.Exists(varKey.Value) Then
+		If objBinds.Exists(varKey) Then
 			Set varRet = objSelf
 		Else
 			If TypeName(objOuter) <> "Nothing" Then
 				Set varRet = objOuter.Find(varKey)
 			Else
 				Err.Raise vbObjectError, _
-					"Environment", "'" + varKey.Value + "' not found"
+					"Environment", "'" + varKey + "' not found"
 			End If
 		End If
 
@@ -53,7 +53,7 @@ Class Environment
 		Dim objEnv, varRet
 		Set objEnv = Find(varKey)
 		If objEnv Is objSelf Then
-			Set varRet = objBinds(varKey.Value)
+			Set varRet = objBinds(varKey)
 		Else
 			Set varRet = objEnv.Get(varKey)
 		End If

--- a/impls/vbs/step2_eval.vbs
+++ b/impls/vbs/step2_eval.vbs
@@ -123,6 +123,9 @@ Function Evaluate(objCode, objEnv)
 		Set Evaluate = Nothing
 		Exit Function
 	End If
+
+	' DebugEval objCode, objEnv
+
 	Dim varRet, objFirst
 	If objCode.Type = TYPES.LIST Then
 		If objCode.Count = 0 Then ' ()

--- a/impls/vbs/step2_eval.vbs
+++ b/impls/vbs/step2_eval.vbs
@@ -14,7 +14,7 @@ Class Enviroment
 	End Sub
 
 	Public Function Add(objSymbol, objProcedure)
-		objDict.Add objSymbol.Value, objProcedure
+		objDict.Add objSymbol, objProcedure
 	End Function
 
 	Public Property Set Self(objThis)
@@ -46,7 +46,7 @@ Function MAdd(objArgs, objEnv)
 	Set MAdd = NewMalNum( _
 		objArgs.Item(1).Value + objArgs.Item(2).Value)
 End Function
-objEnv.Add NewMalSym("+"), NewVbsProc("MAdd", False)
+objEnv.Add "+", NewVbsProc("MAdd", False)
 
 Function MSub(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -55,7 +55,7 @@ Function MSub(objArgs, objEnv)
 	Set MSub = NewMalNum( _
 		objArgs.Item(1).Value - objArgs.Item(2).Value)
 End Function
-objEnv.Add NewMalSym("-"), NewVbsProc("MSub", False)
+objEnv.Add "-", NewVbsProc("MSub", False)
 
 Function MMul(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -64,7 +64,7 @@ Function MMul(objArgs, objEnv)
 	Set MMul = NewMalNum( _
 		objArgs.Item(1).Value * objArgs.Item(2).Value)
 End Function
-objEnv.Add NewMalSym("*"), NewVbsProc("MMul", False)
+objEnv.Add "*", NewVbsProc("MMul", False)
 
 Function MDiv(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -73,7 +73,7 @@ Function MDiv(objArgs, objEnv)
 	Set MDiv = NewMalNum( _
 		objArgs.Item(1).Value \ objArgs.Item(2).Value)
 End Function
-objEnv.Add NewMalSym("/"), NewVbsProc("MDiv", False)
+objEnv.Add "/", NewVbsProc("MDiv", False)
 
 Sub CheckArgNum(objArgs, lngArgNum)
 	If objArgs.Count - 1 <> lngArgNum Then

--- a/impls/vbs/step2_eval.vbs
+++ b/impls/vbs/step2_eval.vbs
@@ -5,39 +5,17 @@ Include "Types.vbs"
 Include "Reader.vbs"
 Include "Printer.vbs"
 
-Class Enviroment
-	Private objDict
-	Private objSelf
-
-	Private Sub Class_Initialize
-		Set objDict = CreateObject("Scripting.Dictionary")
-	End Sub
-
-	Public Function Add(objSymbol, objProcedure)
-		objDict.Add objSymbol, objProcedure
-	End Function
-
-	Public Property Set Self(objThis)
-		Set objSelf = objThis
-	End Property
-
-	Public Function Find(varKey)
-		Set Find = objSelf
-	End Function
-
-	Public Function [Get](objSymbol)
+	Function EnvGet(objDict, objSymbol)
 		If objDict.Exists(objSymbol) Then
-			Set [Get] = objDict.Item(objSymbol)
+			Set EnvGet = objDict.Item(objSymbol)
 		Else
 			Err.Raise vbObjectError, _
 				"Enviroment", "Symbol '" + objSymbol + "' not found."
 		End If
 	End Function
-End Class
 
 Dim objEnv
-Set objEnv = New Enviroment
-Set objEnv.Self = objEnv
+Set objEnv = CreateObject("Scripting.Dictionary")
 
 Function MAdd(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -146,7 +124,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode.Value)
+			Set varRet = EnvGet(objEnv, objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step2_eval.vbs
+++ b/impls/vbs/step2_eval.vbs
@@ -26,11 +26,11 @@ Class Enviroment
 	End Function
 
 	Public Function [Get](objSymbol)
-		If objDict.Exists(objSymbol.Value) Then
-			Set [Get] = objDict.Item(objSymbol.Value)
+		If objDict.Exists(objSymbol) Then
+			Set [Get] = objDict.Item(objSymbol)
 		Else
 			Err.Raise vbObjectError, _
-				"Enviroment", "Symbol '" + PrintMalType(objSymbol, True) + "' not found."
+				"Enviroment", "Symbol '" + objSymbol + "' not found."
 		End If
 	End Function
 End Class
@@ -143,7 +143,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode)
+			Set varRet = objEnv.Get(objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step3_env.vbs
+++ b/impls/vbs/step3_env.vbs
@@ -129,11 +129,34 @@ Function Read(strCode)
 	Set Read = ReadString(strCode)
 End Function
 
+Sub DebugEval(objCode, objEnv)
+	Dim value, bool
+	Set value = objEnv.Get("DEBUG-EVAL")
+	If TypeName(value) = "Nothing" Then
+		bool = False
+	Else
+		Select Case value.Type
+			Case TYPES.NIL
+				bool = False
+			Case TYPES.BOOLEAN
+				bool = value.Value
+			Case Else
+				bool = True
+		End Select
+	End If
+	If bool Then
+		IO.WriteLine "EVAL: " + Print(objCode)
+	End If
+End Sub
+
 Function Evaluate(objCode, objEnv)
 	If TypeName(objCode) = "Nothing" Then
 		Set Evaluate = Nothing
 		Exit Function
 	End If
+
+	DebugEval objCode, objEnv
+
 	Dim varRet, objFirst
 	If objCode.Type = TYPES.LIST Then
 		If objCode.Count = 0 Then ' ()

--- a/impls/vbs/step3_env.vbs
+++ b/impls/vbs/step3_env.vbs
@@ -177,7 +177,7 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
-			if TypeName(varRet) = "Nothing" Then
+			If TypeName(varRet) = "Nothing" Then
 				Err.Raise vbObjectError, _
 					"EvaluateAST", "'" + objCode.Value + "' not found"
 			End If

--- a/impls/vbs/step3_env.vbs
+++ b/impls/vbs/step3_env.vbs
@@ -154,7 +154,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode)
+			Set varRet = objEnv.Get(objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step3_env.vbs
+++ b/impls/vbs/step3_env.vbs
@@ -16,7 +16,7 @@ Function MAdd(objArgs, objEnv)
 	Set MAdd = NewMalNum( _
 		objArgs.Item(1).Value + objArgs.Item(2).Value)
 End Function
-objEnv.Add NewMalSym("+"), NewVbsProc("MAdd", False)
+objEnv.Add "+", NewVbsProc("MAdd", False)
 
 Function MSub(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -25,7 +25,7 @@ Function MSub(objArgs, objEnv)
 	Set MSub = NewMalNum( _
 		objArgs.Item(1).Value - objArgs.Item(2).Value)
 End Function
-objEnv.Add NewMalSym("-"), NewVbsProc("MSub", False)
+objEnv.Add "-", NewVbsProc("MSub", False)
 
 Function MMul(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -34,7 +34,7 @@ Function MMul(objArgs, objEnv)
 	Set MMul = NewMalNum( _
 		objArgs.Item(1).Value * objArgs.Item(2).Value)
 End Function
-objEnv.Add NewMalSym("*"), NewVbsProc("MMul", False)
+objEnv.Add "*", NewVbsProc("MMul", False)
 
 Function MDiv(objArgs, objEnv)
 	CheckArgNum objArgs, 2
@@ -43,7 +43,7 @@ Function MDiv(objArgs, objEnv)
 	Set MDiv = NewMalNum( _
 		objArgs.Item(1).Value \ objArgs.Item(2).Value)
 End Function
-objEnv.Add NewMalSym("/"), NewVbsProc("MDiv", False)
+objEnv.Add "/", NewVbsProc("MDiv", False)
 
 Sub CheckArgNum(objArgs, lngArgNum)
 	If objArgs.Count - 1 <> lngArgNum Then
@@ -64,10 +64,10 @@ Function MDef(objArgs, objEnv)
 	CheckArgNum objArgs, 2
 	CheckType objArgs.Item(1), TYPES.SYMBOL
 	Set varRet = Evaluate(objArgs.Item(2), objEnv)
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDef = varRet
 End Function
-objEnv.Add NewMalSym("def!"), NewVbsProc("MDef", True)
+objEnv.Add "def!", NewVbsProc("MDef", True)
 
 Function MLet(objArgs, objEnv)
 	Dim varRet
@@ -92,17 +92,17 @@ Function MLet(objArgs, objEnv)
 	For i = 0 To objBinds.Count - 1 Step 2
 		Set objSym = objBinds.Item(i)
 		CheckType objSym, TYPES.SYMBOL
-		objNewEnv.Add objSym, Evaluate(objBinds.Item(i + 1), objNewEnv)
+		objNewEnv.Add objSym.Value, Evaluate(objBinds.Item(i + 1), objNewEnv)
 	Next
 
 	Set varRet = Evaluate(objArgs.Item(2), objNewEnv)
 	Set MLet = varRet
 End Function
-objEnv.Add NewMalSym("let*"), NewVbsProc("MLet", True)
+objEnv.Add "let*", NewVbsProc("MLet", True)
 
 Call REPL()
 Sub REPL()
-	Dim strCode, strResult
+	Dim strCode
 	While True
 		IO.Write "user> "
 

--- a/impls/vbs/step3_env.vbs
+++ b/impls/vbs/step3_env.vbs
@@ -155,6 +155,10 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
+			if TypeName(varRet) = "Nothing" Then
+				Err.Raise vbObjectError, _
+					"EvaluateAST", "'" + objCode.Value + "' not found"
+			End If
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step3_env.vbs
+++ b/impls/vbs/step3_env.vbs
@@ -130,23 +130,22 @@ Function Read(strCode)
 End Function
 
 Sub DebugEval(objCode, objEnv)
-	Dim value, bool
+	Dim value
 	Set value = objEnv.Get("DEBUG-EVAL")
+	' And and Or do not short-circuit.
 	If TypeName(value) = "Nothing" Then
-		bool = False
+		Exit Sub
 	Else
 		Select Case value.Type
 			Case TYPES.NIL
-				bool = False
+				Exit Sub
 			Case TYPES.BOOLEAN
-				bool = value.Value
-			Case Else
-				bool = True
+				If Not value.Value Then
+					Exit Sub
+				End If
 		End Select
 	End If
-	If bool Then
-		IO.WriteLine "EVAL: " + Print(objCode)
-	End If
+	IO.WriteLine "EVAL: " + Print(objCode)
 End Sub
 
 Function Evaluate(objCode, objEnv)

--- a/impls/vbs/step4_if_fn_do.vbs
+++ b/impls/vbs/step4_if_fn_do.vbs
@@ -144,23 +144,22 @@ Function Read(strCode)
 End Function
 
 Sub DebugEval(objCode, objEnv)
-	Dim value, bool
+	Dim value
 	Set value = objEnv.Get("DEBUG-EVAL")
+	' And and Or do not short-circuit.
 	If TypeName(value) = "Nothing" Then
-		bool = False
+		Exit Sub
 	Else
 		Select Case value.Type
 			Case TYPES.NIL
-				bool = False
+				Exit Sub
 			Case TYPES.BOOLEAN
-				bool = value.Value
-			Case Else
-				bool = True
+				If Not value.Value Then
+					Exit Sub
+				End If
 		End Select
 	End If
-	If bool Then
-		IO.WriteLine "EVAL: " + Print(objCode)
-	End If
+	IO.WriteLine "EVAL: " + Print(objCode)
 End Sub
 
 Function Evaluate(objCode, objEnv)

--- a/impls/vbs/step4_if_fn_do.vbs
+++ b/impls/vbs/step4_if_fn_do.vbs
@@ -168,7 +168,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode)
+			Set varRet = objEnv.Get(objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step4_if_fn_do.vbs
+++ b/impls/vbs/step4_if_fn_do.vbs
@@ -169,6 +169,10 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
+			if TypeName(varRet) = "Nothing" Then
+				Err.Raise vbObjectError, _
+					"EvaluateAST", "'" + objCode.Value + "' not found"
+			End If
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step4_if_fn_do.vbs
+++ b/impls/vbs/step4_if_fn_do.vbs
@@ -143,11 +143,34 @@ Function Read(strCode)
 	Set Read = ReadString(strCode)
 End Function
 
+Sub DebugEval(objCode, objEnv)
+	Dim value, bool
+	Set value = objEnv.Get("DEBUG-EVAL")
+	If TypeName(value) = "Nothing" Then
+		bool = False
+	Else
+		Select Case value.Type
+			Case TYPES.NIL
+				bool = False
+			Case TYPES.BOOLEAN
+				bool = value.Value
+			Case Else
+				bool = True
+		End Select
+	End If
+	If bool Then
+		IO.WriteLine "EVAL: " + Print(objCode)
+	End If
+End Sub
+
 Function Evaluate(objCode, objEnv)
 	If TypeName(objCode) = "Nothing" Then
 		Set Evaluate = Nothing
 		Exit Function
 	End If
+
+	DebugEval objCode, objEnv
+
 	Dim varRet, objFirst
 	If objCode.Type = TYPES.LIST Then
 		If objCode.Count = 0 Then ' ()

--- a/impls/vbs/step4_if_fn_do.vbs
+++ b/impls/vbs/step4_if_fn_do.vbs
@@ -19,10 +19,10 @@ Function MDef(objArgs, objEnv)
 	CheckArgNum objArgs, 2
 	CheckType objArgs.Item(1), TYPES.SYMBOL
 	Set varRet = Evaluate(objArgs.Item(2), objEnv)
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDef = varRet
 End Function
-objNS.Add NewMalSym("def!"), NewVbsProc("MDef", True)
+objNS.Add "def!", NewVbsProc("MDef", True)
 
 Function MLet(objArgs, objEnv)
 	Dim varRet
@@ -43,13 +43,13 @@ Function MLet(objArgs, objEnv)
 	For i = 0 To objBinds.Count - 1 Step 2
 		Set objSym = objBinds.Item(i)
 		CheckType objSym, TYPES.SYMBOL
-		objNewEnv.Add objSym, Evaluate(objBinds.Item(i + 1), objNewEnv)
+		objNewEnv.Add objSym.Value, Evaluate(objBinds.Item(i + 1), objNewEnv)
 	Next
 
 	Set varRet = Evaluate(objArgs.Item(2), objNewEnv)
 	Set MLet = varRet
 End Function
-objNS.Add NewMalSym("let*"), NewVbsProc("MLet", True)
+objNS.Add "let*", NewVbsProc("MLet", True)
 
 Function MDo(objArgs, objEnv)
 	Dim varRet, i
@@ -62,7 +62,7 @@ Function MDo(objArgs, objEnv)
 	Next
 	Set MDo = varRet
 End Function
-objNS.Add NewMalSym("do"), NewVbsProc("MDo", True)
+objNS.Add "do", NewVbsProc("MDo", True)
 
 Function MIf(objArgs, objEnv)
 	Dim varRet
@@ -92,7 +92,7 @@ Function MIf(objArgs, objEnv)
 	End If
 	Set MIf = varRet
 End Function
-objNS.Add NewMalSym("if"), NewVbsProc("MIf", True)
+objNS.Add "if", NewVbsProc("MIf", True)
 
 Function MFn(objArgs, objEnv)
 	Dim varRet
@@ -110,13 +110,13 @@ Function MFn(objArgs, objEnv)
 	Set varRet = NewMalProc(objParams, objCode, objEnv)
 	Set MFn = varRet
 End Function
-objNS.Add NewMalSym("fn*"), NewVbsProc("MFn", True)
+objNS.Add "fn*", NewVbsProc("MFn", True)
 
 Call InitBuiltIn()
 
 Call REPL()
 Sub REPL()
-	Dim strCode, strResult
+	Dim strCode
 	While True
 		IO.Write "user> "
 

--- a/impls/vbs/step4_if_fn_do.vbs
+++ b/impls/vbs/step4_if_fn_do.vbs
@@ -191,7 +191,7 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
-			if TypeName(varRet) = "Nothing" Then
+			If TypeName(varRet) = "Nothing" Then
 				Err.Raise vbObjectError, _
 					"EvaluateAST", "'" + objCode.Value + "' not found"
 			End If

--- a/impls/vbs/step5_tco.vbs
+++ b/impls/vbs/step5_tco.vbs
@@ -152,12 +152,34 @@ Function Read(strCode)
 	Set Read = ReadString(strCode)
 End Function
 
+Sub DebugEval(objCode, objEnv)
+	Dim value, bool
+	Set value = objEnv.Get("DEBUG-EVAL")
+	If TypeName(value) = "Nothing" Then
+		bool = False
+	Else
+		Select Case value.Type
+			Case TYPES.NIL
+				bool = False
+			Case TYPES.BOOLEAN
+				bool = value.Value
+			Case Else
+				bool = True
+		End Select
+	End If
+	If bool Then
+		IO.WriteLine "EVAL: " + Print(objCode)
+	End If
+End Sub
+
 Function Evaluate(ByVal objCode, ByVal objEnv)
 	While True
 		If TypeName(objCode) = "Nothing" Then
 			Set Evaluate = Nothing
 			Exit Function
 		End If
+
+		DebugEval objCode, objEnv
 
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then

--- a/impls/vbs/step5_tco.vbs
+++ b/impls/vbs/step5_tco.vbs
@@ -153,23 +153,22 @@ Function Read(strCode)
 End Function
 
 Sub DebugEval(objCode, objEnv)
-	Dim value, bool
+	Dim value
 	Set value = objEnv.Get("DEBUG-EVAL")
+	' And and Or do not short-circuit.
 	If TypeName(value) = "Nothing" Then
-		bool = False
+		Exit Sub
 	Else
 		Select Case value.Type
 			Case TYPES.NIL
-				bool = False
+				Exit Sub
 			Case TYPES.BOOLEAN
-				bool = value.Value
-			Case Else
-				bool = True
+				If Not value.Value Then
+					Exit Sub
+				End If
 		End Select
 	End If
-	If bool Then
-		IO.WriteLine "EVAL: " + Print(objCode)
-	End If
+	IO.WriteLine "EVAL: " + Print(objCode)
 End Sub
 
 Function Evaluate(ByVal objCode, ByVal objEnv)

--- a/impls/vbs/step5_tco.vbs
+++ b/impls/vbs/step5_tco.vbs
@@ -212,7 +212,7 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
-			if TypeName(varRet) = "Nothing" Then
+			If TypeName(varRet) = "Nothing" Then
 				Err.Raise vbObjectError, _
 					"EvaluateAST", "'" + objCode.Value + "' not found"
 			End If

--- a/impls/vbs/step5_tco.vbs
+++ b/impls/vbs/step5_tco.vbs
@@ -25,10 +25,10 @@ Function MDef(objArgs, objEnv)
 	CheckArgNum objArgs, 2
 	CheckType objArgs.Item(1), TYPES.SYMBOL
 	Set varRet = Evaluate(objArgs.Item(2), objEnv)
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDef = varRet
 End Function
-objNS.Add NewMalSym("def!"), NewVbsProc("MDef", True)
+objNS.Add "def!", NewVbsProc("MDef", True)
 
 Function MLet(objArgs, objEnv)
 	Dim varRet
@@ -49,13 +49,13 @@ Function MLet(objArgs, objEnv)
 	For i = 0 To objBinds.Count - 1 Step 2
 		Set objSym = objBinds.Item(i)
 		CheckType objSym, TYPES.SYMBOL
-		objNewEnv.Add objSym, Evaluate(objBinds.Item(i + 1), objNewEnv)
+		objNewEnv.Add objSym.Value, Evaluate(objBinds.Item(i + 1), objNewEnv)
 	Next
 
 	Set varRet = EvalLater(objArgs.Item(2), objNewEnv)
 	Set MLet = varRet
 End Function
-objNS.Add NewMalSym("let*"), NewVbsProc("MLet", True)
+objNS.Add "let*", NewVbsProc("MLet", True)
 
 Function MDo(objArgs, objEnv)
 	Dim varRet, i
@@ -71,7 +71,7 @@ Function MDo(objArgs, objEnv)
 		objEnv)
 	Set MDo = varRet
 End Function
-objNS.Add NewMalSym("do"), NewVbsProc("MDo", True)
+objNS.Add "do", NewVbsProc("MDo", True)
 
 Function MIf(objArgs, objEnv)
 	Dim varRet
@@ -101,7 +101,7 @@ Function MIf(objArgs, objEnv)
 	End If
 	Set MIf = varRet
 End Function
-objNS.Add NewMalSym("if"), NewVbsProc("MIf", True)
+objNS.Add "if", NewVbsProc("MIf", True)
 
 Function MFn(objArgs, objEnv)
 	Dim varRet
@@ -119,7 +119,7 @@ Function MFn(objArgs, objEnv)
 	Set varRet = NewMalProc(objParams, objCode, objEnv)
 	Set MFn = varRet
 End Function
-objNS.Add NewMalSym("fn*"), NewVbsProc("MFn", True)
+objNS.Add "fn*", NewVbsProc("MFn", True)
 
 Call InitBuiltIn()
 
@@ -138,7 +138,7 @@ Sub REPL()
 		On Error Resume Next
 			strRes = REP(strCode)
 			If Err.Number <> 0 Then
-				IO.WriteErrLine "Exception: " + Err.Description 
+				IO.WriteErrLine "Exception: " + Err.Description
 			Else
 				If strRes <> "" Then
 					IO.WriteLine strRes
@@ -158,13 +158,14 @@ Function Evaluate(ByVal objCode, ByVal objEnv)
 			Set Evaluate = Nothing
 			Exit Function
 		End If
-		
+
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then
 			If objCode.Count = 0 Then ' ()
 				Set Evaluate = objCode
 				Exit Function
 			End If
+
 			Set objFirst = Evaluate(objCode.Item(0), objEnv)
 			Set varRet = objFirst.Apply(objCode, objEnv)
 		Else

--- a/impls/vbs/step5_tco.vbs
+++ b/impls/vbs/step5_tco.vbs
@@ -191,6 +191,10 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
+			if TypeName(varRet) = "Nothing" Then
+				Err.Raise vbObjectError, _
+					"EvaluateAST", "'" + objCode.Value + "' not found"
+			End If
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step5_tco.vbs
+++ b/impls/vbs/step5_tco.vbs
@@ -189,7 +189,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode)
+			Set varRet = objEnv.Get(objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step6_file.vbs
+++ b/impls/vbs/step6_file.vbs
@@ -180,12 +180,34 @@ Function Read(strCode)
 	Set Read = ReadString(strCode)
 End Function
 
+Sub DebugEval(objCode, objEnv)
+	Dim value, bool
+	Set value = objEnv.Get("DEBUG-EVAL")
+	If TypeName(value) = "Nothing" Then
+		bool = False
+	Else
+		Select Case value.Type
+			Case TYPES.NIL
+				bool = False
+			Case TYPES.BOOLEAN
+				bool = value.Value
+			Case Else
+				bool = True
+		End Select
+	End If
+	If bool Then
+		IO.WriteLine "EVAL: " + Print(objCode)
+	End If
+End Sub
+
 Function Evaluate(ByVal objCode, ByVal objEnv)
 	While True
 		If TypeName(objCode) = "Nothing" Then
 			Set Evaluate = Nothing
 			Exit Function
 		End If
+
+		DebugEval objCode, objEnv
 
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then

--- a/impls/vbs/step6_file.vbs
+++ b/impls/vbs/step6_file.vbs
@@ -240,7 +240,7 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
-			if TypeName(varRet) = "Nothing" Then
+			If TypeName(varRet) = "Nothing" Then
 				Err.Raise vbObjectError, _
 					"EvaluateAST", "'" + objCode.Value + "' not found"
 			End If

--- a/impls/vbs/step6_file.vbs
+++ b/impls/vbs/step6_file.vbs
@@ -181,23 +181,22 @@ Function Read(strCode)
 End Function
 
 Sub DebugEval(objCode, objEnv)
-	Dim value, bool
+	Dim value
 	Set value = objEnv.Get("DEBUG-EVAL")
+	' And and Or do not short-circuit.
 	If TypeName(value) = "Nothing" Then
-		bool = False
+		Exit Sub
 	Else
 		Select Case value.Type
 			Case TYPES.NIL
-				bool = False
+				Exit Sub
 			Case TYPES.BOOLEAN
-				bool = value.Value
-			Case Else
-				bool = True
+				If Not value.Value Then
+					Exit Sub
+				End If
 		End Select
 	End If
-	If bool Then
-		IO.WriteLine "EVAL: " + Print(objCode)
-	End If
+	IO.WriteLine "EVAL: " + Print(objCode)
 End Sub
 
 Function Evaluate(ByVal objCode, ByVal objEnv)

--- a/impls/vbs/step6_file.vbs
+++ b/impls/vbs/step6_file.vbs
@@ -217,7 +217,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode)
+			Set varRet = objEnv.Get(objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step6_file.vbs
+++ b/impls/vbs/step6_file.vbs
@@ -25,10 +25,10 @@ Function MDef(objArgs, objEnv)
 	CheckArgNum objArgs, 2
 	CheckType objArgs.Item(1), TYPES.SYMBOL
 	Set varRet = Evaluate(objArgs.Item(2), objEnv)
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDef = varRet
 End Function
-objNS.Add NewMalSym("def!"), NewVbsProc("MDef", True)
+objNS.Add "def!", NewVbsProc("MDef", True)
 
 Function MLet(objArgs, objEnv)
 	Dim varRet
@@ -49,13 +49,13 @@ Function MLet(objArgs, objEnv)
 	For i = 0 To objBinds.Count - 1 Step 2
 		Set objSym = objBinds.Item(i)
 		CheckType objSym, TYPES.SYMBOL
-		objNewEnv.Add objSym, Evaluate(objBinds.Item(i + 1), objNewEnv)
+		objNewEnv.Add objSym.Value, Evaluate(objBinds.Item(i + 1), objNewEnv)
 	Next
 
 	Set varRet = EvalLater(objArgs.Item(2), objNewEnv)
 	Set MLet = varRet
 End Function
-objNS.Add NewMalSym("let*"), NewVbsProc("MLet", True)
+objNS.Add "let*", NewVbsProc("MLet", True)
 
 Function MDo(objArgs, objEnv)
 	Dim varRet, i
@@ -71,7 +71,7 @@ Function MDo(objArgs, objEnv)
 		objEnv)
 	Set MDo = varRet
 End Function
-objNS.Add NewMalSym("do"), NewVbsProc("MDo", True)
+objNS.Add "do", NewVbsProc("MDo", True)
 
 Function MIf(objArgs, objEnv)
 	Dim varRet
@@ -101,7 +101,7 @@ Function MIf(objArgs, objEnv)
 	End If
 	Set MIf = varRet
 End Function
-objNS.Add NewMalSym("if"), NewVbsProc("MIf", True)
+objNS.Add "if", NewVbsProc("MIf", True)
 
 Function MFn(objArgs, objEnv)
 	Dim varRet
@@ -119,7 +119,7 @@ Function MFn(objArgs, objEnv)
 	Set varRet = NewMalProc(objParams, objCode, objEnv)
 	Set MFn = varRet
 End Function
-objNS.Add NewMalSym("fn*"), NewVbsProc("MFn", True)
+objNS.Add "fn*", NewVbsProc("MFn", True)
 
 Function MEval(objArgs, objEnv)
 	Dim varRes
@@ -129,7 +129,7 @@ Function MEval(objArgs, objEnv)
 	Set varRes = EvalLater(varRes, objNS)
 	Set MEval = varRes
 End Function
-objNS.Add NewMalSym("eval"), NewVbsProc("MEval", True)
+objNS.Add "eval", NewVbsProc("MEval", True)
 
 Call InitBuiltIn()
 
@@ -143,7 +143,7 @@ Sub InitArgs()
 		objArgs.Add NewMalStr(WScript.Arguments.Item(i))
 	Next
 	
-	objNS.Add NewMalSym("*ARGV*"), objArgs
+	objNS.Add "*ARGV*", objArgs
 	
 	If WScript.Arguments.Count > 0 Then
 		REP "(load-file """ + WScript.Arguments.Item(0) + """)"
@@ -186,13 +186,14 @@ Function Evaluate(ByVal objCode, ByVal objEnv)
 			Set Evaluate = Nothing
 			Exit Function
 		End If
-		
+
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then
 			If objCode.Count = 0 Then ' ()
 				Set Evaluate = objCode
 				Exit Function
 			End If
+
 			Set objFirst = Evaluate(objCode.Item(0), objEnv)
 			Set varRet = objFirst.Apply(objCode, objEnv)
 		Else

--- a/impls/vbs/step6_file.vbs
+++ b/impls/vbs/step6_file.vbs
@@ -219,6 +219,10 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
+			if TypeName(varRet) = "Nothing" Then
+				Err.Raise vbObjectError, _
+					"EvaluateAST", "'" + objCode.Value + "' not found"
+			End If
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step7_quote.vbs
+++ b/impls/vbs/step7_quote.vbs
@@ -363,7 +363,7 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
-			if TypeName(varRet) = "Nothing" Then
+			If TypeName(varRet) = "Nothing" Then
 				Err.Raise vbObjectError, _
 					"EvaluateAST", "'" + objCode.Value + "' not found"
 			End If

--- a/impls/vbs/step7_quote.vbs
+++ b/impls/vbs/step7_quote.vbs
@@ -160,7 +160,6 @@ Function MQuasiQuoteExpand(objArgs, objEnv)
 
 	Set MQuasiQuoteExpand = varRes
 End Function
-objNS.Add NewMalSym("quasiquoteexpand"), NewVbsProc("MQuasiQuoteExpand", True)
 
 Class ExpandType
 	Public Splice

--- a/impls/vbs/step7_quote.vbs
+++ b/impls/vbs/step7_quote.vbs
@@ -340,7 +340,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode)
+			Set varRet = objEnv.Get(objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step7_quote.vbs
+++ b/impls/vbs/step7_quote.vbs
@@ -304,23 +304,22 @@ Function Read(strCode)
 End Function
 
 Sub DebugEval(objCode, objEnv)
-	Dim value, bool
+	Dim value
 	Set value = objEnv.Get("DEBUG-EVAL")
+	' And and Or do not short-circuit.
 	If TypeName(value) = "Nothing" Then
-		bool = False
+		Exit Sub
 	Else
 		Select Case value.Type
 			Case TYPES.NIL
-				bool = False
+				Exit Sub
 			Case TYPES.BOOLEAN
-				bool = value.Value
-			Case Else
-				bool = True
+				If Not value.Value Then
+					Exit Sub
+				End If
 		End Select
 	End If
-	If bool Then
-		IO.WriteLine "EVAL: " + Print(objCode)
-	End If
+	IO.WriteLine "EVAL: " + Print(objCode)
 End Sub
 
 Function Evaluate(ByVal objCode, ByVal objEnv)

--- a/impls/vbs/step7_quote.vbs
+++ b/impls/vbs/step7_quote.vbs
@@ -303,12 +303,34 @@ Function Read(strCode)
 	Set Read = ReadString(strCode)
 End Function
 
+Sub DebugEval(objCode, objEnv)
+	Dim value, bool
+	Set value = objEnv.Get("DEBUG-EVAL")
+	If TypeName(value) = "Nothing" Then
+		bool = False
+	Else
+		Select Case value.Type
+			Case TYPES.NIL
+				bool = False
+			Case TYPES.BOOLEAN
+				bool = value.Value
+			Case Else
+				bool = True
+		End Select
+	End If
+	If bool Then
+		IO.WriteLine "EVAL: " + Print(objCode)
+	End If
+End Sub
+
 Function Evaluate(ByVal objCode, ByVal objEnv)
 	While True
 		If TypeName(objCode) = "Nothing" Then
 			Set Evaluate = Nothing
 			Exit Function
 		End If
+
+		DebugEval objCode, objEnv
 
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then

--- a/impls/vbs/step7_quote.vbs
+++ b/impls/vbs/step7_quote.vbs
@@ -25,10 +25,10 @@ Function MDef(objArgs, objEnv)
 	CheckArgNum objArgs, 2
 	CheckType objArgs.Item(1), TYPES.SYMBOL
 	Set varRet = Evaluate(objArgs.Item(2), objEnv)
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDef = varRet
 End Function
-objNS.Add NewMalSym("def!"), NewVbsProc("MDef", True)
+objNS.Add "def!", NewVbsProc("MDef", True)
 
 Function MLet(objArgs, objEnv)
 	Dim varRet
@@ -49,13 +49,13 @@ Function MLet(objArgs, objEnv)
 	For i = 0 To objBinds.Count - 1 Step 2
 		Set objSym = objBinds.Item(i)
 		CheckType objSym, TYPES.SYMBOL
-		objNewEnv.Add objSym, Evaluate(objBinds.Item(i + 1), objNewEnv)
+		objNewEnv.Add objSym.Value, Evaluate(objBinds.Item(i + 1), objNewEnv)
 	Next
 
 	Set varRet = EvalLater(objArgs.Item(2), objNewEnv)
 	Set MLet = varRet
 End Function
-objNS.Add NewMalSym("let*"), NewVbsProc("MLet", True)
+objNS.Add "let*", NewVbsProc("MLet", True)
 
 Function MDo(objArgs, objEnv)
 	Dim varRet, i
@@ -71,7 +71,7 @@ Function MDo(objArgs, objEnv)
 		objEnv)
 	Set MDo = varRet
 End Function
-objNS.Add NewMalSym("do"), NewVbsProc("MDo", True)
+objNS.Add "do", NewVbsProc("MDo", True)
 
 Function MIf(objArgs, objEnv)
 	Dim varRet
@@ -101,7 +101,7 @@ Function MIf(objArgs, objEnv)
 	End If
 	Set MIf = varRet
 End Function
-objNS.Add NewMalSym("if"), NewVbsProc("MIf", True)
+objNS.Add "if", NewVbsProc("MIf", True)
 
 Function MFn(objArgs, objEnv)
 	Dim varRet
@@ -119,7 +119,7 @@ Function MFn(objArgs, objEnv)
 	Set varRet = NewMalProc(objParams, objCode, objEnv)
 	Set MFn = varRet
 End Function
-objNS.Add NewMalSym("fn*"), NewVbsProc("MFn", True)
+objNS.Add "fn*", NewVbsProc("MFn", True)
 
 Function MEval(objArgs, objEnv)
 	Dim varRes
@@ -129,13 +129,13 @@ Function MEval(objArgs, objEnv)
 	Set varRes = EvalLater(varRes, objNS)
 	Set MEval = varRes
 End Function
-objNS.Add NewMalSym("eval"), NewVbsProc("MEval", True)
+objNS.Add "eval", NewVbsProc("MEval", True)
 
 Function MQuote(objArgs, objEnv)
 	CheckArgNum objArgs, 1
 	Set MQuote = objArgs.Item(1)
 End Function
-objNS.Add NewMalSym("quote"), NewVbsProc("MQuote", True)
+objNS.Add "quote", NewVbsProc("MQuote", True)
 
 Function MQuasiQuote(objArgs, objEnv)
 	Dim varRes
@@ -145,7 +145,7 @@ Function MQuasiQuote(objArgs, objEnv)
 		MQuasiQuoteExpand(objArgs, objEnv), objEnv)
 	Set MQuasiQuote = varRes
 End Function
-objNS.Add NewMalSym("quasiquote"), NewVbsProc("MQuasiQuote", True)
+objNS.Add "quasiquote", NewVbsProc("MQuasiQuote", True)
 
 Function MQuasiQuoteExpand(objArgs, objEnv)
 	Dim varRes
@@ -266,7 +266,7 @@ Sub InitArgs()
 		objArgs.Add NewMalStr(WScript.Arguments.Item(i))
 	Next
 	
-	objNS.Add NewMalSym("*ARGV*"), objArgs
+	objNS.Add "*ARGV*", objArgs
 	
 	If WScript.Arguments.Count > 0 Then
 		REP "(load-file """ + WScript.Arguments.Item(0) + """)"
@@ -309,13 +309,14 @@ Function Evaluate(ByVal objCode, ByVal objEnv)
 			Set Evaluate = Nothing
 			Exit Function
 		End If
-		
+
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then
 			If objCode.Count = 0 Then ' ()
 				Set Evaluate = objCode
 				Exit Function
 			End If
+
 			Set objFirst = Evaluate(objCode.Item(0), objEnv)
 			Set varRet = objFirst.Apply(objCode, objEnv)
 		Else

--- a/impls/vbs/step7_quote.vbs
+++ b/impls/vbs/step7_quote.vbs
@@ -342,6 +342,10 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
+			if TypeName(varRet) = "Nothing" Then
+				Err.Raise vbObjectError, _
+					"EvaluateAST", "'" + objCode.Value + "' not found"
+			End If
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step8_macros.vbs
+++ b/impls/vbs/step8_macros.vbs
@@ -25,10 +25,10 @@ Function MDef(objArgs, objEnv)
 	CheckArgNum objArgs, 2
 	CheckType objArgs.Item(1), TYPES.SYMBOL
 	Set varRet = Evaluate(objArgs.Item(2), objEnv)
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDef = varRet
 End Function
-objNS.Add NewMalSym("def!"), NewVbsProc("MDef", True)
+objNS.Add "def!", NewVbsProc("MDef", True)
 
 Function MLet(objArgs, objEnv)
 	Dim varRet
@@ -49,13 +49,13 @@ Function MLet(objArgs, objEnv)
 	For i = 0 To objBinds.Count - 1 Step 2
 		Set objSym = objBinds.Item(i)
 		CheckType objSym, TYPES.SYMBOL
-		objNewEnv.Add objSym, Evaluate(objBinds.Item(i + 1), objNewEnv)
+		objNewEnv.Add objSym.Value, Evaluate(objBinds.Item(i + 1), objNewEnv)
 	Next
 
 	Set varRet = EvalLater(objArgs.Item(2), objNewEnv)
 	Set MLet = varRet
 End Function
-objNS.Add NewMalSym("let*"), NewVbsProc("MLet", True)
+objNS.Add "let*", NewVbsProc("MLet", True)
 
 Function MDo(objArgs, objEnv)
 	Dim varRet, i
@@ -71,7 +71,7 @@ Function MDo(objArgs, objEnv)
 		objEnv)
 	Set MDo = varRet
 End Function
-objNS.Add NewMalSym("do"), NewVbsProc("MDo", True)
+objNS.Add "do", NewVbsProc("MDo", True)
 
 Function MIf(objArgs, objEnv)
 	Dim varRet
@@ -101,7 +101,7 @@ Function MIf(objArgs, objEnv)
 	End If
 	Set MIf = varRet
 End Function
-objNS.Add NewMalSym("if"), NewVbsProc("MIf", True)
+objNS.Add "if", NewVbsProc("MIf", True)
 
 Function MFn(objArgs, objEnv)
 	Dim varRet
@@ -119,7 +119,7 @@ Function MFn(objArgs, objEnv)
 	Set varRet = NewMalProc(objParams, objCode, objEnv)
 	Set MFn = varRet
 End Function
-objNS.Add NewMalSym("fn*"), NewVbsProc("MFn", True)
+objNS.Add "fn*", NewVbsProc("MFn", True)
 
 Function MEval(objArgs, objEnv)
 	Dim varRes
@@ -129,13 +129,13 @@ Function MEval(objArgs, objEnv)
 	Set varRes = EvalLater(varRes, objNS)
 	Set MEval = varRes
 End Function
-objNS.Add NewMalSym("eval"), NewVbsProc("MEval", True)
+objNS.Add "eval", NewVbsProc("MEval", True)
 
 Function MQuote(objArgs, objEnv)
 	CheckArgNum objArgs, 1
 	Set MQuote = objArgs.Item(1)
 End Function
-objNS.Add NewMalSym("quote"), NewVbsProc("MQuote", True)
+objNS.Add "quote", NewVbsProc("MQuote", True)
 
 Function MQuasiQuote(objArgs, objEnv)
 	Dim varRes
@@ -145,7 +145,7 @@ Function MQuasiQuote(objArgs, objEnv)
 		MQuasiQuoteExpand(objArgs, objEnv), objEnv)
 	Set MQuasiQuote = varRes
 End Function
-objNS.Add NewMalSym("quasiquote"), NewVbsProc("MQuasiQuote", True)
+objNS.Add "quasiquote", NewVbsProc("MQuasiQuote", True)
 
 Function MQuasiQuoteExpand(objArgs, objEnv)
 	Dim varRes
@@ -261,10 +261,10 @@ Function MDefMacro(objArgs, objEnv)
 	Set varRet = Evaluate(objArgs.Item(2), objEnv).Copy()
 	CheckType varRet, TYPES.PROCEDURE
 	varRet.IsMacro = True
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDefMacro = varRet
 End Function
-objNS.Add NewMalSym("defmacro!"), NewVbsProc("MDefMacro", True)
+objNS.Add "defmacro!", NewVbsProc("MDefMacro", True)
 
 Call InitBuiltIn()
 Call InitMacro()
@@ -279,7 +279,7 @@ Sub InitArgs()
 		objArgs.Add NewMalStr(WScript.Arguments.Item(i))
 	Next
 	
-	objNS.Add NewMalSym("*ARGV*"), objArgs
+	objNS.Add "*ARGV*", objArgs
 	
 	If WScript.Arguments.Count > 0 Then
 		REP "(load-file """ + WScript.Arguments.Item(0) + """)"

--- a/impls/vbs/step8_macros.vbs
+++ b/impls/vbs/step8_macros.vbs
@@ -160,7 +160,6 @@ Function MQuasiQuoteExpand(objArgs, objEnv)
 
 	Set MQuasiQuoteExpand = varRes
 End Function
-objNS.Add NewMalSym("quasiquoteexpand"), NewVbsProc("MQuasiQuoteExpand", True)
 
 Class ExpandType
 	Public Splice

--- a/impls/vbs/step8_macros.vbs
+++ b/impls/vbs/step8_macros.vbs
@@ -380,7 +380,7 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
-			if TypeName(varRet) = "Nothing" Then
+			If TypeName(varRet) = "Nothing" Then
 				Err.Raise vbObjectError, _
 					"EvaluateAST", "'" + objCode.Value + "' not found"
 			End If

--- a/impls/vbs/step8_macros.vbs
+++ b/impls/vbs/step8_macros.vbs
@@ -317,23 +317,22 @@ Function Read(strCode)
 End Function
 
 Sub DebugEval(objCode, objEnv)
-	Dim value, bool
+	Dim value
 	Set value = objEnv.Get("DEBUG-EVAL")
+	' And and Or do not short-circuit.
 	If TypeName(value) = "Nothing" Then
-		bool = False
+		Exit Sub
 	Else
 		Select Case value.Type
 			Case TYPES.NIL
-				bool = False
+				Exit Sub
 			Case TYPES.BOOLEAN
-				bool = value.Value
-			Case Else
-				bool = True
+				If Not value.Value Then
+					Exit Sub
+				End If
 		End Select
 	End If
-	If bool Then
-		IO.WriteLine "EVAL: " + Print(objCode)
-	End If
+	IO.WriteLine "EVAL: " + Print(objCode)
 End Sub
 
 Function Evaluate(ByVal objCode, ByVal objEnv)

--- a/impls/vbs/step8_macros.vbs
+++ b/impls/vbs/step8_macros.vbs
@@ -266,47 +266,6 @@ Function MDefMacro(objArgs, objEnv)
 End Function
 objNS.Add NewMalSym("defmacro!"), NewVbsProc("MDefMacro", True)
 
-Function IsMacroCall(objCode, objEnv)
-	Dim varRes
-	varRes = False
-
-	' VBS has no short-circuit evaluation.
-	If objCode.Type = TYPES.LIST Then
-		If objCode.Count > 0 Then
-			If objCode.Item(0).Type = TYPES.SYMBOL Then
-				Dim varValue
-				Set varValue = objEnv.Get(objCode.Item(0))
-				If varValue.Type = TYPES.PROCEDURE Then
-					If varValue.IsMacro Then
-						varRes = True
-					End If
-				End If
-			End If
-		End If
-	End If
-
-	IsMacroCall = varRes
-End Function
-
-Function MacroExpand(ByVal objAST, ByVal objEnv)
-	Dim varRes
-	While IsMacroCall(objAST, objEnv)
-		Dim varMacro
-		Set varMacro = objEnv.Get(objAST.Item(0))
-		Set objAST = varMacro.MacroApply(objAST, objEnv)		
-	Wend
-	Set varRes = objAST
-	Set MacroExpand = varRes
-End Function
-
-Function MMacroExpand(objArgs, objEnv)
-	Dim varRes
-	CheckArgNum objArgs, 1
-	Set varRes = MacroExpand(objArgs.Item(1), objEnv)
-	Set MMacroExpand = varRes
-End Function
-objNS.Add NewMalSym("macroexpand"), NewVbsProc("MMacroExpand", True)
-
 Call InitBuiltIn()
 Call InitMacro()
 
@@ -363,8 +322,6 @@ Function Evaluate(ByVal objCode, ByVal objEnv)
 			Set Evaluate = Nothing
 			Exit Function
 		End If
-		
-		Set objCode = MacroExpand(objCode, objEnv)
 
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then
@@ -374,7 +331,11 @@ Function Evaluate(ByVal objCode, ByVal objEnv)
 			End If
 
 			Set objFirst = Evaluate(objCode.Item(0), objEnv)
-			Set varRet = objFirst.Apply(objCode, objEnv)
+			If objFirst.IsMacro Then
+				Set varRet = EvalLater(objFirst.MacroApply(objCode, objEnv), objEnv)
+			Else
+				Set varRet = objFirst.Apply(objCode, objEnv)
+			End If
 		Else
 			Set varRet = EvaluateAST(objCode, objEnv)
 		End If

--- a/impls/vbs/step8_macros.vbs
+++ b/impls/vbs/step8_macros.vbs
@@ -316,12 +316,34 @@ Function Read(strCode)
 	Set Read = ReadString(strCode)
 End Function
 
+Sub DebugEval(objCode, objEnv)
+	Dim value, bool
+	Set value = objEnv.Get("DEBUG-EVAL")
+	If TypeName(value) = "Nothing" Then
+		bool = False
+	Else
+		Select Case value.Type
+			Case TYPES.NIL
+				bool = False
+			Case TYPES.BOOLEAN
+				bool = value.Value
+			Case Else
+				bool = True
+		End Select
+	End If
+	If bool Then
+		IO.WriteLine "EVAL: " + Print(objCode)
+	End If
+End Sub
+
 Function Evaluate(ByVal objCode, ByVal objEnv)
 	While True
 		If TypeName(objCode) = "Nothing" Then
 			Set Evaluate = Nothing
 			Exit Function
 		End If
+
+		DebugEval objCode, objEnv
 
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then

--- a/impls/vbs/step8_macros.vbs
+++ b/impls/vbs/step8_macros.vbs
@@ -358,7 +358,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode)
+			Set varRet = objEnv.Get(objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step8_macros.vbs
+++ b/impls/vbs/step8_macros.vbs
@@ -359,6 +359,10 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
+			if TypeName(varRet) = "Nothing" Then
+				Err.Raise vbObjectError, _
+					"EvaluateAST", "'" + objCode.Value + "' not found"
+			End If
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step9_try.vbs
+++ b/impls/vbs/step9_try.vbs
@@ -160,7 +160,6 @@ Function MQuasiQuoteExpand(objArgs, objEnv)
 
 	Set MQuasiQuoteExpand = varRes
 End Function
-objNS.Add NewMalSym("quasiquoteexpand"), NewVbsProc("MQuasiQuoteExpand", True)
 
 Class ExpandType
 	Public Splice

--- a/impls/vbs/step9_try.vbs
+++ b/impls/vbs/step9_try.vbs
@@ -266,47 +266,6 @@ Function MDefMacro(objArgs, objEnv)
 End Function
 objNS.Add NewMalSym("defmacro!"), NewVbsProc("MDefMacro", True)
 
-Function IsMacroCall(objCode, objEnv)
-	Dim varRes
-	varRes = False
-
-	' VBS has no short-circuit evaluation.
-	If objCode.Type = TYPES.LIST Then
-		If objCode.Count > 0 Then
-			If objCode.Item(0).Type = TYPES.SYMBOL Then
-				Dim varValue
-				Set varValue = objEnv.Get(objCode.Item(0))
-				If varValue.Type = TYPES.PROCEDURE Then
-					If varValue.IsMacro Then
-						varRes = True
-					End If
-				End If
-			End If
-		End If
-	End If
-
-	IsMacroCall = varRes
-End Function
-
-Function MacroExpand(ByVal objAST, ByVal objEnv)
-	Dim varRes
-	While IsMacroCall(objAST, objEnv)
-		Dim varMacro
-		Set varMacro = objEnv.Get(objAST.Item(0))
-		Set objAST = varMacro.MacroApply(objAST, objEnv)		
-	Wend
-	Set varRes = objAST
-	Set MacroExpand = varRes
-End Function
-
-Function MMacroExpand(objArgs, objEnv)
-	Dim varRes
-	CheckArgNum objArgs, 1
-	Set varRes = MacroExpand(objArgs.Item(1), objEnv)
-	Set MMacroExpand = varRes
-End Function
-objNS.Add NewMalSym("macroexpand"), NewVbsProc("MMacroExpand", True)
-
 Function MTry(objArgs, objEnv)
 	Dim varRes
 	
@@ -429,8 +388,6 @@ Function Evaluate(ByVal objCode, ByVal objEnv)
 			Set Evaluate = Nothing
 			Exit Function
 		End If
-		
-		Set objCode = MacroExpand(objCode, objEnv)
 
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then
@@ -440,7 +397,11 @@ Function Evaluate(ByVal objCode, ByVal objEnv)
 			End If
 
 			Set objFirst = Evaluate(objCode.Item(0), objEnv)
-			Set varRet = objFirst.Apply(objCode, objEnv)
+			If objFirst.IsMacro Then
+				Set varRet = EvalLater(objFirst.MacroApply(objCode, objEnv), objEnv)
+			Else
+				Set varRet = objFirst.Apply(objCode, objEnv)
+			End If
 		Else
 			Set varRet = EvaluateAST(objCode, objEnv)
 		End If

--- a/impls/vbs/step9_try.vbs
+++ b/impls/vbs/step9_try.vbs
@@ -425,6 +425,10 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
+			if TypeName(varRet) = "Nothing" Then
+				Err.Raise vbObjectError, _
+					"EvaluateAST", "'" + objCode.Value + "' not found"
+			End If
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step9_try.vbs
+++ b/impls/vbs/step9_try.vbs
@@ -424,7 +424,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode)
+			Set varRet = objEnv.Get(objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/step9_try.vbs
+++ b/impls/vbs/step9_try.vbs
@@ -446,7 +446,7 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
-			if TypeName(varRet) = "Nothing" Then
+			If TypeName(varRet) = "Nothing" Then
 				Err.Raise vbObjectError, _
 					"EvaluateAST", "'" + objCode.Value + "' not found"
 			End If

--- a/impls/vbs/step9_try.vbs
+++ b/impls/vbs/step9_try.vbs
@@ -382,12 +382,34 @@ Function Read(strCode)
 	Set Read = ReadString(strCode)
 End Function
 
+Sub DebugEval(objCode, objEnv)
+	Dim value, bool
+	Set value = objEnv.Get("DEBUG-EVAL")
+	If TypeName(value) = "Nothing" Then
+		bool = False
+	Else
+		Select Case value.Type
+			Case TYPES.NIL
+				bool = False
+			Case TYPES.BOOLEAN
+				bool = value.Value
+			Case Else
+				bool = True
+		End Select
+	End If
+	If bool Then
+		IO.WriteLine "EVAL: " + Print(objCode)
+	End If
+End Sub
+
 Function Evaluate(ByVal objCode, ByVal objEnv)
 	While True
 		If TypeName(objCode) = "Nothing" Then
 			Set Evaluate = Nothing
 			Exit Function
 		End If
+
+		DebugEval objCode, objEnv
 
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then

--- a/impls/vbs/step9_try.vbs
+++ b/impls/vbs/step9_try.vbs
@@ -25,10 +25,10 @@ Function MDef(objArgs, objEnv)
 	CheckArgNum objArgs, 2
 	CheckType objArgs.Item(1), TYPES.SYMBOL
 	Set varRet = Evaluate(objArgs.Item(2), objEnv)
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDef = varRet
 End Function
-objNS.Add NewMalSym("def!"), NewVbsProc("MDef", True)
+objNS.Add "def!", NewVbsProc("MDef", True)
 
 Function MLet(objArgs, objEnv)
 	Dim varRet
@@ -49,13 +49,13 @@ Function MLet(objArgs, objEnv)
 	For i = 0 To objBinds.Count - 1 Step 2
 		Set objSym = objBinds.Item(i)
 		CheckType objSym, TYPES.SYMBOL
-		objNewEnv.Add objSym, Evaluate(objBinds.Item(i + 1), objNewEnv)
+		objNewEnv.Add objSym.Value, Evaluate(objBinds.Item(i + 1), objNewEnv)
 	Next
 
 	Set varRet = EvalLater(objArgs.Item(2), objNewEnv)
 	Set MLet = varRet
 End Function
-objNS.Add NewMalSym("let*"), NewVbsProc("MLet", True)
+objNS.Add "let*", NewVbsProc("MLet", True)
 
 Function MDo(objArgs, objEnv)
 	Dim varRet, i
@@ -71,7 +71,7 @@ Function MDo(objArgs, objEnv)
 		objEnv)
 	Set MDo = varRet
 End Function
-objNS.Add NewMalSym("do"), NewVbsProc("MDo", True)
+objNS.Add "do", NewVbsProc("MDo", True)
 
 Function MIf(objArgs, objEnv)
 	Dim varRet
@@ -101,7 +101,7 @@ Function MIf(objArgs, objEnv)
 	End If
 	Set MIf = varRet
 End Function
-objNS.Add NewMalSym("if"), NewVbsProc("MIf", True)
+objNS.Add "if", NewVbsProc("MIf", True)
 
 Function MFn(objArgs, objEnv)
 	Dim varRet
@@ -119,7 +119,7 @@ Function MFn(objArgs, objEnv)
 	Set varRet = NewMalProc(objParams, objCode, objEnv)
 	Set MFn = varRet
 End Function
-objNS.Add NewMalSym("fn*"), NewVbsProc("MFn", True)
+objNS.Add "fn*", NewVbsProc("MFn", True)
 
 Function MEval(objArgs, objEnv)
 	Dim varRes
@@ -129,13 +129,13 @@ Function MEval(objArgs, objEnv)
 	Set varRes = EvalLater(varRes, objNS)
 	Set MEval = varRes
 End Function
-objNS.Add NewMalSym("eval"), NewVbsProc("MEval", True)
+objNS.Add "eval", NewVbsProc("MEval", True)
 
 Function MQuote(objArgs, objEnv)
 	CheckArgNum objArgs, 1
 	Set MQuote = objArgs.Item(1)
 End Function
-objNS.Add NewMalSym("quote"), NewVbsProc("MQuote", True)
+objNS.Add "quote", NewVbsProc("MQuote", True)
 
 Function MQuasiQuote(objArgs, objEnv)
 	Dim varRes
@@ -145,7 +145,7 @@ Function MQuasiQuote(objArgs, objEnv)
 		MQuasiQuoteExpand(objArgs, objEnv), objEnv)
 	Set MQuasiQuote = varRes
 End Function
-objNS.Add NewMalSym("quasiquote"), NewVbsProc("MQuasiQuote", True)
+objNS.Add "quasiquote", NewVbsProc("MQuasiQuote", True)
 
 Function MQuasiQuoteExpand(objArgs, objEnv)
 	Dim varRes
@@ -261,10 +261,10 @@ Function MDefMacro(objArgs, objEnv)
 	Set varRet = Evaluate(objArgs.Item(2), objEnv).Copy()
 	CheckType varRet, TYPES.PROCEDURE
 	varRet.IsMacro = True
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDefMacro = varRet
 End Function
-objNS.Add NewMalSym("defmacro!"), NewVbsProc("MDefMacro", True)
+objNS.Add "defmacro!", NewVbsProc("MDefMacro", True)
 
 Function MTry(objArgs, objEnv)
 	Dim varRes
@@ -324,7 +324,7 @@ Function MTry(objArgs, objEnv)
 
 	Set MTry = varRes
 End Function
-objNS.Add NewMalSym("try*"), NewVbsProc("MTry", True)
+objNS.Add "try*", NewVbsProc("MTry", True)
 
 Call InitBuiltIn()
 Call InitMacro()
@@ -339,7 +339,7 @@ Sub InitArgs()
 		objArgs.Add NewMalStr(WScript.Arguments.Item(i))
 	Next
 	
-	objNS.Add NewMalSym("*ARGV*"), objArgs
+	objNS.Add "*ARGV*", objArgs
 	
 	If WScript.Arguments.Count > 0 Then
 		REP "(load-file """ + WScript.Arguments.Item(0) + """)"

--- a/impls/vbs/step9_try.vbs
+++ b/impls/vbs/step9_try.vbs
@@ -383,23 +383,22 @@ Function Read(strCode)
 End Function
 
 Sub DebugEval(objCode, objEnv)
-	Dim value, bool
+	Dim value
 	Set value = objEnv.Get("DEBUG-EVAL")
+	' And and Or do not short-circuit.
 	If TypeName(value) = "Nothing" Then
-		bool = False
+		Exit Sub
 	Else
 		Select Case value.Type
 			Case TYPES.NIL
-				bool = False
+				Exit Sub
 			Case TYPES.BOOLEAN
-				bool = value.Value
-			Case Else
-				bool = True
+				If Not value.Value Then
+					Exit Sub
+				End If
 		End Select
 	End If
-	If bool Then
-		IO.WriteLine "EVAL: " + Print(objCode)
-	End If
+	IO.WriteLine "EVAL: " + Print(objCode)
 End Sub
 
 Function Evaluate(ByVal objCode, ByVal objEnv)

--- a/impls/vbs/stepA_mal.vbs
+++ b/impls/vbs/stepA_mal.vbs
@@ -447,7 +447,7 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
-			if TypeName(varRet) = "Nothing" Then
+			If TypeName(varRet) = "Nothing" Then
 				Err.Raise vbObjectError, _
 					"EvaluateAST", "'" + objCode.Value + "' not found"
 			End If

--- a/impls/vbs/stepA_mal.vbs
+++ b/impls/vbs/stepA_mal.vbs
@@ -160,7 +160,6 @@ Function MQuasiQuoteExpand(objArgs, objEnv)
 
 	Set MQuasiQuoteExpand = varRes
 End Function
-objNS.Add NewMalSym("quasiquoteexpand"), NewVbsProc("MQuasiQuoteExpand", True)
 
 Class ExpandType
 	Public Splice

--- a/impls/vbs/stepA_mal.vbs
+++ b/impls/vbs/stepA_mal.vbs
@@ -425,7 +425,7 @@ Function EvaluateAST(objCode, objEnv)
 	Dim varRet, i
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
-			Set varRet = objEnv.Get(objCode)
+			Set varRet = objEnv.Get(objCode.Value)
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/stepA_mal.vbs
+++ b/impls/vbs/stepA_mal.vbs
@@ -384,23 +384,22 @@ Function Read(strCode)
 End Function
 
 Sub DebugEval(objCode, objEnv)
-	Dim value, bool
+	Dim value
 	Set value = objEnv.Get("DEBUG-EVAL")
+	' And and Or do not short-circuit.
 	If TypeName(value) = "Nothing" Then
-		bool = False
+		Exit Sub
 	Else
 		Select Case value.Type
 			Case TYPES.NIL
-				bool = False
+				Exit Sub
 			Case TYPES.BOOLEAN
-				bool = value.Value
-			Case Else
-				bool = True
+				If Not value.Value Then
+					Exit Sub
+				End If
 		End Select
 	End If
-	If bool Then
-		IO.WriteLine "EVAL: " + Print(objCode)
-	End If
+	IO.WriteLine "EVAL: " + Print(objCode)
 End Sub
 
 Function Evaluate(ByVal objCode, ByVal objEnv)

--- a/impls/vbs/stepA_mal.vbs
+++ b/impls/vbs/stepA_mal.vbs
@@ -426,6 +426,10 @@ Function EvaluateAST(objCode, objEnv)
 	Select Case objCode.Type
 		Case TYPES.SYMBOL
 			Set varRet = objEnv.Get(objCode.Value)
+			if TypeName(varRet) = "Nothing" Then
+				Err.Raise vbObjectError, _
+					"EvaluateAST", "'" + objCode.Value + "' not found"
+			End If
 		Case TYPES.LIST
 			Err.Raise vbObjectError, _
 				"EvaluateAST", "Unexpect type."

--- a/impls/vbs/stepA_mal.vbs
+++ b/impls/vbs/stepA_mal.vbs
@@ -383,12 +383,34 @@ Function Read(strCode)
 	Set Read = ReadString(strCode)
 End Function
 
+Sub DebugEval(objCode, objEnv)
+	Dim value, bool
+	Set value = objEnv.Get("DEBUG-EVAL")
+	If TypeName(value) = "Nothing" Then
+		bool = False
+	Else
+		Select Case value.Type
+			Case TYPES.NIL
+				bool = False
+			Case TYPES.BOOLEAN
+				bool = value.Value
+			Case Else
+				bool = True
+		End Select
+	End If
+	If bool Then
+		IO.WriteLine "EVAL: " + Print(objCode)
+	End If
+End Sub
+
 Function Evaluate(ByVal objCode, ByVal objEnv)
 	While True
 		If TypeName(objCode) = "Nothing" Then
 			Set Evaluate = Nothing
 			Exit Function
 		End If
+
+		DebugEval objCode, objEnv
 
 		Dim varRet, objFirst
 		If objCode.Type = TYPES.LIST Then

--- a/impls/vbs/stepA_mal.vbs
+++ b/impls/vbs/stepA_mal.vbs
@@ -25,10 +25,10 @@ Function MDef(objArgs, objEnv)
 	CheckArgNum objArgs, 2
 	CheckType objArgs.Item(1), TYPES.SYMBOL
 	Set varRet = Evaluate(objArgs.Item(2), objEnv)
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDef = varRet
 End Function
-objNS.Add NewMalSym("def!"), NewVbsProc("MDef", True)
+objNS.Add "def!", NewVbsProc("MDef", True)
 
 Function MLet(objArgs, objEnv)
 	Dim varRet
@@ -49,13 +49,13 @@ Function MLet(objArgs, objEnv)
 	For i = 0 To objBinds.Count - 1 Step 2
 		Set objSym = objBinds.Item(i)
 		CheckType objSym, TYPES.SYMBOL
-		objNewEnv.Add objSym, Evaluate(objBinds.Item(i + 1), objNewEnv)
+		objNewEnv.Add objSym.Value, Evaluate(objBinds.Item(i + 1), objNewEnv)
 	Next
 
 	Set varRet = EvalLater(objArgs.Item(2), objNewEnv)
 	Set MLet = varRet
 End Function
-objNS.Add NewMalSym("let*"), NewVbsProc("MLet", True)
+objNS.Add "let*", NewVbsProc("MLet", True)
 
 Function MDo(objArgs, objEnv)
 	Dim varRet, i
@@ -71,7 +71,7 @@ Function MDo(objArgs, objEnv)
 		objEnv)
 	Set MDo = varRet
 End Function
-objNS.Add NewMalSym("do"), NewVbsProc("MDo", True)
+objNS.Add "do", NewVbsProc("MDo", True)
 
 Function MIf(objArgs, objEnv)
 	Dim varRet
@@ -101,7 +101,7 @@ Function MIf(objArgs, objEnv)
 	End If
 	Set MIf = varRet
 End Function
-objNS.Add NewMalSym("if"), NewVbsProc("MIf", True)
+objNS.Add "if", NewVbsProc("MIf", True)
 
 Function MFn(objArgs, objEnv)
 	Dim varRet
@@ -119,7 +119,7 @@ Function MFn(objArgs, objEnv)
 	Set varRet = NewMalProc(objParams, objCode, objEnv)
 	Set MFn = varRet
 End Function
-objNS.Add NewMalSym("fn*"), NewVbsProc("MFn", True)
+objNS.Add "fn*", NewVbsProc("MFn", True)
 
 Function MEval(objArgs, objEnv)
 	Dim varRes
@@ -129,13 +129,13 @@ Function MEval(objArgs, objEnv)
 	Set varRes = EvalLater(varRes, objNS)
 	Set MEval = varRes
 End Function
-objNS.Add NewMalSym("eval"), NewVbsProc("MEval", True)
+objNS.Add "eval", NewVbsProc("MEval", True)
 
 Function MQuote(objArgs, objEnv)
 	CheckArgNum objArgs, 1
 	Set MQuote = objArgs.Item(1)
 End Function
-objNS.Add NewMalSym("quote"), NewVbsProc("MQuote", True)
+objNS.Add "quote", NewVbsProc("MQuote", True)
 
 Function MQuasiQuote(objArgs, objEnv)
 	Dim varRes
@@ -145,7 +145,7 @@ Function MQuasiQuote(objArgs, objEnv)
 		MQuasiQuoteExpand(objArgs, objEnv), objEnv)
 	Set MQuasiQuote = varRes
 End Function
-objNS.Add NewMalSym("quasiquote"), NewVbsProc("MQuasiQuote", True)
+objNS.Add "quasiquote", NewVbsProc("MQuasiQuote", True)
 
 Function MQuasiQuoteExpand(objArgs, objEnv)
 	Dim varRes
@@ -261,10 +261,10 @@ Function MDefMacro(objArgs, objEnv)
 	Set varRet = Evaluate(objArgs.Item(2), objEnv).Copy()
 	CheckType varRet, TYPES.PROCEDURE
 	varRet.IsMacro = True
-	objEnv.Add objArgs.Item(1), varRet
+	objEnv.Add objArgs.Item(1).Value, varRet
 	Set MDefMacro = varRet
 End Function
-objNS.Add NewMalSym("defmacro!"), NewVbsProc("MDefMacro", True)
+objNS.Add "defmacro!", NewVbsProc("MDefMacro", True)
 
 Function MTry(objArgs, objEnv)
 	Dim varRes
@@ -324,7 +324,7 @@ Function MTry(objArgs, objEnv)
 
 	Set MTry = varRes
 End Function
-objNS.Add NewMalSym("try*"), NewVbsProc("MTry", True)
+objNS.Add "try*", NewVbsProc("MTry", True)
 
 Call InitBuiltIn()
 Call InitMacro()
@@ -339,7 +339,7 @@ Sub InitArgs()
 		objArgs.Add NewMalStr(WScript.Arguments.Item(i))
 	Next
 	
-	objNS.Add NewMalSym("*ARGV*"), objArgs
+	objNS.Add "*ARGV*", objArgs
 	
 	If WScript.Arguments.Count > 0 Then
 		REP "(load-file """ + WScript.Arguments.Item(0) + """)"

--- a/impls/vbs/types.vbs
+++ b/impls/vbs/types.vbs
@@ -458,7 +458,7 @@ Class MalProcedure 'Extends MalType
 			If objParams.Item(i).Value = "&" Then
 				If objParams.Count - 1 = i + 1 Then
 					Set objList = NewMalList(Array())
-					objNewEnv.Add objParams.Item(i + 1), objList
+					objNewEnv.Add objParams.Item(i + 1).Value, objList
 					While i + 1 < objArgs.Count
 						objList.Add Evaluate(objArgs.Item(i + 1), objEnv)
 						i = i + 1
@@ -473,7 +473,7 @@ Class MalProcedure 'Extends MalType
 					Err.Raise vbObjectError, _
 						"MalProcedureApply", "Need more arguments."
 				End If
-				objNewEnv.Add objParams.Item(i), _
+				objNewEnv.Add objParams.Item(i).Value, _
 					Evaluate(objArgs.Item(i + 1), objEnv)
 				i = i + 1
 			End If
@@ -501,7 +501,7 @@ Class MalProcedure 'Extends MalType
 					Set objList = NewMalList(Array())
 					
 					' No evaluation
-					objNewEnv.Add objParams.Item(i + 1), objList
+					objNewEnv.Add objParams.Item(i + 1).Value, objList
 					While i + 1 < objArgs.Count
 						objList.Add objArgs.Item(i + 1)
 						i = i + 1
@@ -518,7 +518,7 @@ Class MalProcedure 'Extends MalType
 				End If
 				
 				' No evaluation
-				objNewEnv.Add objParams.Item(i), _
+				objNewEnv.Add objParams.Item(i).Value, _
 					objArgs.Item(i + 1)
 				i = i + 1
 			End If
@@ -543,7 +543,7 @@ Class MalProcedure 'Extends MalType
 					Set objList = NewMalList(Array())
 					
 					' No evaluation
-					objNewEnv.Add objParams.Item(i + 1), objList
+					objNewEnv.Add objParams.Item(i + 1).Value, objList
 					While i + 1 < objArgs.Count
 						objList.Add objArgs.Item(i + 1)
 						i = i + 1
@@ -560,7 +560,7 @@ Class MalProcedure 'Extends MalType
 				End If
 				
 				' No evaluation
-				objNewEnv.Add objParams.Item(i), _
+				objNewEnv.Add objParams.Item(i).Value, _
 					objArgs.Item(i + 1)
 				i = i + 1
 			End If


### PR DESCRIPTION
Eval_ast was already reserved to lists.

env.vbs: rewrite env.get with a string argument and without exception because this is convenient for DEBUG-EVAL.

types.vbs: after a macro expansion, evaluate with TCO.