### PR TITLE
fantom: merge eval_ast and macroexpand into EVAL, implement DEBUG-EVAL

### DIFF
--- a/impls/fantom/src/mallib/fan/env.fan
+++ b/impls/fantom/src/mallib/fan/env.fan
@@ -27,14 +27,8 @@ class MalEnv
     return value
   }
 
-  MalEnv? find(MalSymbol key)
+  MalVal? get(Str key)
   {
-    return data.containsKey(key.value) ? this : outer?.find(key)
-  }
-
-  MalVal get(MalSymbol key)
-  {
-    foundEnv := find(key) ?: throw Err("'$key.value' not found")
-    return (MalVal)foundEnv.data[key.value]
+    return data.containsKey(key) ? data[key] : outer?.get(key)
   }
 }

--- a/impls/fantom/src/step3_env/fan/main.fan
+++ b/impls/fantom/src/step3_env/fan/main.fan
@@ -7,46 +7,52 @@ class Main
     return Reader.read_str(s)
   }
 
-  static MalVal eval_ast(MalVal ast, MalEnv env)
+  static Void debug_eval(MalVal ast, MalEnv env)
   {
-    switch (ast.typeof)
-    {
-      case MalSymbol#:
-        return env.get(ast)
-      case MalList#:
-        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalList(newElements)
-      case MalVector#:
-        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalVector(newElements)
-      case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalHashMap.fromMap(newElements)
-      default:
-        return ast
-    }
+    value := env.get("DEBUG-EVAL")
+    if ((value != null) && !(value is MalFalseyVal))
+        echo("EVAL: ${PRINT(ast)}")
   }
 
   static MalVal EVAL(MalVal ast, MalEnv env)
   {
-    if (!(ast is MalList)) return eval_ast(ast, env)
-    astList := ast as MalList
-    if (astList.isEmpty) return ast
-    switch ((astList[0] as MalSymbol).value)
-    {
-      case "def!":
-        return env.set(astList[1], EVAL(astList[2], env))
-      case "let*":
-        let_env := MalEnv(env)
-        varList := (astList[1] as MalSeq)
-        for (i := 0; i < varList.count; i += 2)
-          let_env.set(varList[i], EVAL(varList[i + 1], let_env))
-        return EVAL(astList[2], let_env)
-      default:
-        evaled_ast := eval_ast(ast, env) as MalList
-        f := evaled_ast[0] as MalFunc
-        return f.call(evaled_ast[1..-1])
-    }
+      debug_eval(ast, env)
+      switch (ast.typeof)
+      {
+        case MalSymbol#:
+          varName := (ast as MalSymbol).value
+          return env.get(varName) ?: throw Err("'$varName' not found")
+        case MalVector#:
+          newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalVector(newElements)
+        case MalHashMap#:
+          newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalHashMap.fromMap(newElements)
+        case MalList#:
+          astList := ast as MalList
+          if (astList.isEmpty) return ast
+          switch ((astList[0] as MalSymbol)?.value)
+          {
+            case "def!":
+              value := EVAL(astList[2], env)
+              return env.set(astList[1], value)
+            case "let*":
+              let_env := MalEnv(env)
+              varList := astList[1] as MalSeq
+              for (i := 0; i < varList.count; i += 2)
+                let_env.set(varList[i], EVAL(varList[i + 1], let_env))
+              return EVAL(astList[2], let_env)
+            default:
+              f := EVAL(astList[0], env)
+              args := astList.value[1..-1].map |MalVal v -> MalVal| { EVAL(v, env) }
+
+                  malfunc := f as MalFunc
+                  return malfunc.call(args)
+
+          }
+        default:
+          return ast
+      }
   }
 
   static Str PRINT(MalVal exp)

--- a/impls/fantom/src/step4_if_fn_do/fan/main.fan
+++ b/impls/fantom/src/step4_if_fn_do/fan/main.fan
@@ -7,56 +7,67 @@ class Main
     return Reader.read_str(s)
   }
 
