### PR TITLE
haskell: various small improvements

### DIFF
--- a/impls/haskell/Core.hs
+++ b/impls/haskell/Core.hs
@@ -133,16 +133,10 @@ read_string _ = throwStr "invalid read-string"
 
 -- Numeric functions
 
-num_op :: String -> (Int -> Int -> Int) -> (String, Fn)
-num_op name op = (name, fn) where
+num_op :: String -> (Int -> Int -> a) -> (a -> MalVal) -> (String, Fn)
+num_op name op constructor = (name, fn) where
   fn :: Fn
-  fn [MalNumber a, MalNumber b] = return $ MalNumber $ op a b
-  fn _ = throwStr $ "illegal arguments to " ++ name
-
-cmp_op :: String -> (Int -> Int -> Bool) -> (String, Fn)
-cmp_op name op = (name, fn) where
-  fn :: Fn
-  fn [MalNumber a, MalNumber b] = return $ MalBoolean $ op a b
+  fn [MalNumber a, MalNumber b] = return $ constructor $ op a b
   fn _ = throwStr $ "illegal arguments to " ++ name
 
 time_ms :: Fn
@@ -351,14 +345,14 @@ ns = [
     ("read-string", read_string),
     ("slurp",       slurp),
 
-    (cmp_op "<"     (<)),
-    (cmp_op "<="    (<=)),
-    (cmp_op ">"     (>)),
-    (cmp_op ">="    (>=)),
-    (num_op "+"     (+)),
-    (num_op "-"     (-)),
-    (num_op "*"     (*)),
-    (num_op "/"     div),
+    num_op "<"  (<)  MalBoolean,
+    num_op "<=" (<=) MalBoolean,
+    num_op ">"  (>)  MalBoolean,
+    num_op ">=" (>=) MalBoolean,
+    num_op "+"  (+)  MalNumber,
+    num_op "-"  (-)  MalNumber,
+    num_op "*"  (*)  MalNumber,
+    num_op "/"  div  MalNumber,
     ("time-ms",     time_ms),
 
     ("list",        list),

--- a/impls/haskell/Core.hs
+++ b/impls/haskell/Core.hs
@@ -126,7 +126,7 @@ do_readline :: Fn
 do_readline [MalString prompt] = do
     maybeLine <- liftIO $ readline prompt
     case maybeLine of
-        Nothing -> throwStr "readline failed"
+        Nothing -> return Nil
         Just line -> return $ MalString line
 do_readline _ = throwStr "invalid arguments to readline"
 

--- a/impls/haskell/Core.hs
+++ b/impls/haskell/Core.hs
@@ -2,7 +2,6 @@ module Core
 ( ns )
 where
 
-import System.IO (hFlush, stdout)
 import Control.Monad.Except (throwError)
 import Control.Monad.Trans (liftIO)
 import qualified Data.Map.Strict as Map
@@ -109,13 +108,11 @@ str args = liftIO $ MalString <$> _pr_list False "" args
 prn :: Fn
 prn args = liftIO $ do
     putStrLn =<< _pr_list True " " args
-    hFlush stdout
     return Nil
 
 println :: Fn
 println args = liftIO $ do
     putStrLn =<< _pr_list False " " args
-    hFlush stdout
     return Nil
 
 slurp :: Fn

--- a/impls/haskell/Makefile
+++ b/impls/haskell/Makefile
@@ -1,21 +1,22 @@
-SRCS = step0_repl.hs step1_read_print.hs step2_eval.hs step3_env.hs \
-       step4_if_fn_do.hs step5_tco.hs step6_file.hs step7_quote.hs \
-       step8_macros.hs step9_try.hs stepA_mal.hs
-OTHER_SRCS = Readline.hs Types.hs Reader.hs Printer.hs Env.hs Core.hs
-BINS = $(SRCS:%.hs=%)
-ghc_flags = -Wall
+BINS4 = step4_if_fn_do step5_tco step6_file step7_quote step8_macros \
+  step9_try stepA_mal
+BINS3 = step3_env $(BINS4)
+BINS1 = step1_read_print step2_eval $(BINS3)
+BINS = step0_repl $(BINS1)
+ghc_flags = -Wall -Wextra
+LDLIBS = -lreadline
 
 #####################
 
 all: $(BINS)
 
-dist: mal
+$(BINS): %: %.hs
+	ghc ${ghc_flags} --make $< $(LDLIBS) -o $@
 
-mal: $(word $(words $(BINS)),$(BINS))
-	cp $< $@
-
-$(BINS): %: %.hs $(OTHER_SRCS)
-	ghc ${ghc_flags} --make $< -o $@
+$(BINS1): Types.hs Reader.hs Printer.hs
+$(BINS3): Env.hs
+$(BINS4): Core.hs
+$(BINS): Readline.hs
 
 clean:
-	rm -f $(BINS) mal *.hi *.o
+	rm -f $(BINS) *.hi *.o

--- a/impls/haskell/Readline.hs
+++ b/impls/haskell/Readline.hs
@@ -10,6 +10,7 @@ import qualified System.Console.Readline as RL
 
 import Control.Monad (when)
 import System.Directory (getHomeDirectory, doesFileExist)
+import System.IO (hFlush, stdout)
 import System.IO.Error (tryIOError)
 
 history_file :: IO String
@@ -26,7 +27,9 @@ load_history = do
         mapM_ RL.addHistory (lines content)
 
 readline :: String -> IO (Maybe String)
-readline = RL.readline
+readline prompt = do
+    hFlush stdout
+    RL.readline prompt
 
 addHistory :: String -> IO ()
 addHistory line = do

--- a/impls/haskell/run
+++ b/impls/haskell/run
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 exec $(dirname $0)/${STEP:-stepA_mal} "${@}"

--- a/impls/haskell/step0_repl.hs
+++ b/impls/haskell/step0_repl.hs
@@ -1,5 +1,3 @@
-import System.IO (hFlush, stdout)
-
 import Readline (addHistory, readline, load_history)
 
 type MalVal = String
@@ -33,7 +31,6 @@ repl_loop = do
         Just str -> do
             addHistory str
             putStrLn $ rep str
-            hFlush stdout
             repl_loop
 
 main :: IO ()

--- a/impls/haskell/step0_repl.hs
+++ b/impls/haskell/step0_repl.hs
@@ -19,9 +19,6 @@ mal_print = id
 
 -- repl
 
-rep :: String -> String
-rep = mal_print . eval . mal_read
-
 repl_loop :: IO ()
 repl_loop = do
     line <- readline "user> "
@@ -30,11 +27,11 @@ repl_loop = do
         Just "" -> repl_loop
         Just str -> do
             addHistory str
-            putStrLn $ rep str
+            let out = mal_print $ eval $ mal_read str
+            putStrLn out
             repl_loop
 
 main :: IO ()
 main = do
     load_history
-
     repl_loop

--- a/impls/haskell/step1_read_print.hs
+++ b/impls/haskell/step1_read_print.hs
@@ -1,4 +1,4 @@
-import Control.Monad.Except (liftIO, runExceptT)
+import Control.Monad.Except (runExceptT)
 
 import Readline (addHistory, readline, load_history)
 import Types
@@ -17,13 +17,10 @@ eval = id
 
 -- print
 
-mal_print :: MalVal -> IOThrows String
-mal_print = liftIO . Printer._pr_str True
+mal_print :: MalVal -> IO String
+mal_print = _pr_str True
 
 -- repl
-
-rep :: String -> IOThrows String
-rep line = mal_print =<< (eval <$> mal_read line)
 
 repl_loop :: IO ()
 repl_loop = do
@@ -33,15 +30,14 @@ repl_loop = do
         Just "" -> repl_loop
         Just str -> do
             addHistory str
-            res <- runExceptT $ rep str
+            res <- runExceptT $ eval <$> mal_read str
             out <- case res of
-                Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
-                Right val -> return val
+                Left mv -> (++) "Error: " <$> mal_print mv
+                Right val -> mal_print val
             putStrLn out
             repl_loop
 
 main :: IO ()
 main = do
     load_history
-
     repl_loop

--- a/impls/haskell/step1_read_print.hs
+++ b/impls/haskell/step1_read_print.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import Control.Monad.Except (liftIO, runExceptT)
 
 import Readline (addHistory, readline, load_history)
@@ -39,7 +38,6 @@ repl_loop = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop
 
 main :: IO ()

--- a/impls/haskell/step2_eval.hs
+++ b/impls/haskell/step2_eval.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import Control.Monad.Except (liftIO, runExceptT)
 import qualified Data.Map as Map
 
@@ -33,7 +32,6 @@ eval ast = do
         True -> liftIO $ do
             putStr "EVAL: "
             putStrLn =<< _pr_str True ast
-            hFlush stdout
         False -> pure ()
     case ast of
         MalSymbol sym -> do
@@ -90,7 +88,6 @@ repl_loop = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop
 
 _func :: Fn -> MalVal

--- a/impls/haskell/step3_env.hs
+++ b/impls/haskell/step3_env.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import Control.Monad.Except (liftIO, runExceptT)
 
 import Readline (addHistory, readline, load_history)
@@ -54,7 +53,6 @@ eval env ast = do
             putStr "   "
             env_put env
             putStrLn ""
-            hFlush stdout
     case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
@@ -105,7 +103,6 @@ repl_loop env = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop env
 
 defBuiltIn :: Env -> String -> Fn -> IO ()

--- a/impls/haskell/step3_env.hs
+++ b/impls/haskell/step3_env.hs
@@ -4,7 +4,7 @@ import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
 import Printer (_pr_list, _pr_str)
-import Env (Env, env_get, env_let, env_put, env_repl, env_set)
+import Env
 
 -- read
 
@@ -29,7 +29,7 @@ apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
 apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
 apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_let env
+    let_env <- liftIO $ env_new $ Just env
     let_bind let_env params
     eval let_env a2
 apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
@@ -113,7 +113,7 @@ main :: IO ()
 main = do
     load_history
 
-    repl_env <- env_repl
+    repl_env <- env_new Nothing
 
     defBuiltIn repl_env "+" add
     defBuiltIn repl_env "-" sub

--- a/impls/haskell/step4_if_fn_do.hs
+++ b/impls/haskell/step4_if_fn_do.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM)
 
