### PR TITLE
Test fns not special forms

### DIFF
--- a/impls/tests/step6_file.mal
+++ b/impls/tests/step6_file.mal
@@ -153,6 +153,23 @@
 (let* (b 12) (do (eval (read-string "(def! aa 7)")) aa ))
 ;=>7
 
+;;
+;; Testing for core fns instead of special forms
+(let* [x read-string] (x "(+ 2 3)"))
+;=>(+ 2 3)
+(let* [x slurp] (x "../tests/test.txt"))
+;=>"A line of text\n"
+(let* [x atom] (x 7))
+;=>(atom 7)
+(let* [x atom?] (x (atom 1)))
+;=>true
+(let* [x deref] (x (atom 7)))
+;=>7
+(let* [x reset!] (x (atom 7) 8))
+;=>8
+ (let* [x swap!] (x (atom 6) (fn* (y) (+ y 1))))
+;=>7
+
 ;>>> soft=True
 ;>>> optional=True
 ;;

--- a/impls/tests/step7_quote.mal
+++ b/impls/tests/step7_quote.mal
@@ -158,6 +158,12 @@ b
 (concat [1 2])
 ;=>(1 2)
 
+;; Testing for core fns instead of special forms
+(let* [x cons] (x 1 '(2 3)))
+;=>(1 2 3)
+(let* [x concat] (x '(1) '(2)))
+;=>(1 2)
+
 ;>>> optional=True
 ;;
 ;; -------- Optional Functionality --------
@@ -294,3 +300,7 @@ a
 ;/EVAL: \(cons 1 \(concat c \(cons 3 \(\)\)\)\).*\n\(1 1 "b" "d" 3\)
 (let* (DEBUG-EVAL true) `[])
 ;/EVAL: \(vec \(\)\).*\n\[\]
+
+;; Testing for core fn instead of special-form
+(let* [a vec] (a '(1 2 3)))
+;=>[1 2 3]


### PR DESCRIPTION
Add tests for steps 6 and 7 so atom-related, cons, and concat are implemented as fns and not special forms.

Pull request requirements:

- [x] Commits are well written and well organized.
- [x] Commits for a specific implementation should be prefixed with
  the implementation name.
- [x] Github Actions CI passes all checks (including self-host)

GHA CI had 2 failures, but these failures also occur with the upstream [178b7a8] commit:
https://github.com/moquist/mal/actions/runs/14948899199/job/41995831023#step:9:122
https://github.com/moquist/mal/actions/runs/14948899199/job/41995831107#step:10:5
                                                                             
The same failures, with my changes:
https://github.com/moquist/mal/actions/runs/14947777877/job/41993343841#step:9:122
https://github.com/moquist/mal/actions/runs/14947777877/job/41993343887#step:10:5