-  static MalVal eval_ast(MalVal ast, MalEnv env)
+  static Void debug_eval(MalVal ast, MalEnv env)
   {
-    switch (ast.typeof)
-    {
-      case MalSymbol#:
-        return env.get(ast)
-      case MalList#:
-        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalList(newElements)
-      case MalVector#:
-        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalVector(newElements)
-      case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalHashMap.fromMap(newElements)
-      default:
-        return ast
-    }
+    value := env.get("DEBUG-EVAL")
+    if ((value != null) && !(value is MalFalseyVal))
+        echo("EVAL: ${PRINT(ast)}")
   }
 
   static MalVal EVAL(MalVal ast, MalEnv env)
   {
-    if (!(ast is MalList)) return eval_ast(ast, env)
-    astList := ast as MalList
-    if (astList.isEmpty) return ast
-    switch ((astList[0] as MalSymbol)?.value)
-    {
-      case "def!":
-        return env.set(astList[1], EVAL(astList[2], env))
-      case "let*":
-        let_env := MalEnv(env)
-        varList := astList[1] as MalSeq
-        for (i := 0; i < varList.count; i += 2)
-          let_env.set(varList[i], EVAL(varList[i + 1], let_env))
-        return EVAL(astList[2], let_env)
-      case "do":
-        eval_ast(MalList(astList[1..-2]), env)
-        return EVAL(astList[-1], env)
-      case "if":
-        if (EVAL(astList[1], env) is MalFalseyVal)
-          return astList.count > 3 ? EVAL(astList[3], env) : MalNil.INSTANCE
-        else
-          return EVAL(astList[2], env)
-      case "fn*":
-        return MalFunc { EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(it))) }
-      default:
-        evaled_ast := eval_ast(ast, env) as MalList
-        f := evaled_ast[0] as MalFunc
-        return f.call(evaled_ast[1..-1])
-    }
+      debug_eval(ast, env)
+      switch (ast.typeof)
+      {
+        case MalSymbol#:
+          varName := (ast as MalSymbol).value
+          return env.get(varName) ?: throw Err("'$varName' not found")
+        case MalVector#:
+          newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalVector(newElements)
+        case MalHashMap#:
+          newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalHashMap.fromMap(newElements)
+        case MalList#:
+          astList := ast as MalList
+          if (astList.isEmpty) return ast
+          switch ((astList[0] as MalSymbol)?.value)
+          {
+            case "def!":
+              value := EVAL(astList[2], env)
+              return env.set(astList[1], value)
+            case "let*":
+              let_env := MalEnv(env)
+              varList := astList[1] as MalSeq
+              for (i := 0; i < varList.count; i += 2)
+                let_env.set(varList[i], EVAL(varList[i + 1], let_env))
+              return EVAL(astList[2], let_env)
+            case "do":
+              for (i:=1; i<astList.count-1; i+=1)
+                EVAL(astList[i], env);
+              return EVAL(astList[-1], env)
+            case "if":
+              if (EVAL(astList[1], env) is MalFalseyVal)
+                return astList.count > 3 ? EVAL(astList[3], env) : MalNil.INSTANCE
+              else
+                return EVAL(astList[2], env)
+            case "fn*":
+              return MalFunc { EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(it))) }
+            default:
+              f := EVAL(astList[0], env)
+              args := astList.value[1..-1].map |MalVal v -> MalVal| { EVAL(v, env) }
+              switch (f.typeof)
+              {
+                case MalFunc#:
+                  malfunc := f as MalFunc
+                  return malfunc.call(args)
+                default:
+                  throw Err("Unknown type")
+              }
+          }
+        default:
+          return ast
+      }
   }
 
   static Str PRINT(MalVal exp)

--- a/impls/fantom/src/step5_tco/fan/main.fan
+++ b/impls/fantom/src/step5_tco/fan/main.fan
@@ -7,75 +7,81 @@ class Main
     return Reader.read_str(s)
   }
 