@@ -83,7 +82,6 @@ eval env ast = do
             putStr "   "
             env_put env
             putStrLn ""
-            hFlush stdout
     case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
@@ -118,7 +116,6 @@ repl_loop env = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop env
 
 --  Read and evaluate a line.  Ignore successful results, else print

--- a/impls/haskell/step4_if_fn_do.hs
+++ b/impls/haskell/step4_if_fn_do.hs
@@ -5,7 +5,7 @@ import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
 import Printer(_pr_list, _pr_str)
-import Env (Env, env_apply, env_get, env_let, env_put, env_repl, env_set)
+import Env
 import Core (ns)
 
 -- read
@@ -31,7 +31,7 @@ apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
 apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
 apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_let env
+    let_env <- liftIO $ env_new $ Just env
     let_bind let_env params
     eval let_env a2
 apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
@@ -55,12 +55,17 @@ apply_ast (MalSymbol "if") _ _ = throwStr "invalid if"
 apply_ast (MalSymbol "fn*") [MalSeq _ _ params, ast] env = return $ MalFunction (MetaData Nil) fn where
     fn :: [MalVal] -> IOThrows MalVal
     fn args = do
-        case env_apply env params args of
-            Just fn_env -> eval fn_env ast
-            Nothing -> do
+        fn_env <- liftIO $ env_new $ Just env
+        let loop [] [] = eval fn_env ast
+            loop [MalSymbol "&", k] vs = loop [k] [toList vs]
+            loop (MalSymbol k : ks) (v : vs) = do
+                liftIO $ env_set fn_env k v
+                loop ks vs
+            loop _ _ = do
                 p <- liftIO $ _pr_list True " " params
                 a <- liftIO $ _pr_list True " " args
                 throwStr $ "actual parameters: " ++ a ++ " do not match signature: " ++ p