-  static MalVal eval_ast(MalVal ast, MalEnv env)
+  static Void debug_eval(MalVal ast, MalEnv env)
   {
-    switch (ast.typeof)
-    {
-      case MalSymbol#:
-        return env.get(ast)
-      case MalList#:
-        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalList(newElements)
-      case MalVector#:
-        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalVector(newElements)
-      case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalHashMap.fromMap(newElements)
-      default:
-        return ast
-    }
+    value := env.get("DEBUG-EVAL")
+    if ((value != null) && !(value is MalFalseyVal))
+        echo("EVAL: ${PRINT(ast)}")
   }
 
   static MalVal EVAL(MalVal ast, MalEnv env)
   {
     while (true)
     {
-      if (!(ast is MalList)) return eval_ast(ast, env)
-      astList := ast as MalList
-      if (astList.isEmpty) return ast
-      switch ((astList[0] as MalSymbol)?.value)
+      debug_eval(ast, env)
+      switch (ast.typeof)
       {
-        case "def!":
-          return env.set(astList[1], EVAL(astList[2], env))
-        case "let*":
-          let_env := MalEnv(env)
-          varList := astList[1] as MalSeq
-          for (i := 0; i < varList.count; i += 2)
-            let_env.set(varList[i], EVAL(varList[i + 1], let_env))
-          env = let_env
-          ast = astList[2]
-          // TCO
-        case "do":
-          eval_ast(MalList(astList[1..-2]), env)
-          ast = astList[-1]
-          // TCO
-        case "if":
-          if (EVAL(astList[1], env) is MalFalseyVal)
-            ast = astList.count > 3 ? astList[3] : MalNil.INSTANCE
-          else
-            ast = astList[2]
-          // TCO
-        case "fn*":
-          f := |MalVal[] a -> MalVal|
+        case MalSymbol#:
+          varName := (ast as MalSymbol).value
+          return env.get(varName) ?: throw Err("'$varName' not found")
+        case MalVector#:
+          newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalVector(newElements)
+        case MalHashMap#:
+          newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalHashMap.fromMap(newElements)
+        case MalList#:
+          astList := ast as MalList
+          if (astList.isEmpty) return ast
+          switch ((astList[0] as MalSymbol)?.value)
           {
-            return EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(a)))
-          }
-          return MalUserFunc(astList[2], env, (MalSeq)astList[1], f)
-        default:
-          evaled_ast := eval_ast(ast, env) as MalList
-          switch (evaled_ast[0].typeof)
-          {
-            case MalUserFunc#:
-              user_fn := evaled_ast[0] as MalUserFunc
-              ast = user_fn.ast
-              env = user_fn.genEnv(evaled_ast.drop(1))
+            case "def!":
+              value := EVAL(astList[2], env)
+              return env.set(astList[1], value)
+            case "let*":
+              let_env := MalEnv(env)
+              varList := astList[1] as MalSeq
+              for (i := 0; i < varList.count; i += 2)
+                let_env.set(varList[i], EVAL(varList[i + 1], let_env))
+              env = let_env
+              ast = astList[2]
               // TCO
-            case MalFunc#:
-              return (evaled_ast[0] as MalFunc).call(evaled_ast[1..-1])
+            case "do":
+              for (i:=1; i<astList.count-1; i+=1)
+                EVAL(astList[i], env);
+              ast = astList[-1]
+              // TCO
+            case "if":
+              if (EVAL(astList[1], env) is MalFalseyVal)
+                ast = astList.count > 3 ? astList[3] : MalNil.INSTANCE
+              else
+                ast = astList[2]
+              // TCO
+            case "fn*":
+              f := |MalVal[] a -> MalVal|
+              {
+                return EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(a)))
+              }
+              return MalUserFunc(astList[2], env, (MalSeq)astList[1], f)
             default:
-              throw Err("Unknown type")
+              f := EVAL(astList[0], env)
+              args := astList.value[1..-1].map |MalVal v -> MalVal| { EVAL(v, env) }
+              switch (f.typeof)
+              {
+                case MalUserFunc#:
+                  user_fn := f as MalUserFunc
+                  ast = user_fn.ast
+                  env = user_fn.genEnv(MalList(args))
+                  // TCO
+                case MalFunc#:
+                  malfunc := f as MalFunc
+                  return malfunc.call(args)
+                default:
+                  throw Err("Unknown type")
+              }
           }
+        default:
+          return ast
       }
     }
     return MalNil.INSTANCE // never reached

--- a/impls/fantom/src/step6_file/fan/main.fan
+++ b/impls/fantom/src/step6_file/fan/main.fan
@@ -7,75 +7,81 @@ class Main
     return Reader.read_str(s)
   }
 
-  static MalVal eval_ast(MalVal ast, MalEnv env)
+  static Void debug_eval(MalVal ast, MalEnv env)
   {
-    switch (ast.typeof)
-    {
-      case MalSymbol#:
-        return env.get(ast)
-      case MalList#:
-        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalList(newElements)
-      case MalVector#:
-        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalVector(newElements)
-      case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalHashMap.fromMap(newElements)
-      default:
-        return ast
-    }
+    value := env.get("DEBUG-EVAL")
+    if ((value != null) && !(value is MalFalseyVal))
+        echo("EVAL: ${PRINT(ast)}")
   }
 
   static MalVal EVAL(MalVal ast, MalEnv env)
   {
     while (true)
     {
-      if (!(ast is MalList)) return eval_ast(ast, env)
-      astList := ast as MalList
-      if (astList.isEmpty) return ast
-      switch ((astList[0] as MalSymbol)?.value)
+      debug_eval(ast, env)
+      switch (ast.typeof)
       {
-        case "def!":
-          return env.set(astList[1], EVAL(astList[2], env))
-        case "let*":
-          let_env := MalEnv(env)
-          varList := astList[1] as MalSeq
-          for (i := 0; i < varList.count; i += 2)
-            let_env.set(varList[i], EVAL(varList[i + 1], let_env))
-          env = let_env
-          ast = astList[2]
-          // TCO
-        case "do":
-          eval_ast(MalList(astList[1..-2]), env)
-          ast = astList[-1]
-          // TCO
-        case "if":
-          if (EVAL(astList[1], env) is MalFalseyVal)
-            ast = astList.count > 3 ? astList[3] : MalNil.INSTANCE
-          else
-            ast = astList[2]
-          // TCO
-        case "fn*":
-          f := |MalVal[] a -> MalVal|
+        case MalSymbol#:
+          varName := (ast as MalSymbol).value
+          return env.get(varName) ?: throw Err("'$varName' not found")
+        case MalVector#:
+          newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalVector(newElements)
+        case MalHashMap#:
+          newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalHashMap.fromMap(newElements)
+        case MalList#:
+          astList := ast as MalList
+          if (astList.isEmpty) return ast
+          switch ((astList[0] as MalSymbol)?.value)
           {
-            return EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(a)))
-          }
-          return MalUserFunc(astList[2], env, (MalSeq)astList[1], f)
-        default:
-          evaled_ast := eval_ast(ast, env) as MalList
-          switch (evaled_ast[0].typeof)
-          {
-            case MalUserFunc#:
-              user_fn := evaled_ast[0] as MalUserFunc
-              ast = user_fn.ast
-              env = user_fn.genEnv(evaled_ast.drop(1))
+            case "def!":
+              value := EVAL(astList[2], env)
+              return env.set(astList[1], value)
+            case "let*":
+              let_env := MalEnv(env)
+              varList := astList[1] as MalSeq
+              for (i := 0; i < varList.count; i += 2)
+                let_env.set(varList[i], EVAL(varList[i + 1], let_env))
+              env = let_env
+              ast = astList[2]
               // TCO
-            case MalFunc#:
-              return (evaled_ast[0] as MalFunc).call(evaled_ast[1..-1])
+            case "do":
+              for (i:=1; i<astList.count-1; i+=1)
+                EVAL(astList[i], env);
+              ast = astList[-1]
+              // TCO
+            case "if":
+              if (EVAL(astList[1], env) is MalFalseyVal)
+                ast = astList.count > 3 ? astList[3] : MalNil.INSTANCE
+              else
+                ast = astList[2]
+              // TCO
+            case "fn*":
+              f := |MalVal[] a -> MalVal|
+              {
+                return EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(a)))
+              }
+              return MalUserFunc(astList[2], env, (MalSeq)astList[1], f)
             default:
-              throw Err("Unknown type")
+              f := EVAL(astList[0], env)
+              args := astList.value[1..-1].map |MalVal v -> MalVal| { EVAL(v, env) }
+              switch (f.typeof)
+              {
+                case MalUserFunc#:
+                  user_fn := f as MalUserFunc
+                  ast = user_fn.ast
+                  env = user_fn.genEnv(MalList(args))
+                  // TCO
+                case MalFunc#:
+                  malfunc := f as MalFunc
+                  return malfunc.call(args)
+                default:
+                  throw Err("Unknown type")
+              }
           }