+        loop params args
 apply_ast (MalSymbol "fn*") _ _ = throwStr "invalid fn*"
 
 apply_ast first rest env = do
@@ -136,7 +141,7 @@ main :: IO ()
 main = do
     load_history
 
-    repl_env <- env_repl
+    repl_env <- env_new Nothing
 
     -- core.hs: defined using Haskell
     mapM_ (defBuiltIn repl_env) Core.ns

--- a/impls/haskell/step4_if_fn_do.hs
+++ b/impls/haskell/step4_if_fn_do.hs
@@ -121,13 +121,14 @@ repl_loop env = do
             hFlush stdout
             repl_loop env
 
---  Read and evaluate a line. Ignore successful results, but crash in
---  case of error. This is intended for the startup procedure.
+--  Read and evaluate a line.  Ignore successful results, else print
+--  an error message case of error.
+--  The error function seems appropriate, but has no effect.
 re :: Env -> String -> IO ()
 re repl_env line = do
     res <- runExceptT $ eval repl_env =<< mal_read line
     case res of
-        Left mv -> error . (++) "Startup failed: " <$> Printer._pr_str True mv
+        Left mv -> putStrLn . (++) "Startup failed: " =<< _pr_str True mv
         Right _ -> return ()
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()

--- a/impls/haskell/step5_tco.hs
+++ b/impls/haskell/step5_tco.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM)
 