+        default:
+          return ast
       }
     }
     return MalNil.INSTANCE // never reached

--- a/impls/fantom/src/step7_quote/fan/main.fan
+++ b/impls/fantom/src/step7_quote/fan/main.fan
@@ -46,82 +46,86 @@ class Main
     return Reader.read_str(s)
   }
 
-  static MalVal eval_ast(MalVal ast, MalEnv env)
+  static Void debug_eval(MalVal ast, MalEnv env)
   {
-    switch (ast.typeof)
-    {
-      case MalSymbol#:
-        return env.get(ast)
-      case MalList#:
-        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalList(newElements)
-      case MalVector#:
-        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalVector(newElements)
-      case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalHashMap.fromMap(newElements)
-      default:
-        return ast
-    }
+    value := env.get("DEBUG-EVAL")
+    if ((value != null) && !(value is MalFalseyVal))
+        echo("EVAL: ${PRINT(ast)}")
   }
 
   static MalVal EVAL(MalVal ast, MalEnv env)
   {
     while (true)
     {
-      if (!(ast is MalList)) return eval_ast(ast, env)
-      astList := ast as MalList
-      if (astList.isEmpty) return ast
-      switch ((astList[0] as MalSymbol)?.value)
+      debug_eval(ast, env)
+      switch (ast.typeof)
       {
-        case "def!":
-          return env.set(astList[1], EVAL(astList[2], env))
-        case "let*":
-          let_env := MalEnv(env)
-          varList := astList[1] as MalSeq
-          for (i := 0; i < varList.count; i += 2)
-            let_env.set(varList[i], EVAL(varList[i + 1], let_env))
-          env = let_env
-          ast = astList[2]
-          // TCO
-        case "quote":
-          return astList[1]
-        case "quasiquoteexpand":
-          return quasiquote(astList[1])
-        case "quasiquote":
-          ast = quasiquote(astList[1])
-          // TCO
-        case "do":
-          eval_ast(MalList(astList[1..-2]), env)
-          ast = astList[-1]
-          // TCO
-        case "if":
-          if (EVAL(astList[1], env) is MalFalseyVal)
-            ast = astList.count > 3 ? astList[3] : MalNil.INSTANCE
-          else
-            ast = astList[2]
-          // TCO
-        case "fn*":
-          f := |MalVal[] a -> MalVal|
+        case MalSymbol#:
+          varName := (ast as MalSymbol).value
+          return env.get(varName) ?: throw Err("'$varName' not found")
+        case MalVector#:
+          newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalVector(newElements)
+        case MalHashMap#:
+          newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalHashMap.fromMap(newElements)
+        case MalList#:
+          astList := ast as MalList
+          if (astList.isEmpty) return ast
+          switch ((astList[0] as MalSymbol)?.value)
           {
-            return EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(a)))
-          }
-          return MalUserFunc(astList[2], env, (MalSeq)astList[1], f)
-        default:
-          evaled_ast := eval_ast(ast, env) as MalList
-          switch (evaled_ast[0].typeof)
-          {
-            case MalUserFunc#:
-              user_fn := evaled_ast[0] as MalUserFunc
-              ast = user_fn.ast
-              env = user_fn.genEnv(evaled_ast.drop(1))
+            case "def!":
+              value := EVAL(astList[2], env)
+              return env.set(astList[1], value)
+            case "let*":
+              let_env := MalEnv(env)
+              varList := astList[1] as MalSeq
+              for (i := 0; i < varList.count; i += 2)
+                let_env.set(varList[i], EVAL(varList[i + 1], let_env))
+              env = let_env
+              ast = astList[2]
               // TCO
-            case MalFunc#:
-              return (evaled_ast[0] as MalFunc).call(evaled_ast[1..-1])
+            case "quote":
+              return astList[1]
+            case "quasiquote":
+              ast = quasiquote(astList[1])
+              // TCO
+            case "do":
+              for (i:=1; i<astList.count-1; i+=1)
+                EVAL(astList[i], env);
+              ast = astList[-1]
+              // TCO
+            case "if":
+              if (EVAL(astList[1], env) is MalFalseyVal)
+                ast = astList.count > 3 ? astList[3] : MalNil.INSTANCE
+              else
+                ast = astList[2]
+              // TCO
+            case "fn*":
+              f := |MalVal[] a -> MalVal|
+              {
+                return EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(a)))
+              }
+              return MalUserFunc(astList[2], env, (MalSeq)astList[1], f)
             default:
-              throw Err("Unknown type")
+              f := EVAL(astList[0], env)
+              args := astList.value[1..-1].map |MalVal v -> MalVal| { EVAL(v, env) }
+              switch (f.typeof)
+              {
+                case MalUserFunc#:
+                  user_fn := f as MalUserFunc
+                  ast = user_fn.ast
+                  env = user_fn.genEnv(MalList(args))
+                  // TCO
+                case MalFunc#:
+                  malfunc := f as MalFunc
+                  return malfunc.call(args)
+                default:
+                  throw Err("Unknown type")
+              }
           }
+        default:
+          return ast
       }
     }
     return MalNil.INSTANCE // never reached

--- a/impls/fantom/src/step8_macros/fan/main.fan
+++ b/impls/fantom/src/step8_macros/fan/main.fan
@@ -41,116 +41,101 @@ class Main
     }
   }
 
-  static Bool isMacroCall(MalVal ast, MalEnv env)
-  {
-    if (!(ast is MalList)) return false
-    astList := ast as MalList
-    if (astList.isEmpty) return false
-    if (!(astList[0] is MalSymbol)) return false
-    ast0 := astList[0] as MalSymbol
-    f := env.find(ast0)?.get(ast0)
-    return (f as MalUserFunc)?.isMacro ?: false
-  }
-
-  static MalVal macroexpand(MalVal ast, MalEnv env)
-  {
-    while (isMacroCall(ast, env))
-    {
-      mac := env.get((ast as MalList)[0]) as MalUserFunc
-      ast = mac.call((ast as MalSeq).drop(1).value)
-    }
-    return ast
-  }
-
   static MalVal READ(Str s)
   {
     return Reader.read_str(s)
   }
 