@@ -83,7 +82,6 @@ eval env ast = do
             putStr "   "
             env_put env
             putStrLn ""
-            hFlush stdout
     case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
@@ -118,7 +116,6 @@ repl_loop env = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop env
 
 --  Read and evaluate a line.  Ignore successful results, else print

--- a/impls/haskell/step5_tco.hs
+++ b/impls/haskell/step5_tco.hs
@@ -5,7 +5,7 @@ import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
 import Printer(_pr_list, _pr_str)
-import Env (Env, env_apply, env_get, env_let, env_put, env_repl, env_set)
+import Env
 import Core (ns)
 
 -- read
@@ -31,7 +31,7 @@ apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
 apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
 apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_let env
+    let_env <- liftIO $ env_new $ Just env
     let_bind let_env params
     eval let_env a2
 apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
@@ -55,12 +55,17 @@ apply_ast (MalSymbol "if") _ _ = throwStr "invalid if"
 apply_ast (MalSymbol "fn*") [MalSeq _ _ params, ast] env = return $ MalFunction (MetaData Nil) fn where
     fn :: [MalVal] -> IOThrows MalVal
     fn args = do
-        case env_apply env params args of
-            Just fn_env -> eval fn_env ast
-            Nothing -> do
+        fn_env <- liftIO $ env_new $ Just env
+        let loop [] [] = eval fn_env ast
+            loop [MalSymbol "&", k] vs = loop [k] [toList vs]
+            loop (MalSymbol k : ks) (v : vs) = do
+                liftIO $ env_set fn_env k v
+                loop ks vs
+            loop _ _ = do
                 p <- liftIO $ _pr_list True " " params
                 a <- liftIO $ _pr_list True " " args
                 throwStr $ "actual parameters: " ++ a ++ " do not match signature: " ++ p
+        loop params args
 apply_ast (MalSymbol "fn*") _ _ = throwStr "invalid fn*"
 
 apply_ast first rest env = do
@@ -136,7 +141,7 @@ main :: IO ()
 main = do
     load_history
 
-    repl_env <- env_repl
+    repl_env <- env_new Nothing
 
     -- core.hs: defined using Haskell
     mapM_ (defBuiltIn repl_env) Core.ns

--- a/impls/haskell/step5_tco.hs
+++ b/impls/haskell/step5_tco.hs
@@ -121,13 +121,14 @@ repl_loop env = do
             hFlush stdout
             repl_loop env
 
---  Read and evaluate a line. Ignore successful results, but crash in
---  case of error. This is intended for the startup procedure.
+--  Read and evaluate a line.  Ignore successful results, else print
+--  an error message case of error.
+--  The error function seems appropriate, but has no effect.
 re :: Env -> String -> IO ()
 re repl_env line = do
     res <- runExceptT $ eval repl_env =<< mal_read line
     case res of
-        Left mv -> error . (++) "Startup failed: " <$> Printer._pr_str True mv
+        Left mv -> putStrLn . (++) "Startup failed: " =<< _pr_str True mv
         Right _ -> return ()
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()

--- a/impls/haskell/step6_file.hs
+++ b/impls/haskell/step6_file.hs
@@ -101,13 +101,10 @@ eval env ast = do
 
 -- print
 
-mal_print :: MalVal -> IOThrows String
-mal_print = liftIO . Printer._pr_str True
+mal_print :: MalVal -> IO String
+mal_print = _pr_str True
 
 -- repl
-
-rep :: Env -> String -> IOThrows String
-rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -117,10 +114,10 @@ repl_loop env = do
         Just "" -> repl_loop env
         Just str -> do
             addHistory str
-            res <- runExceptT $ rep env str
+            res <- runExceptT $ eval env =<< mal_read str
             out <- case res of
-                Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
-                Right val -> return val
+                Left mv -> (++) "Error: " <$> mal_print mv
+                Right val -> mal_print val
             putStrLn out
             repl_loop env
 
@@ -145,7 +142,6 @@ evalFn _ _ = throwStr "illegal call of eval"
 main :: IO ()
 main = do
     args <- getArgs
-    load_history
 
     repl_env <- env_new Nothing
 
@@ -163,4 +159,6 @@ main = do
             re repl_env $ "(load-file \"" ++ script ++ "\")"
         [] -> do
             env_set repl_env "*ARGV*" $ toList []
+
+            load_history
             repl_loop repl_env

--- a/impls/haskell/step6_file.hs
+++ b/impls/haskell/step6_file.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
 import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM)
@@ -84,7 +83,6 @@ eval env ast = do
             putStr "   "
             env_put env
             putStrLn ""
-            hFlush stdout
     case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
@@ -119,7 +117,6 @@ repl_loop env = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop env
 
 --  Read and evaluate a line.  Ignore successful results, else print

--- a/impls/haskell/step6_file.hs
+++ b/impls/haskell/step6_file.hs
@@ -122,13 +122,14 @@ repl_loop env = do
             hFlush stdout
             repl_loop env
 
---  Read and evaluate a line. Ignore successful results, but crash in
---  case of error. This is intended for the startup procedure.
+--  Read and evaluate a line.  Ignore successful results, else print
+--  an error message case of error.
+--  The error function seems appropriate, but has no effect.
 re :: Env -> String -> IO ()
 re repl_env line = do
     res <- runExceptT $ eval repl_env =<< mal_read line
     case res of
-        Left mv -> error . (++) "Startup failed: " <$> Printer._pr_str True mv
+        Left mv -> putStrLn . (++) "Startup failed: " =<< _pr_str True mv
         Right _ -> return ()
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()

--- a/impls/haskell/step7_quote.hs
+++ b/impls/haskell/step7_quote.hs
@@ -125,13 +125,10 @@ eval env ast = do
 
 -- print
 
-mal_print :: MalVal -> IOThrows String
-mal_print = liftIO . Printer._pr_str True
+mal_print :: MalVal -> IO String
+mal_print = _pr_str True
 
 -- repl
-
-rep :: Env -> String -> IOThrows String
-rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -141,10 +138,10 @@ repl_loop env = do
         Just "" -> repl_loop env
         Just str -> do
             addHistory str
-            res <- runExceptT $ rep env str
+            res <- runExceptT $ eval env =<< mal_read str
             out <- case res of
-                Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
-                Right val -> return val
+                Left mv -> (++) "Error: " <$> mal_print mv
+                Right val -> mal_print val
             putStrLn out
             repl_loop env
 
@@ -169,7 +166,6 @@ evalFn _ _ = throwStr "illegal call of eval"
 main :: IO ()
 main = do
     args <- getArgs
-    load_history
 
     repl_env <- env_new Nothing
 
@@ -187,4 +183,6 @@ main = do
             re repl_env $ "(load-file \"" ++ script ++ "\")"
         [] -> do
             env_set repl_env "*ARGV*" $ toList []
+
+            load_history
             repl_loop repl_env

--- a/impls/haskell/step7_quote.hs
+++ b/impls/haskell/step7_quote.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
 import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM, foldrM)
@@ -108,7 +107,6 @@ eval env ast = do
             putStr "   "
             env_put env
             putStrLn ""
-            hFlush stdout
     case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
@@ -143,7 +141,6 @@ repl_loop env = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop env
 
 --  Read and evaluate a line.  Ignore successful results, else print

--- a/impls/haskell/step7_quote.hs
+++ b/impls/haskell/step7_quote.hs
@@ -146,13 +146,14 @@ repl_loop env = do
             hFlush stdout
             repl_loop env
 
---  Read and evaluate a line. Ignore successful results, but crash in
---  case of error. This is intended for the startup procedure.
+--  Read and evaluate a line.  Ignore successful results, else print
+--  an error message case of error.
+--  The error function seems appropriate, but has no effect.
 re :: Env -> String -> IO ()
 re repl_env line = do
     res <- runExceptT $ eval repl_env =<< mal_read line
     case res of
-        Left mv -> error . (++) "Startup failed: " <$> Printer._pr_str True mv
+        Left mv -> putStrLn . (++) "Startup failed: " =<< _pr_str True mv
         Right _ -> return ()
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()

--- a/impls/haskell/step7_quote.hs
+++ b/impls/haskell/step7_quote.hs
@@ -6,7 +6,7 @@ import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
 import Printer(_pr_list, _pr_str)
-import Env (Env, env_apply, env_get, env_let, env_put, env_repl, env_set)
+import Env
 import Core (ns)
 
 -- read
@@ -50,7 +50,7 @@ apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
 apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
 apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_let env
+    let_env <- liftIO $ env_new $ Just env
     let_bind let_env params
     eval let_env a2
 apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