-  static MalVal eval_ast(MalVal ast, MalEnv env)
+  static Void debug_eval(MalVal ast, MalEnv env)
   {
-    switch (ast.typeof)
-    {
-      case MalSymbol#:
-        return env.get(ast)
-      case MalList#:
-        newElements := (ast as MalList).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalList(newElements)
-      case MalVector#:
-        newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalVector(newElements)
-      case MalHashMap#:
-        newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
-        return MalHashMap.fromMap(newElements)
-      default:
-        return ast
-    }
+    value := env.get("DEBUG-EVAL")
+    if ((value != null) && !(value is MalFalseyVal))
+        echo("EVAL: ${PRINT(ast)}")
   }
 
   static MalVal EVAL(MalVal ast, MalEnv env)
   {
     while (true)
     {
-      if (!(ast is MalList)) return eval_ast(ast, env)
-      ast = macroexpand(ast, env)
-      if (!(ast is MalList)) return eval_ast(ast, env)
-      astList := ast as MalList
-      if (astList.isEmpty) return ast
-      switch ((astList[0] as MalSymbol)?.value)
+      debug_eval(ast, env)
+      switch (ast.typeof)
       {
-        case "def!":
-          return env.set(astList[1], EVAL(astList[2], env))
-        case "let*":
-          let_env := MalEnv(env)
-          varList := astList[1] as MalSeq
-          for (i := 0; i < varList.count; i += 2)
-            let_env.set(varList[i], EVAL(varList[i + 1], let_env))
-          env = let_env
-          ast = astList[2]
-          // TCO
-        case "quote":
-          return astList[1]
-        case "quasiquoteexpand":
-          return quasiquote(astList[1])
-        case "quasiquote":
-          ast = quasiquote(astList[1])
-          // TCO
-        case "defmacro!":
-          f := (EVAL(astList[2], env) as MalUserFunc).dup
-          f.isMacro = true
-          return env.set(astList[1], f)
-        case "macroexpand":
-          return macroexpand(astList[1], env)
-        case "do":
-          eval_ast(MalList(astList[1..-2]), env)
-          ast = astList[-1]
-          // TCO
-        case "if":
-          if (EVAL(astList[1], env) is MalFalseyVal)
-            ast = astList.count > 3 ? astList[3] : MalNil.INSTANCE
-          else
-            ast = astList[2]
-          // TCO
-        case "fn*":
-          f := |MalVal[] a -> MalVal|
+        case MalSymbol#:
+          varName := (ast as MalSymbol).value
+          return env.get(varName) ?: throw Err("'$varName' not found")
+        case MalVector#:
+          newElements := (ast as MalVector).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalVector(newElements)
+        case MalHashMap#:
+          newElements := (ast as MalHashMap).value.map |MalVal v -> MalVal| { EVAL(v, env) }
+          return MalHashMap.fromMap(newElements)
+        case MalList#:
+          astList := ast as MalList
+          if (astList.isEmpty) return ast
+          switch ((astList[0] as MalSymbol)?.value)
           {
-            return EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(a)))
-          }
-          return MalUserFunc(astList[2], env, (MalSeq)astList[1], f)
-        default:
-          evaled_ast := eval_ast(ast, env) as MalList
-          switch (evaled_ast[0].typeof)
-          {
-            case MalUserFunc#:
-              user_fn := evaled_ast[0] as MalUserFunc
-              ast = user_fn.ast
-              env = user_fn.genEnv(evaled_ast.drop(1))
+            case "def!":
+              value := EVAL(astList[2], env)
+              return env.set(astList[1], value)
+            case "let*":
+              let_env := MalEnv(env)
+              varList := astList[1] as MalSeq
+              for (i := 0; i < varList.count; i += 2)
+                let_env.set(varList[i], EVAL(varList[i + 1], let_env))
+              env = let_env
+              ast = astList[2]
               // TCO
-            case MalFunc#:
-              return (evaled_ast[0] as MalFunc).call(evaled_ast[1..-1])
+            case "quote":
+              return astList[1]
+            case "quasiquote":
+              ast = quasiquote(astList[1])
+              // TCO
+            case "defmacro!":
+              f := (EVAL(astList[2], env) as MalUserFunc).dup
+              f.isMacro = true
+              return env.set(astList[1], f)
+            case "do":
+              for (i:=1; i<astList.count-1; i+=1)
+                EVAL(astList[i], env);
+              ast = astList[-1]
+              // TCO
+            case "if":
+              if (EVAL(astList[1], env) is MalFalseyVal)
+                ast = astList.count > 3 ? astList[3] : MalNil.INSTANCE
+              else
+                ast = astList[2]
+              // TCO
+            case "fn*":
+              f := |MalVal[] a -> MalVal|
+              {
+                return EVAL(astList[2], MalEnv(env, (astList[1] as MalSeq), MalList(a)))
+              }
+              return MalUserFunc(astList[2], env, (MalSeq)astList[1], f)
             default:
-              throw Err("Unknown type")
+              f := EVAL(astList[0], env)
+              args := astList.value[1..-1]
+              switch (f.typeof)
+              {
+                case MalUserFunc#:
+                  user_fn := f as MalUserFunc
+                  if (user_fn.isMacro) {
+                    ast = user_fn.call(args)
+                    continue // TCO
+                  }
+                  args = args.map |MalVal v -> MalVal| { EVAL(v, env) }
+                  ast = user_fn.ast
+                  env = user_fn.genEnv(MalList(args))
+                  // TCO
+                case MalFunc#:
+                  malfunc := f as MalFunc
+                  args = args.map |MalVal v -> MalVal| { EVAL(v, env) }
+                  return malfunc.call(args)
+                default:
+                  throw Err("Unknown type")
+              }
           }
+        default:
+          return ast
       }
     }
     return MalNil.INSTANCE // never reached


### PR DESCRIPTION
Various trivial changes minimizing the diff between steps. Hence, this commit should be reviewed with git -b.

Change the type of the key argument in env.{get,set} from MAL symbol to fantom Str.
Return null instead of raising an exception.
Both changes help DEBUG-EVAL.

For readability, merge env.find into env.get.