@@ -80,12 +80,17 @@ apply_ast (MalSymbol "if") _ _ = throwStr "invalid if"
 apply_ast (MalSymbol "fn*") [MalSeq _ _ params, ast] env = return $ MalFunction (MetaData Nil) fn where
     fn :: [MalVal] -> IOThrows MalVal
     fn args = do
-        case env_apply env params args of
-            Just fn_env -> eval fn_env ast
-            Nothing -> do
+        fn_env <- liftIO $ env_new $ Just env
+        let loop [] [] = eval fn_env ast
+            loop [MalSymbol "&", k] vs = loop [k] [toList vs]
+            loop (MalSymbol k : ks) (v : vs) = do
+                liftIO $ env_set fn_env k v
+                loop ks vs
+            loop _ _ = do
                 p <- liftIO $ _pr_list True " " params
                 a <- liftIO $ _pr_list True " " args
                 throwStr $ "actual parameters: " ++ a ++ " do not match signature: " ++ p
+        loop params args
 apply_ast (MalSymbol "fn*") _ _ = throwStr "invalid fn*"
 
 apply_ast first rest env = do
@@ -166,7 +171,7 @@ main = do
     args <- getArgs
     load_history
 
-    repl_env <- env_repl
+    repl_env <- env_new Nothing
 
     -- core.hs: defined using Haskell
     mapM_ (defBuiltIn repl_env) Core.ns

--- a/impls/haskell/step8_macros.hs
+++ b/impls/haskell/step8_macros.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
 import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM, foldrM)
@@ -119,7 +118,6 @@ eval env ast = do
             putStr "   "
             env_put env
             putStrLn ""
-            hFlush stdout
     case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
@@ -154,7 +152,6 @@ repl_loop env = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop env
 
 --  Read and evaluate a line.  Ignore successful results, else print

--- a/impls/haskell/step8_macros.hs
+++ b/impls/haskell/step8_macros.hs
@@ -157,13 +157,14 @@ repl_loop env = do
             hFlush stdout
             repl_loop env
 
---  Read and evaluate a line. Ignore successful results, but crash in
---  case of error. This is intended for the startup procedure.
+--  Read and evaluate a line.  Ignore successful results, else print
+--  an error message case of error.
+--  The error function seems appropriate, but has no effect.
 re :: Env -> String -> IO ()
 re repl_env line = do
     res <- runExceptT $ eval repl_env =<< mal_read line
     case res of
-        Left mv -> error . (++) "Startup failed: " <$> Printer._pr_str True mv
+        Left mv -> putStrLn . (++) "Startup failed: " =<< _pr_str True mv
         Right _ -> return ()
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()

--- a/impls/haskell/step8_macros.hs
+++ b/impls/haskell/step8_macros.hs
@@ -136,13 +136,10 @@ eval env ast = do
 
 -- print
 
-mal_print :: MalVal -> IOThrows String
-mal_print = liftIO . Printer._pr_str True
+mal_print :: MalVal -> IO String
+mal_print = _pr_str True
 
 -- repl
-
-rep :: Env -> String -> IOThrows String
-rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -152,10 +149,10 @@ repl_loop env = do
         Just "" -> repl_loop env
         Just str -> do
             addHistory str
-            res <- runExceptT $ rep env str
+            res <- runExceptT $ eval env =<< mal_read str
             out <- case res of
-                Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
-                Right val -> return val
+                Left mv -> (++) "Error: " <$> mal_print mv
+                Right val -> mal_print val
             putStrLn out
             repl_loop env
 
@@ -180,7 +177,6 @@ evalFn _ _ = throwStr "illegal call of eval"
 main :: IO ()
 main = do
     args <- getArgs
-    load_history
 
     repl_env <- env_new Nothing
 
@@ -199,4 +195,6 @@ main = do
             re repl_env $ "(load-file \"" ++ script ++ "\")"
         [] -> do
             env_set repl_env "*ARGV*" $ toList []
+
+            load_history
             repl_loop repl_env

--- a/impls/haskell/step8_macros.hs
+++ b/impls/haskell/step8_macros.hs
@@ -6,7 +6,7 @@ import Readline (addHistory, readline, load_history)
 import Types
 import Reader (read_str)
 import Printer(_pr_list, _pr_str)
-import Env (Env, env_apply, env_get, env_let, env_put, env_repl, env_set)
+import Env
 import Core (ns)
 
 -- read
@@ -50,7 +50,7 @@ apply_ast (MalSymbol "def!") [MalSymbol a1, a2] env = do
 apply_ast (MalSymbol "def!") _ _ = throwStr "invalid def!"
 
 apply_ast (MalSymbol "let*") [MalSeq _ _ params, a2] env = do
-    let_env <- liftIO $ env_let env
+    let_env <- liftIO $ env_new $ Just env
     let_bind let_env params
     eval let_env a2
 apply_ast (MalSymbol "let*") _ _ = throwStr "invalid let*"
@@ -90,12 +90,17 @@ apply_ast (MalSymbol "if") _ _ = throwStr "invalid if"
 apply_ast (MalSymbol "fn*") [MalSeq _ _ params, ast] env = return $ MalFunction (MetaData Nil) fn where
     fn :: [MalVal] -> IOThrows MalVal
     fn args = do
-        case env_apply env params args of
-            Just fn_env -> eval fn_env ast
-            Nothing -> do
+        fn_env <- liftIO $ env_new $ Just env
+        let loop [] [] = eval fn_env ast
+            loop [MalSymbol "&", k] vs = loop [k] [toList vs]
+            loop (MalSymbol k : ks) (v : vs) = do
+                liftIO $ env_set fn_env k v
+                loop ks vs
+            loop _ _ = do
                 p <- liftIO $ _pr_list True " " params
                 a <- liftIO $ _pr_list True " " args
                 throwStr $ "actual parameters: " ++ a ++ " do not match signature: " ++ p
+        loop params args
 apply_ast (MalSymbol "fn*") _ _ = throwStr "invalid fn*"
 
 apply_ast first rest env = do
@@ -177,7 +182,7 @@ main = do
     args <- getArgs
     load_history
 
-    repl_env <- env_repl
+    repl_env <- env_new Nothing
 
     -- core.hs: defined using Haskell
     mapM_ (defBuiltIn repl_env) Core.ns

--- a/impls/haskell/step9_try.hs
+++ b/impls/haskell/step9_try.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
 import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM, foldrM)
@@ -129,7 +128,6 @@ eval env ast = do
             putStr "   "
             env_put env
             putStrLn ""
-            hFlush stdout
     case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
@@ -164,7 +162,6 @@ repl_loop env = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop env
 
 --  Read and evaluate a line.  Ignore successful results, else print

--- a/impls/haskell/step9_try.hs
+++ b/impls/haskell/step9_try.hs
@@ -167,13 +167,14 @@ repl_loop env = do
             hFlush stdout
             repl_loop env
 
---  Read and evaluate a line. Ignore successful results, but crash in
---  case of error. This is intended for the startup procedure.
+--  Read and evaluate a line.  Ignore successful results, else print
+--  an error message case of error.
+--  The error function seems appropriate, but has no effect.
 re :: Env -> String -> IO ()
 re repl_env line = do
     res <- runExceptT $ eval repl_env =<< mal_read line
     case res of
-        Left mv -> error . (++) "Startup failed: " <$> Printer._pr_str True mv
+        Left mv -> putStrLn . (++) "Startup failed: " =<< _pr_str True mv
         Right _ -> return ()
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()

--- a/impls/haskell/step9_try.hs
+++ b/impls/haskell/step9_try.hs
@@ -1,5 +1,5 @@
 import System.Environment (getArgs)
-import Control.Monad.Except (liftIO, runExceptT)
+import Control.Monad.Except (catchError, liftIO, runExceptT)
 import Data.Foldable (foldlM, foldrM)
 
 import Readline (addHistory, readline, load_history)
@@ -72,14 +72,11 @@ apply_ast (MalSymbol "defmacro!") [MalSymbol a1, a2] env = do
 apply_ast (MalSymbol "defmacro!") _ _ = throwStr "invalid defmacro!"
 
 apply_ast (MalSymbol "try*") [a1] env = eval env a1
-apply_ast (MalSymbol "try*") [a1, MalSeq _ (Vect False) [MalSymbol "catch*", MalSymbol a21, a22]] env = do
-    res <- liftIO $ runExceptT $ eval env a1
-    case res of
-        Right val -> return val
-        Left exc -> do
-            try_env <- liftIO $ env_new $ Just env
-            liftIO $ env_set try_env a21 exc
-            eval try_env a22
+apply_ast (MalSymbol "try*") [a1, MalSeq _ (Vect False) [MalSymbol "catch*", MalSymbol a21, a22]] env =
+    catchError (eval env a1) $ \exc -> do
+        try_env <- liftIO $ env_new $ Just env
+        liftIO $ env_set try_env a21 exc
+        eval try_env a22
 apply_ast (MalSymbol "try*") _ _ = throwStr "invalid try*"
 
 apply_ast (MalSymbol "do") args env = foldlM (const $ eval env) Nil args
@@ -147,13 +144,10 @@ eval env ast = do
 
 -- print
 
-mal_print :: MalVal -> IOThrows String
-mal_print = liftIO . Printer._pr_str True
+mal_print :: MalVal -> IO String
+mal_print = _pr_str True
 
 -- repl
-
-rep :: Env -> String -> IOThrows String
-rep env line = mal_print =<< eval env =<< mal_read line
 
 repl_loop :: Env -> IO ()
 repl_loop env = do
@@ -163,10 +157,10 @@ repl_loop env = do
         Just "" -> repl_loop env
         Just str -> do
             addHistory str
-            res <- runExceptT $ rep env str
+            res <- runExceptT $ eval env =<< mal_read str
             out <- case res of
-                Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
-                Right val -> return val
+                Left mv -> (++) "Error: " <$> mal_print mv
+                Right val -> mal_print val
             putStrLn out
             repl_loop env
 
@@ -191,7 +185,6 @@ evalFn _ _ = throwStr "illegal call of eval"
 main :: IO ()
 main = do
     args <- getArgs
-    load_history
 
     repl_env <- env_new Nothing
 
@@ -210,4 +203,6 @@ main = do
             re repl_env $ "(load-file \"" ++ script ++ "\")"
         [] -> do
             env_set repl_env "*ARGV*" $ toList []
+
+            load_history
             repl_loop repl_env

--- a/impls/haskell/stepA_mal.hs
+++ b/impls/haskell/stepA_mal.hs
@@ -1,4 +1,3 @@
-import System.IO (hFlush, stdout)
 import System.Environment (getArgs)
 import Control.Monad.Except (liftIO, runExceptT)
 import Data.Foldable (foldlM, foldrM)
@@ -129,7 +128,6 @@ eval env ast = do
             putStr "   "
             env_put env
             putStrLn ""
-            hFlush stdout
     case ast of
         MalSymbol sym -> do
             maybeVal <- liftIO $ env_get env sym
@@ -164,7 +162,6 @@ repl_loop env = do
                 Left mv -> (++) "Error: " <$> liftIO (Printer._pr_str True mv)
                 Right val -> return val
             putStrLn out
-            hFlush stdout
             repl_loop env
 
 --  Read and evaluate a line.  Ignore successful results, else print

--- a/impls/haskell/stepA_mal.hs
+++ b/impls/haskell/stepA_mal.hs
@@ -167,13 +167,14 @@ repl_loop env = do
             hFlush stdout
             repl_loop env
 
---  Read and evaluate a line. Ignore successful results, but crash in
---  case of error. This is intended for the startup procedure.
+--  Read and evaluate a line.  Ignore successful results, else print
+--  an error message case of error.
+--  The error function seems appropriate, but has no effect.
 re :: Env -> String -> IO ()
 re repl_env line = do
     res <- runExceptT $ eval repl_env =<< mal_read line
     case res of
-        Left mv -> error . (++) "Startup failed: " <$> Printer._pr_str True mv
+        Left mv -> putStrLn . (++) "Startup failed: " =<< _pr_str True mv
         Right _ -> return ()
 
 defBuiltIn :: Env -> (String, Fn) -> IO ()


### PR DESCRIPTION
Core, steps: flush standard output before read instead of after print.

Core: merge num_op and cmp_op templates.

Types, Core: use a specific type for map keys.
Fix "get nil :k" (for consistency).
Fix "contains? nil :k" (it was accepting symbols instead of keywords). Remove an unneeded key check in decodeKey.
Move encodeKey from Types.hs to Core.hs.

Env.hs, steps:
Replace the complex and fragile part of c9c504ac creating two sorts of environments with mutable environments, closer to the guide. Move env_apply from Env.hs to stepA_mal.

Makefile:
Remove targets building the last implemented step. Link with readline (explicitly).
Add extra compiler warnings.
Refine the Make dependencies.

run:
Stop requiring bash.

steps:
Import all functions from Env module instead of duplicating the export list. Simplify mal/try* with haskell/catchError.
Merge rep into repl_loop for readability.
Print errors during startup (they were ignored).
Only load readline history in interactive mode.
