### PR TITLE
c.2: various improvememts, fix new tests

### DIFF
--- a/impls/c.2/Makefile
+++ b/impls/c.2/Makefile
@@ -1,46 +1,10 @@
 CC = gcc
 
-CFLAGS = -std=c99 -g -Wall
+# Optimization is not required but enables some more warnings.
+CFLAGS = -std=c99 -g -Wall -Wextra -O1
 
-LIBS = -ledit -lgc
-FFI_LIBS = -ldl -lffi
-
-SRC = reader.c printer.c types.c env.c core.c
-HEADERS = reader.h printer.h types.h env.h core.h
-
-LIB_DIR = ./libs
-LIB_LIST_H = $(LIB_DIR)/linked_list/linked_list.h
-LIB_LIST_SRC = $(LIB_DIR)/linked_list/linked_list.c
-
-LIB_MAP_H = $(LIB_DIR)/hashmap/hashmap.h
-LIB_MAP_SRC = $(LIB_DIR)/hashmap/hashmap.c
-
-LIBS_H = $(LIB_LIST_H) $(LIB_MAP_H)
-LIBS_SRC = $(LIB_LIST_SRC) $(LIB_MAP_SRC)
-
-S0_SRC = step0_repl.c
-S1_SRC = step1_read_print.c reader.c types.c printer.c $(LIB_LIST_SRC)
-S2_SRC = step2_eval.c reader.c types.c printer.c $(LIBS_SRC)
-S3_SRC = step3_env.c reader.c types.c printer.c env.c $(LIBS_SRC)
-S4_SRC = step4_if_fn_do.c $(SRC) $(LIBS_SRC)
-S5_SRC = step5_tco.c $(SRC) $(LIBS_SRC)
-S6_SRC = step6_file.c $(SRC) $(LIBS_SRC)
-S7_SRC = step7_quote.c $(SRC) $(LIBS_SRC)
-S8_SRC = step8_macros.c $(SRC) $(LIBS_SRC)
-S9_SRC = step9_try.c $(SRC) $(LIBS_SRC)
-SA_SRC = stepA_mal.c $(SRC) $(LIBS_SRC)
-
-S0_HEADERS =
-S1_HEADERS = reader.h types.h printer.h $(LIB_LIST_H)
-S2_HEADERS = reader.h types.h printer.h $(LIBS_H)
-S3_HEADERS = reader.h types.h printer.h env.h $(LIBS_H)
-S4_HEADERS = $(HEADERS) $(LIBS_H)
-S5_HEADERS = $(HEADERS) $(LIBS_H)
-S6_HEADERS = $(HEADERS) $(LIBS_H)
-S7_HEADERS = $(HEADERS) $(LIBS_H)
-S8_HEADERS = $(HEADERS) $(LIBS_H)
-S9_HEADERS = $(HEADERS) $(LIBS_H)
-SA_HEADERS = $(HEADERS) $(LIBS_H)
+# The code defines new format specifiers.
+CPPFLAGS = -Wno-format
 
 S0 = step0_repl
 S1 = step1_read_print
@@ -54,40 +18,36 @@ S8 = step8_macros
 S9 = step9_try
 SA = stepA_mal
 
-all: $(S0) $(S1) $(S2) $(S3) $(S4) $(S5) $(S6) $(S7) $(S8) $(S9) $(SA)
+S4+ := $(S4) $(S5) $(S6) $(S7) $(S8) $(S9) $(SA)
+S3+ := $(S3) $(S4+)
+S1+ := $(S1) $(S2) $(S3+)
+S0+ := $(S0) $(S1+)
 
-$(S0): $(S0_SRC) $(S0_HEADERS)
-	$(CC) $(CFLAGS) $(S0_SRC) $(LIBS) -o $(S0)
+VPATH = libs/hashmap libs/linked_list
 
-$(S1): $(S1_SRC) $(S1_HEADERS)
-	$(CC) $(CFLAGS) $(S1_SRC) $(LIBS) -o $(S1)
+all: $(S0+)
 
-$(S2): $(S2_SRC) $(S2_HEADERS)
-	$(CC) $(CFLAGS) $(S2_SRC) $(LIBS) -o $(S2)
+# GCC could create temporary objects files, but separate recipes for
+# .o objects give faster build cycles when debugging.
 
-$(S3): $(S3_SRC) $(S3_HEADERS)
-	$(CC) $(CFLAGS) $(S3_SRC) $(LIBS) -o $(S3)
+$(S0+): LDLIBS += -ledit
 
-$(S4): $(S4_SRC) $(S4_HEADERS)
-	$(CC) $(CFLAGS) $(S4_SRC) $(LIBS) -o $(S4)
+$(S1+): hashmap.o linked_list.o printer.o reader.o types.o
+$(S1+): LDLIBS += -lgc
 
-$(S5): $(S5_SRC) $(S5_HEADERS)
-	$(CC) $(CFLAGS) $(S5_SRC) $(LIBS) -o $(S5)
+$(S3+): env.o
 
-$(S6): $(S6_SRC) $(S6_HEADERS)
-	$(CC) $(CFLAGS) $(S6_SRC) $(LIBS) -o $(S6)
+# ffi is only used by stepA, but we want the same core.o for all steps.
+# Anyway, the --as-needed linker option is active by default.
+$(S4+): core.o
+$(S4+): LDLIBS += -ldl -lffi
+core.o: CPPFLAGS += -DWITH_FFI
 
-$(S7): $(S7_SRC) $(S7_HEADERS)
-	$(CC) $(CFLAGS) $(S7_SRC) $(LIBS) -o $(S7)
+include deps
+deps:
+	gcc -MM -MF- *.c > $@
 
-$(S8): $(S8_SRC) $(S8_HEADERS)
-	$(CC) $(CFLAGS) $(S8_SRC) $(LIBS) -o $(S8)
+clean:
+	rm -f $(S0+) *.o deps
 
-$(S9): $(S9_SRC) $(S9_HEADERS)
-	$(CC) $(CFLAGS) $(S9_SRC) $(LIBS) -o $(S9)
-
-$(SA): $(SA_SRC) $(SA_HEADERS)
-	$(CC) $(CFLAGS) $(SA_SRC) $(LIBS) $(FFI_LIBS) -DWITH_FFI -o $(SA)
-
-.PHONY clean:
-	rm -f $(S0) $(S1) $(S2) $(S3) $(S4) $(S5) $(S6) $(S7) $(S8) $(S9) $(SA)
+.PHONY: all clean

--- a/impls/c.2/core.c
+++ b/impls/c.2/core.c
@@ -1,7 +1,12 @@
+#include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
 #include <math.h>
+
+#include <editline/readline.h>
+#include <editline/history.h>
 #include <gc.h>
 
 /* only needed for ffi */
@@ -12,880 +17,474 @@
 
 #include "libs/hashmap/hashmap.h"
 #include "core.h"
-#include "types.h"
 #include "printer.h"
 #include "reader.h"
-#include "env.h"
-
-#define STRING_BUFFER_SIZE 128
 
 /* forward references to main file */
-MalType* apply(MalType* fn, list args);
+MalType apply(MalType fn, list args);
+
+// Helper functions
+
+bool equal_lists(list, list);
+bool equal_hashmaps(list, list);
+bool equal_forms(MalType, MalType);
+MalType make_boolean(bool);
 
 /* core ns functions */
-MalType* mal_add(list);
-MalType* mal_sub(list);
-MalType* mal_mul(list);
-MalType* mal_div(list);
+MalType mal_add(list);
+MalType mal_sub(list);
+MalType mal_mul(list);
+MalType mal_div(list);
 
-MalType* mal_prn(list);
-MalType* mal_println(list);
-MalType* mal_pr_str(list);
-MalType* mal_str(list);
-MalType* mal_read_string(list);
-MalType* mal_slurp(list);
+MalType mal_prn(list);
+MalType mal_println(list);
+MalType mal_pr_str(list);
+MalType mal_str(list);
+MalType mal_read_string(list);
+MalType mal_slurp(list);
 
-MalType* mal_list(list);
-MalType* mal_list_questionmark(list);
-MalType* mal_empty_questionmark(list);
-MalType* mal_count(list);
-MalType* mal_cons(list);
-MalType* mal_concat(list);
-MalType* mal_nth(list);
-MalType* mal_first(list);
-MalType* mal_rest(list);
+MalType mal_list_questionmark(list);
+MalType mal_empty_questionmark(list);
+MalType mal_count(list);
+MalType mal_cons(list);
+MalType mal_concat(list);
+MalType mal_nth(list);
+MalType mal_first(list);
+MalType mal_rest(list);
 
-MalType* mal_equals(list);
-MalType* mal_lessthan(list);
-MalType* mal_lessthanorequalto(list);
-MalType* mal_greaterthan(list);
-MalType* mal_greaterthanorequalto(list);
+MalType mal_equals(list);
+MalType mal_lessthan(list);
+MalType mal_lessthanorequalto(list);
+MalType mal_greaterthan(list);
+MalType mal_greaterthanorequalto(list);
 
-MalType* mal_atom(list);
-MalType* mal_atom_questionmark(list);
-MalType* mal_deref(list);
-MalType* mal_reset_bang(list);
-MalType* mal_swap_bang(list);
+MalType mal_atom(list);
+MalType mal_atom_questionmark(list);
+MalType mal_deref(list);
+MalType mal_reset_bang(list);
+MalType mal_swap_bang(list);
 
-MalType* mal_throw(list);
-MalType* mal_apply(list);
-MalType* mal_map(list);
+MalType mal_throw(list);
+MalType mal_apply(list);
+MalType mal_map(list);
 
-MalType* mal_nil_questionmark(list);
-MalType* mal_true_questionmark(list);
-MalType* mal_false_questionmark(list);
-MalType* mal_symbol_questionmark(list);
-MalType* mal_keyword_questionmark(list);
-MalType* mal_symbol(list);
-MalType* mal_keyword(list);
+MalType mal_nil_questionmark(list);
+MalType mal_true_questionmark(list);
+MalType mal_false_questionmark(list);
+MalType mal_symbol_questionmark(list);
+MalType mal_keyword_questionmark(list);
+MalType mal_symbol(list);
+MalType mal_keyword(list);
 
-MalType* mal_vec(list);
-MalType* mal_vector(list);
-MalType* mal_vector_questionmark(list);
-MalType* mal_sequential_questionmark(list);
-MalType* mal_hash_map(list);
-MalType* mal_map_questionmark(list);
-MalType* mal_assoc(list);
-MalType* mal_dissoc(list);
-MalType* mal_get(list);
-MalType* mal_contains_questionmark(list);
-MalType* mal_keys(list);
-MalType* mal_vals(list);
-MalType* mal_string_questionmark(list);
-MalType* mal_number_questionmark(list);
-MalType* mal_fn_questionmark(list);
-MalType* mal_macro_questionmark(list);
+MalType mal_vec(list);
+MalType mal_vector_questionmark(list);
+MalType mal_sequential_questionmark(list);
+MalType mal_map_questionmark(list);
+MalType mal_assoc(list);
+MalType mal_dissoc(list);
+MalType mal_get(list);
+MalType mal_contains_questionmark(list);
+MalType mal_keys(list);
+MalType mal_vals(list);
+MalType mal_string_questionmark(list);
+MalType mal_number_questionmark(list);
+MalType mal_fn_questionmark(list);
+MalType mal_macro_questionmark(list);
 
-MalType* mal_time_ms(list);
-MalType* mal_conj(list);
-MalType* mal_seq(list);
-MalType* mal_meta(list);
-MalType* mal_with_meta(list);
+MalType mal_time_ms(list);
+MalType mal_conj(list);
+MalType mal_seq(list);
+MalType mal_meta(list);
+MalType mal_with_meta(list);
+
+MalType mal_readline(list);
 
 /* only needed for ffi */
 #ifdef WITH_FFI
-MalType* mal_dot(list);
+MalType mal_dot(list);
 #endif
 
-ns* ns_make_core() {
-
-  ns* core = GC_MALLOC(sizeof(*core));
-
-  hashmap core_functions = NULL;
+struct ns_s THE_CORE_NS[] = {
 
   /* arithmetic */
-  core_functions = hashmap_put(core_functions, "+", mal_add);
-  core_functions = hashmap_put(core_functions, "-", mal_sub);
-  core_functions = hashmap_put(core_functions, "*", mal_mul);
-  core_functions = hashmap_put(core_functions, "/", mal_div);
+  { "+", mal_add },
+  { "-", mal_sub },
+  { "*", mal_mul },
+  { "/", mal_div },
 
   /* strings */
-  core_functions = hashmap_put(core_functions, "prn", mal_prn);
-  core_functions = hashmap_put(core_functions, "pr-str", mal_pr_str);
-  core_functions = hashmap_put(core_functions, "str", mal_str);
-  core_functions = hashmap_put(core_functions, "println", mal_println);
-  core_functions = hashmap_put(core_functions, "read-string", mal_read_string);
+  { "prn", mal_prn },
+  { "pr-str", mal_pr_str },
+  { "str", mal_str },
+  { "println", mal_println },
+  { "read-string", mal_read_string },
 
   /* files */
-  core_functions = hashmap_put(core_functions, "slurp", mal_slurp);
+  { "slurp", mal_slurp },
 
   /* lists */
-  core_functions = hashmap_put(core_functions, "list", mal_list);
-  core_functions = hashmap_put(core_functions, "empty?", mal_empty_questionmark);
-  core_functions = hashmap_put(core_functions, "count", mal_count);
-  core_functions = hashmap_put(core_functions, "cons", mal_cons);
-  core_functions = hashmap_put(core_functions, "concat", mal_concat);
-  core_functions = hashmap_put(core_functions, "nth", mal_nth);
-  core_functions = hashmap_put(core_functions, "first", mal_first);
-  core_functions = hashmap_put(core_functions, "rest", mal_rest);
+  { "list", make_list },
+  { "empty?", mal_empty_questionmark },
+  { "count", mal_count },
+  { "cons", mal_cons },
+  { "concat", mal_concat },
+  { "nth", mal_nth },
+  { "first", mal_first },
+  { "rest", mal_rest },
 
   /* predicates */
-  core_functions = hashmap_put(core_functions, "=", mal_equals);
-  core_functions = hashmap_put(core_functions, "<", mal_lessthan);
-  core_functions = hashmap_put(core_functions, "<=", mal_lessthanorequalto);
-  core_functions = hashmap_put(core_functions, ">", mal_greaterthan);
-  core_functions = hashmap_put(core_functions, ">=", mal_greaterthanorequalto);
+  { "=", mal_equals },
+  { "<", mal_lessthan },
+  { "<=", mal_lessthanorequalto },
+  { ">", mal_greaterthan },
+  { ">=", mal_greaterthanorequalto },
 
-  core_functions = hashmap_put(core_functions, "list?", mal_list_questionmark);
-  core_functions = hashmap_put(core_functions, "nil?", mal_nil_questionmark);
-  core_functions = hashmap_put(core_functions, "true?", mal_true_questionmark);
-  core_functions = hashmap_put(core_functions, "false?", mal_false_questionmark);
-  core_functions = hashmap_put(core_functions, "symbol?", mal_symbol_questionmark);
-  core_functions = hashmap_put(core_functions, "keyword?", mal_keyword_questionmark);
-  core_functions = hashmap_put(core_functions, "vector?", mal_vector_questionmark);
-  core_functions = hashmap_put(core_functions, "sequential?", mal_sequential_questionmark);
-  core_functions = hashmap_put(core_functions, "map?", mal_map_questionmark);
-  core_functions = hashmap_put(core_functions, "string?", mal_string_questionmark);
-  core_functions = hashmap_put(core_functions, "number?", mal_number_questionmark);
-  core_functions = hashmap_put(core_functions, "fn?", mal_fn_questionmark);
-  core_functions = hashmap_put(core_functions, "macro?", mal_macro_questionmark);
+  { "list?", mal_list_questionmark },
+  { "nil?", mal_nil_questionmark },
+  { "true?", mal_true_questionmark },
+  { "false?", mal_false_questionmark },
+  { "symbol?", mal_symbol_questionmark },
+  { "keyword?", mal_keyword_questionmark },
+  { "vector?", mal_vector_questionmark },
+  { "sequential?", mal_sequential_questionmark },
+  { "map?", mal_map_questionmark },
+  { "string?", mal_string_questionmark },
+  { "number?", mal_number_questionmark },
+  { "fn?", mal_fn_questionmark },
+  { "macro?", mal_macro_questionmark },
 
   /* atoms */
-  core_functions = hashmap_put(core_functions, "atom", mal_atom);
-  core_functions = hashmap_put(core_functions, "atom?", mal_atom_questionmark);
-  core_functions = hashmap_put(core_functions, "deref", mal_deref);
-  core_functions = hashmap_put(core_functions, "reset!", mal_reset_bang);
-  core_functions = hashmap_put(core_functions, "swap!", mal_swap_bang);
+  { "atom", mal_atom },
+  { "atom?", mal_atom_questionmark },
+  { "deref", mal_deref },
+  { "reset!", mal_reset_bang },
+  { "swap!", mal_swap_bang },
 
   /* other */
-  core_functions = hashmap_put(core_functions, "throw", mal_throw);
-  core_functions = hashmap_put(core_functions, "apply", mal_apply);
-  core_functions = hashmap_put(core_functions, "map", mal_map);
+  { "throw", mal_throw },
+  { "apply", mal_apply },
+  { "map", mal_map },
 
-  core_functions = hashmap_put(core_functions, "symbol", mal_symbol);
-  core_functions = hashmap_put(core_functions, "keyword", mal_keyword);
-  core_functions = hashmap_put(core_functions, "vec", mal_vec);
-  core_functions = hashmap_put(core_functions, "vector", mal_vector);
-  core_functions = hashmap_put(core_functions, "hash-map", mal_hash_map);
+  { "symbol", mal_symbol },
+  { "keyword", mal_keyword },
+  { "vec", mal_vec },
+  { "vector", make_vector },
+  { "hash-map", mal_hash_map },
 
   /* hash-maps */
-  core_functions = hashmap_put(core_functions, "contains?", mal_contains_questionmark);
-  core_functions = hashmap_put(core_functions, "assoc", mal_assoc);
-  core_functions = hashmap_put(core_functions, "dissoc", mal_dissoc);
-  core_functions = hashmap_put(core_functions, "get", mal_get);
-  core_functions = hashmap_put(core_functions, "keys", mal_keys);
-  core_functions = hashmap_put(core_functions, "vals", mal_vals);
+  { "contains?", mal_contains_questionmark },
+  { "assoc", mal_assoc },
+  { "dissoc", mal_dissoc },
+  { "get", mal_get },
+  { "keys", mal_keys },
+  { "vals", mal_vals },
 
   /* misc */
-  core_functions = hashmap_put(core_functions, "time-ms", mal_time_ms);
-  core_functions = hashmap_put(core_functions, "conj", mal_conj);
-  core_functions = hashmap_put(core_functions, "seq", mal_seq);
-  core_functions = hashmap_put(core_functions, "meta", mal_meta);
-  core_functions = hashmap_put(core_functions, "with-meta", mal_with_meta);
+  { "time-ms", mal_time_ms },
+  { "conj", mal_conj },
+  { "seq", mal_seq },
+  { "meta", mal_meta },
+  { "with-meta", mal_with_meta },
+
+  { "readline", mal_readline },
 
   /* only needed for ffi */
   #ifdef WITH_FFI
-  core_functions = hashmap_put(core_functions, ".", mal_dot);
+  { ".", mal_dot },
   #endif
+};
 
-  core->mappings = core_functions;
-  return core;
+void ns_make_core(ns* core, size_t* size) {
+  *core = THE_CORE_NS;
+  *size = sizeof(THE_CORE_NS) / sizeof(struct ns_s);
 }
 
 /* core function definitons */
 
-MalType* mal_add(list args) {
-  /* Accepts any number of arguments */
-
-  int return_float = 0;
-
-  long i_sum = 0;
-  double r_sum = 0.0;
-
-  while(args) {
-
-    MalType* val = args->data;
-    if (!is_number(val)) {
-      return make_error("'+': expected numerical arguments");
-    }
-
-    if (is_integer(val) && !return_float) {
-      i_sum = i_sum + val->value.mal_integer;
-    }
-    else if (is_integer(val)) {
-      r_sum = (double)i_sum + r_sum + val->value.mal_integer;
-      i_sum = 0;
-    }
-    else {
-      r_sum = (double)i_sum + r_sum + val->value.mal_float;
-      i_sum = 0;
-      return_float = 1;
-    }
-    args = args->next;
+#define generic_arithmetic(name, op, iconst, fconst)                   \
+  MalType name(list args) {                                            \
+    MalType a1 = eat_argument(args);                                   \
+    MalType a2 = eat_argument(args);                                   \
+    check_empty(args);                                                 \
+    switch(a1->type) {                                                 \
+    case MALTYPE_INTEGER:                                              \
+      switch(a2->type) {                                               \
+      case MALTYPE_INTEGER:                                            \
+        return iconst(a1->value.mal_integer op a2->value.mal_integer); \
+      case MALTYPE_FLOAT:                                              \
+        return fconst(a1->value.mal_integer op a2->value.mal_float);   \
+      default: return bad_type(a2, "a number");                        \
+      }                                                                \
+    case MALTYPE_FLOAT:                                                \
+      switch(a2->type) {                                               \
+      case MALTYPE_INTEGER:                                            \
+        return fconst(a1->value.mal_float   op a2->value.mal_integer); \
+      case MALTYPE_FLOAT:                                              \
+        return fconst(a1->value.mal_float   op a2->value.mal_float);   \
+      default: return bad_type(a2, "a number");                        \
+      }                                                                \
+    default: return bad_type(a1, "a number");                          \
+    }                                                                  \
   }
+generic_arithmetic(mal_add,                  +,  make_integer, make_float)
+generic_arithmetic(mal_sub,                  -,  make_integer, make_float)
+generic_arithmetic(mal_mul,                  *,  make_integer, make_float)
+generic_arithmetic(mal_div,                  /,  make_integer, make_float)
+generic_arithmetic(mal_lessthan,             <,  make_boolean, make_boolean)
+generic_arithmetic(mal_lessthanorequalto,    <=, make_boolean, make_boolean)
+generic_arithmetic(mal_greaterthan,          >,  make_boolean, make_boolean)
+generic_arithmetic(mal_greaterthanorequalto, >=, make_boolean, make_boolean)
 
-  if (return_float) {
-    return make_float(r_sum);
-  } else {
-    return make_integer(i_sum);
+#define generic_type_predicate(name, mask)   \
+  MalType name(list args) {                  \
+    MalType val = eat_argument(args);        \
+    check_empty(args);                       \
+    return make_boolean(val->type & (mask)); \
   }
-}
+generic_type_predicate(mal_list_questionmark, MALTYPE_LIST)
+generic_type_predicate(mal_atom_questionmark, MALTYPE_ATOM)
+generic_type_predicate(mal_nil_questionmark, MALTYPE_NIL)
+generic_type_predicate(mal_true_questionmark, MALTYPE_TRUE)
+generic_type_predicate(mal_false_questionmark, MALTYPE_FALSE)
+generic_type_predicate(mal_symbol_questionmark, MALTYPE_SYMBOL)
+generic_type_predicate(mal_keyword_questionmark, MALTYPE_KEYWORD)
+generic_type_predicate(mal_vector_questionmark, MALTYPE_VECTOR)
+generic_type_predicate(mal_sequential_questionmark, MALTYPE_LIST | MALTYPE_VECTOR)
+generic_type_predicate(mal_map_questionmark, MALTYPE_HASHMAP)
+generic_type_predicate(mal_string_questionmark, MALTYPE_STRING)
+generic_type_predicate(mal_number_questionmark, MALTYPE_FLOAT | MALTYPE_INTEGER)
+generic_type_predicate(mal_fn_questionmark, MALTYPE_CLOSURE | MALTYPE_FUNCTION)
+generic_type_predicate(mal_macro_questionmark, MALTYPE_MACRO)
 
-MalType* mal_sub(list args) {
-  /* Accepts any number of arguments */
-
-  int return_float = 0;
-
-  long i_sum = 0;
-  double r_sum = 0.0;
-
-  if (args) {
-
-    MalType* val = args->data;
-    args = args->next;
-
-    if (!is_number(val)) {
-      return make_error_fmt("'-': expected numerical arguments");
-    }
-
-    if (is_integer(val)) {
-      i_sum = val->value.mal_integer;
-    } else {
-      r_sum = val->value.mal_float;
-      return_float = 1;
-    }
-
-      while(args) {
-
-      val = args->data;
-
-      if (!is_number(val)) {
-        return make_error_fmt("'-': expected numerical arguments");
-      }
-
-      if (is_integer(val) && !return_float) {
-        i_sum = i_sum - val->value.mal_integer;
-      }
-      else if (is_integer(val)) {
-        r_sum = (double)i_sum + r_sum - (double)val->value.mal_integer;
-        i_sum = 0;
-      }
-      else {
-        r_sum = (double)i_sum + r_sum - val->value.mal_float;
-        i_sum = 0;
-        return_float = 1;
-      }
-      args = args->next;
-    }
-  }
-
-  if (return_float) {
-    return make_float(r_sum);
-  } else {
-    return make_integer(i_sum);
-  }
-}
-
-
-MalType* mal_mul(list args) {
-  /* Accepts any number of arguments */
-
-  int return_float = 0;
-
-  long i_product = 1;
-  double r_product = 1.0;
-
-  while(args) {
-
-    MalType* val = args->data;
-
-    if (!is_number(val)) {
-      return make_error_fmt("'*': expected numerical arguments");
-    }
-
-    if (is_integer(val) && !return_float) {
-      i_product *= val->value.mal_integer;
-    }
-    else if (is_integer(val)) {
-      r_product *= (double)val->value.mal_integer;
-      r_product *= (double)i_product;
-      i_product = 1;
-    }
-    else {
-      r_product *= (double)i_product;
-      r_product *= val->value.mal_float;
-      i_product = 1;
-      return_float = 1;
-    }
-    args = args->next;
-  }
-
-  if (return_float) {
-    return make_float(r_product);
-  } else {
-    return make_integer(i_product);
-  }
-}
-
-MalType* mal_div(list args) {
-  /* Accepts any number of arguments */
-
-  int return_float = 0;
-
-  long i_product = 1;
-  double r_product = 1.0;
-
-  if (args) {
-    MalType* val = args->data;
-
-    if (!is_number(val)) {
-      return make_error_fmt("'/': expected numerical arguments");
-    }
-
-    if (is_integer(val)) {
-      i_product = val->value.mal_integer;
-    } else {
-      r_product = val->value.mal_float;
-      return_float = 1;
-    }
-
-    args = args->next;
-
-    while(args) {
-
-      val = args->data;
-
-      if (!is_number(val)) {
-        return make_error_fmt("'/': expected numerical arguments");
-      }
-
-      /* integer division */
-      if (is_integer(val) && !return_float) {
-        i_product /= val->value.mal_integer;
-      }
-      /* promote integer to double */
-      else if (is_integer(val)) {
-        if (i_product != 1) {
-          r_product = (double)i_product / (double)val->value.mal_integer;
-          i_product = 1;
-        } else {
-          r_product /= (double)val->value.mal_integer;
-        }
-      }
-      /* double division */
-      else {
-        return_float = 1;
-        if (i_product != 1) {
-          r_product = (double)i_product / val->value.mal_float;
-          i_product = 1;
-        } else {
-          r_product /= val->value.mal_float;
-        }
-      }
-      args = args->next;
-    }
-  }
-
-  if (return_float) {
-    return make_float(r_product);
-  } else {
-    return make_integer(i_product);
-  }
-}
-
-MalType* mal_lessthan(list args) {
-
-  if (!args || !args->next || args->next->next) {
-    return make_error_fmt("'<': expected exactly two arguments");
-  }
-
-  MalType* first_val = args->data;
-  MalType* second_val = args->next->data;
-
-  if (!is_number(first_val) || !is_number(second_val)) {
-      return make_error_fmt("'<': expected numerical arguments");
-  }
-
-  int cmp = 0;
-
-  if (is_integer(first_val) && is_integer(second_val)) {
-    cmp = (first_val->value.mal_integer < second_val->value.mal_integer);
-  }
-  else if (is_integer(first_val) && is_float(second_val)) {
-    cmp = (first_val->value.mal_integer < second_val->value.mal_float);
-  }
-  else if (is_float(first_val) && is_integer(second_val)) {
-    cmp = (first_val->value.mal_float < second_val->value.mal_integer);
-  }
-  else if (is_float(first_val) && is_float(second_val)) {
-    cmp = (first_val->value.mal_float < second_val->value.mal_float);
-  }
-  else {
-    /* shouldn't happen unless new numerical type is added */
-    return make_error_fmt("'<': unknown numerical type");
-  }
-
-  if (cmp) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_lessthanorequalto(list args) {
-
-  if (!args || !args->next || args->next->next) {
-    return make_error_fmt("'<=': expected exactly two arguments");
-  }
-
-  MalType* first_val = args->data;
-  MalType* second_val = args->next->data;
-
-  if (!is_number(first_val) || !is_number(second_val)) {
-      return make_error_fmt("'<=': expected numerical arguments");
-  }
-
-  int cmp = 0;
-
-  if (is_integer(first_val) && is_integer(second_val)) {
-    cmp = (first_val->value.mal_integer <= second_val->value.mal_integer);
-  }
-  else if (is_integer(first_val) && is_float(second_val)) {
-    cmp = (first_val->value.mal_integer <= second_val->value.mal_float);
-  }
-  else if (is_float(first_val) && is_integer(second_val)) {
-    cmp = (first_val->value.mal_float <= second_val->value.mal_integer);
-  }
-  else if (is_float(first_val) && is_float(second_val)) {
-    cmp = (first_val->value.mal_float < second_val->value.mal_float);
-  }
-  else {
-    /* shouldn't happen unless new numerical type is added */
-    return make_error_fmt("'<=': unknown numerical type");
-  }
-
-  if (cmp) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_greaterthan(list args) {
-
-  if (!args || !args->next || args->next->next) {
-    return make_error_fmt("'>': expected exactly two arguments");
-  }
-
-  MalType* first_val = args->data;
-  MalType* second_val = args->next->data;
-
-  if (!is_number(first_val) || !is_number(second_val)) {
-      return make_error_fmt("'>': expected numerical arguments");
-  }
-
-  int cmp = 0;
-
-  if (is_integer(first_val) && is_integer(second_val)) {
-    cmp = (first_val->value.mal_integer > second_val->value.mal_integer);
-  }
-  else if (is_integer(first_val) && is_float(second_val)) {
-    cmp = (first_val->value.mal_integer > second_val->value.mal_float);
-  }
-  else if (is_float(first_val) && is_integer(second_val)) {
-    cmp = (first_val->value.mal_float > second_val->value.mal_integer);
-  }
-  else if (is_float(first_val) && is_float(second_val)) {
-    cmp = (first_val->value.mal_float > second_val->value.mal_float);
-  }
-  else {
-    /* shouldn't happen unless new numerical type is added */
-    return make_error_fmt("'>': unknown numerical type");
-  }
-
-  if (cmp) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_greaterthanorequalto(list args) {
-
-  if (!args || !args->next || args->next->next) {
-    return make_error_fmt("'>=': expected exactly two arguments");
-  }
-
-  MalType* first_val = args->data;
-  MalType* second_val = args->next->data;
-
-  if (!is_number(first_val) || !is_number(second_val)) {
-      return make_error_fmt("'>=': expected numerical arguments");
-  }
-
-  int cmp = 0;
-
-  if (is_integer(first_val) && is_integer(second_val)) {
-    cmp = (first_val->value.mal_integer >= second_val->value.mal_integer);
-  }
-  else if (is_integer(first_val) && is_float(second_val)) {
-    cmp = (first_val->value.mal_integer >= second_val->value.mal_float);
-  }
-  else if (is_float(first_val) && is_integer(second_val)) {
-    cmp = (first_val->value.mal_float >= second_val->value.mal_integer);
-  }
-  else if (is_float(first_val) && is_float(second_val)) {
-    cmp = (first_val->value.mal_float >= second_val->value.mal_float);
-  }
-  else {
-    /* shouldn't happen unless new numerical type is added */
-    return make_error_fmt("'>=': unknown numerical type");
-  }
-
-  if (cmp) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_equals(list args) {
+MalType mal_equals(list args) {
   /* Accepts any type of arguments */
 
-  if (!args || !args->next || args->next->next) {
-    return make_error_fmt("'=': expected exactly two arguments");
-  }
+  MalType first_val = eat_argument(args);
+  MalType second_val = eat_argument(args);
+  check_empty(args);
+  return make_boolean(equal_forms(first_val, second_val));
+}
 
-  MalType* first_val = args->data;
-  MalType* second_val = args->next->data;
-
-  if (is_sequential(first_val) && is_sequential(second_val)) {
-    return equal_lists(first_val, second_val);
-  }
-  else if (first_val->type != second_val->type) {
-    return make_false();
-  }
-  else {
+bool equal_forms(MalType first_val, MalType second_val) {
 
     switch(first_val->type) {
 
+    case MALTYPE_LIST:
+    case MALTYPE_VECTOR:
+
+      return (second_val->type & (MALTYPE_LIST | MALTYPE_VECTOR))
+        && equal_lists(first_val->value.mal_list, second_val->value.mal_list);
+
     case MALTYPE_INTEGER:
 
-      if (first_val->value.mal_integer == second_val->value.mal_integer) {
-        return make_true();
-      } else {
-        return make_false();
-      }
-      break;
+      return (second_val->type == MALTYPE_INTEGER)
+        && (first_val->value.mal_integer == second_val->value.mal_integer);
 
     case MALTYPE_FLOAT:
 
-      if (first_val->value.mal_float == second_val->value.mal_float) {
-        return make_true();
-      } else {
-        return make_false();
-      }
-      break;
+      return (second_val->type == MALTYPE_FLOAT)
+        && (first_val->value.mal_float == second_val->value.mal_float);
 
     case MALTYPE_SYMBOL:
-
-      if (strcmp(first_val->value.mal_symbol, second_val->value.mal_symbol) == 0) {
-        return make_true();
-      } else {
-        return make_false();
-      }
-      break;
-
     case MALTYPE_STRING:
-      if (strcmp(first_val->value.mal_string, second_val->value.mal_string) == 0) {
-        return make_true();
-      } else {
-        return make_false();
-      }
-      break;
-
     case MALTYPE_KEYWORD:
-      if (strcmp(first_val->value.mal_keyword, second_val->value.mal_keyword) == 0) {
-        return make_true();
-      } else {
-        return make_false();
-      }
-      break;
+      return (first_val->type == second_val->type)
+        && !strcmp(first_val->value.mal_string, second_val->value.mal_string);
 
     case MALTYPE_HASHMAP:
-      return equal_hashmaps(first_val, second_val);
-      break;
+      return (second_val->type == MALTYPE_HASHMAP)
+        && equal_hashmaps(first_val->value.mal_list, second_val->value.mal_list);
 
     case MALTYPE_TRUE:
     case MALTYPE_FALSE:
     case MALTYPE_NIL:
 
-      return make_true();
-      break;
+      return first_val == second_val;
 
-    case MALTYPE_FUNCTION:
+    default:
 
-      if (first_val->value.mal_function == second_val->value.mal_function) {
-        return make_true();
-      } else {
-        return make_false();
-      }
-      break;
+      return false;
+    }
+}
 
-    case MALTYPE_CLOSURE:
+MalType mal_nth(list args) {
 
-      if (&first_val->value.mal_closure == &second_val->value.mal_closure) {
-        return make_true();
-      } else {
-        return make_false();
-      }
-      break;
+  MalType lst = eat_argument(args);
+  MalType n = eat_argument(args);
+  check_empty(args);
+
+  list l = as_sequence(lst);
+  long idx = as_integer(n);
+  if(0 <= idx) {
+    while(l) {
+      if(!idx)
+        return l->data;
+      l = l->next;
+      idx--;
     }
   }
-  return make_false();
+  return make_error_fmt("index %M out of bounds for: %M", n, lst);
 }
 
-MalType* mal_list(list args) {
-  /* Accepts any number and type of arguments */
-  return make_list(args);
-}
+MalType mal_first(list args) {
 
-MalType* mal_nth(list args) {
+  MalType lst = eat_argument(args);
+  check_empty(args);
 
-  if (!args || !args->next || args->next->next) {
-    return make_error("'nth': Expected exactly two arguments");
+  if(is_nil(lst)) {
+    return make_nil();
+  }
+  else if(!is_sequential(lst)) {
+    return bad_type(lst, "a list, vector or nil");
   }
 
-  MalType* lst = args->data;
-  MalType* n = args->next->data;
-
-  if (!is_sequential(lst)) {
-    return make_error_fmt("'nth': first argument is not a list or vector: '%s'\n", pr_str(lst, UNREADABLY));
-  }
-
-  if (!is_integer(n)) {
-    return make_error_fmt("'nth': second argument is not an integer: '%s'\n", pr_str(lst, UNREADABLY));
-  }
-
-  MalType* result = list_nth(lst->value.mal_list, n->value.mal_integer);
+  list result = lst->value.mal_list;
 
   if (result) {
-    return result;
-  }
-  else {
-    return make_error_fmt("'nth': index %s out of bounds for: '%s'\n", \
-                          pr_str(n, UNREADABLY), pr_str(lst, UNREADABLY));
-  }
-}
-
-MalType* mal_first(list args) {
-
-  if (!args || args->next) {
-    return make_error("'first': expected exactly one argument");
-  }
-
-  MalType* lst = args->data;
-
-  if (!is_sequential(lst) && !is_nil(lst)) {
-    return make_error("'first': expected a list or vector");
-  }
-
-  MalType* result = list_first(lst->value.mal_list);
-
-  if (result) {
-    return result;
+    return result->data;
   }
   else {
     return make_nil();
   }
 }
 
-MalType* mal_rest(list args) {
+MalType mal_rest(list args) {
 
-  if (!args || args->next) {
-    return make_error("'rest': expected exactly one argument");
-  }
+  MalType lst = eat_argument(args);
+  check_empty(args);
 
-  MalType* lst = args->data;
-
-  if (!is_sequential(lst) && !is_nil(lst)) {
-    return make_error("'rest': expected a list or vector");
-  }
-
-  list result = list_rest(lst->value.mal_list);
-
-  if (lst) {
-    return make_list(result);
-  }
-  else {
-    return make_nil();
-  }
-}
-
-
-MalType* mal_cons(list args) {
-
-  if (!args || (args->next && args->next->next)) {
-    return make_error("'cons': Expected exactly two arguments");
-  }
-
-  MalType* lst = args->next->data;
-  if (is_sequential(lst)) {
-     return make_list(list_push(lst->value.mal_list, args->data));
-  }
-  else if (is_nil(lst)) {
-    return make_list(list_push(NULL, args->data));
-  }
-  else {
-    return make_error_fmt("'cons': second argument is not a list or vector: '%s'\n", \
-                          pr_str(lst, UNREADABLY));
-  }
-}
-
-MalType* mal_concat(list args) {
-
-  /* return an empty list for no arguments */
-  if (!args) {
+  if(is_nil(lst)) {
     return make_list(NULL);
   }
+  else if(!is_sequential(lst)) {
+    return bad_type(lst, "a list, vector or nil");
+  }
+
+  list result = lst->value.mal_list;
+  if (result) {
+    result = result->next;
+  }
+  return make_list(result);
+}
+
+
+MalType mal_cons(list args) {
+
+  MalType a1 = eat_argument(args);
+  MalType lst = eat_argument(args);
+  check_empty(args);
+
+  if (is_sequential(lst)) {
+    return make_list(list_push(lst->value.mal_list, a1));
+  }
+  else if (is_nil(lst)) {
+    return make_list(list_push(NULL, a1));
+  }
+  else {
+    return bad_type(lst, "a list, vector or nil");
+  }
+}
+
+MalType mal_concat(list args) {
+
+  //  Could reuse the last if it is not nil...
 
   list new_list = NULL;
+  list* new_list_last = &new_list;
   while (args) {
 
-    MalType* val = args->data;
+    MalType val = args->data;
 
     /* skip nils */
     if (is_nil(val)) {
-      args = args->next;
-      continue;
     }
     /* concatenate lists and vectors */
     else if (is_sequential(val)) {
-
-      list lst = val->value.mal_list;
-      new_list = list_concatenate(new_list, lst);
-      args = args->next;
+      for(list lst=val->value.mal_list; lst; lst=lst->next) {
+        *new_list_last = list_push(NULL, lst->data);
+        new_list_last = &(*new_list_last)->next;
+      }
     }
     /* raise an error for any non-sequence types */
     else {
-      return make_error_fmt("'concat': all arguments must be lists or vectors '%s'", \
-                            pr_str(val, UNREADABLY));
+      return bad_type(val, "a list, vector or nil");
     }
+    args = args->next;
   }
   return make_list(new_list);
 }
 
-MalType* mal_count(list args) {
+MalType mal_count(list args) {
 
-  if (args->next) {
-    return make_error_fmt("'count': too many arguments");
+  MalType val = eat_argument(args);
+  check_empty(args);
+
+  if(is_nil(val)) {
+    return make_integer(0);
   }
-
-  MalType* val = args->data;
-  if (!is_sequential(val) && !is_nil(val)) {
-        return make_error_fmt("'count': argument is not a list or vector: '%s'\n", \
-                              pr_str(val, UNREADABLY));
+  else if (!is_sequential(val)) {
+    return bad_type(val, "a list, vector or nil");
   }
   return make_integer(list_count(val->value.mal_list));
 }
 
+MalType mal_empty_questionmark(list args) {
 
-MalType* mal_list_questionmark(list args) {
+  MalType val = eat_argument(args);
+  check_empty(args);
 
-  if (args->next) {
-    return make_error_fmt("'list?': too many arguments");
-  }
-
-  MalType* val = args->data;
-  if (is_list(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
+  return make_boolean(!as_sequence(val));
 }
 
-MalType* mal_empty_questionmark(list args) {
-
-  if (args->next) {
-    return make_error_fmt("'empty?': too many arguments");
-  }
-
-  MalType* val = args->data;
-  if (!is_sequential(val)) {
-    return make_error_fmt("'empty?': argument is not a list or vector: '%s'\n", pr_str(val, UNREADABLY));
-  }
-
-  if (!val->value.mal_list) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_pr_str(list args) {
+MalType mal_pr_str(list args) {
   /* Accepts any number and type of arguments */
-  return as_str(args, READABLY, " ");
+  return make_string(mal_printf("% N", args));
 }
 
-MalType* mal_str(list args) {
+MalType mal_str(list args) {
   /* Accepts any number and type of arguments */
-  return as_str(args, UNREADABLY, "");
+  return make_string(mal_printf("%#N", args));
 }
 
-MalType* mal_prn(list args) {
+MalType mal_prn(list args) {
   /* Accepts any number and type of arguments */
-   return print(args, READABLY, " ");
+  printf("% N\n", args);
+  return make_nil();
 }
 
-MalType* mal_println(list args) {
+MalType mal_println(list args) {
   /* Accepts any number and type of arguments */
-  return print(args, UNREADABLY, " ");
+  printf("% #N\n", args);
+  return make_nil();
 }
 
-MalType* mal_read_string(list args) {
+MalType mal_read_string(list args) {
 
-  if (!args || args->next) {
-    return make_error_fmt("'read-string': expected exactly one argument");
-  }
-
-  MalType* val = args->data;
-  if (!is_string(val)) {
-    return make_error_fmt("'read-string': expected a string argument '%s'", pr_str(val, UNREADABLY));
-  }
-  return read_str(val->value.mal_string);
+  MalType val = eat_argument(args);
+  check_empty(args);
+  return read_str(as_string(val));
 }
 
-MalType* mal_slurp(list args) {
+MalType mal_slurp(list args) {
 
-  if (args->next) {
-    return make_error_fmt("'slurp': too many arguments");
-  }
+  MalType a1 = eat_argument(args);
+  check_empty(args);
 
-  MalType* filename = args->data;
-  if (!is_string(filename)) {
-    return make_error_fmt("'slurp': expected a string argument");
-  }
+  const char* filename = as_string(a1);
 
-  long file_length = 0;
-  FILE* file = fopen(filename->value.mal_string, "rb");
+  FILE* file = fopen(filename, "rb");
 
   if (!file){
-    return make_error_fmt("'slurp': file not found '%s'", pr_str(filename, UNREADABLY));
+    return make_error_fmt("file not found '%s'", filename);
   }
 
   fseek(file, 0, SEEK_END);
-  file_length = ftell(file);
+  size_t file_length = ftell(file);
   fseek(file, 0, SEEK_SET);
 
   char* buffer = (char*)GC_MALLOC(sizeof(*buffer) * file_length + 1);
   if (file_length != fread(buffer, sizeof(*buffer), file_length, file)) {
-    return make_error_fmt("'slurp': failed to read file '%s'", pr_str(filename, UNREADABLY));
+    return make_error_fmt("failed to read file '%s'", filename);
   }
 
   fclose(file);
@@ -894,400 +493,158 @@ MalType* mal_slurp(list args) {
   return make_string(buffer);
 }
 
-MalType* mal_atom(list args) {
-
-  if (!args || args->next) {
-    return make_error_fmt("'atom': expected exactly one argument");
-  }
-
-  MalType* val = args->data;
+MalType mal_atom(list args) {
+  MalType val = eat_argument(args);
+  check_empty(args);
   return make_atom(val);
 }
-
-MalType* mal_atom_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error_fmt("'atom?': expected exactly one argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_atom(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
+MalType mal_deref(list args) {
+  MalType val = eat_argument(args);
+  check_empty(args);
+  return *as_atom(val);
 }
-
-MalType* mal_deref(list args) {
-
-  if (!args || args->next) {
-    return make_error_fmt("'deref': expected exactly one argument");
-  }
-
-  MalType* val = args->data;
-
-  if (!is_atom(val)) {
-    return make_error_fmt("'deref': value is not an atom '%s'", pr_str(val, UNREADABLY));
-  }
-
-  return val->value.mal_atom;
+MalType mal_reset_bang(list args) {
+  MalType a1 = eat_argument(args);
+  MalType a2 = eat_argument(args);
+  check_empty(args);
+  *as_atom(a1) = a2;
+  return a2;
 }
-
-MalType* mal_reset_bang(list args) {
-
-  if (!args || args->next->next) {
-    return make_error_fmt("'reset!': expected exactly two arguments");
-  }
-
-  MalType* val = args->data;
-
-  if (!is_atom(val)) {
-    return make_error_fmt("'reset!': value is not an atom '%s'", pr_str(val, UNREADABLY));
-  }
-
-  val->value.mal_atom = args->next->data;
-  return args->next->data;
-}
-
-MalType* mal_swap_bang(list args) {
-
-  MalType* val = args->data;
-
-  if (!is_atom(val)) {
-    return make_error_fmt("'swap!': first argument is not an atom '%s'", pr_str(val, UNREADABLY));
-  }
-
-  MalType* fn = args->next->data;
-
-  if (!is_callable(fn)) {
-    return make_error_fmt("'swap!': second argument is not callable '%s'", pr_str(fn, UNREADABLY));
-  }
-
-  list fn_args = args->next->next;
-  fn_args = list_push(fn_args, val->value.mal_atom);
-
-  MalType* result = apply(fn, fn_args);
+MalType mal_swap_bang(list args) {
+  MalType a1 = eat_argument(args);
+  MalType fn = eat_argument(args);
+  MalType* atm = as_atom(a1);
+  list fn_args = list_push(args, *atm);
+  MalType result = apply(fn, fn_args);
 
   if (is_error(result)) {
     return result;
   }
   else {
-    val->value.mal_atom = result;
+    *atm = result;
     return result;
   }
 }
 
-MalType* mal_throw(list args) {
-
-  if (!args || args->next) {
-    return make_error_fmt("'throw': expected exactly one argument");
-  }
-
-  MalType* val = args->data;
+MalType mal_throw(list args) {
+  MalType val = eat_argument(args);
+  check_empty(args);
 
   /* re-throw an existing exception */
-  if (is_error(val)) {
-    return val;
-  }
+  assert(!is_error(val));
   /* create a new exception */
-  else {
     return wrap_error(val);
-  }
 }
 
-MalType* mal_apply(list args) {
+MalType mal_apply(list args) {
 
-  if (!args || !args->next) {
-    return make_error("'apply': expected at least two arguments");
-  }
-
-  MalType* func = args->data;
-
-  if (!is_callable(func)) {
-    return make_error("'apply': first argument must be callable");
+  MalType func = eat_argument(args);
+  if(!args) {
+    return make_error_fmt("expected at least two arguments");
   }
 
   /* assemble loose arguments */
-  args = args->next;
   list lst = NULL;
+  list* lst_last = &lst;
   while(args->next) {
-    lst = list_push(lst, args->data);
+    *lst_last = list_push(NULL, args->data);
+    lst_last = &(*lst_last)->next;
     args = args->next;
   }
 
-  MalType* final = args->data;
+  MalType final = args->data;
 
-  if (is_sequential(final)) {
-    lst = list_concatenate(list_reverse(lst), final->value.mal_list);
-  }
-  else {
-    lst = list_push(lst, final);
-    lst = list_reverse(lst);
-  }
+  *lst_last = as_sequence(final);
 
   return apply(func, lst);
 }
 
-MalType* mal_map(list args) {
+MalType mal_map(list args) {
 
-  if (!args || !args->next || args->next->next) {
-    return make_error("'map': expected two arguments");
-  }
-
-  MalType* func = args->data;
+  MalType func = eat_argument(args);
+  MalType arg = eat_argument(args);
+  check_empty(args);
 
   if (!is_callable(func)) {
-    return make_error("'map': first argument must be a function");
+    //  This check is not redundant when arg is empty.
+    return bad_type(func, "a closure, function or macro");
   }
 
-  MalType* arg = args->next->data;
-
-  if (!is_sequential(arg)) {
-    return make_error("'map': second argument must be a list or vector");
-  }
-
-  list arg_list = arg->value.mal_list;
+  list arg_list = as_sequence(arg);
   list result_list = NULL;
+  list* result_list_last = &result_list;
 
   while(arg_list) {
 
-    MalType* result = apply(func, list_make(arg_list->data));
+    MalType result = apply(func, list_push(NULL, arg_list->data));
 
     /* early return if error */
     if (is_error(result)) {
       return result;
     }
     else {
-      result_list = list_push(result_list, result);
+      *result_list_last = list_push(NULL, result);
+      result_list_last = &(*result_list_last)->next;
+
     }
     arg_list = arg_list->next;
   }
-  return make_list(list_reverse(result_list));
+  return make_list(result_list);
 }
 
-MalType* mal_nil_questionmark(list args) {
+MalType mal_symbol(list args) {
+  MalType val = eat_argument(args);
+  check_empty(args);
 
-  if (!args || args->next) {
-    return make_error("'nil?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_nil(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
+  return make_symbol(as_string(val));
 }
 
-MalType* mal_true_questionmark(list args) {
+MalType mal_keyword(list args) {
 
-  if (!args || args->next) {
-    return make_error("'true?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_true(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_false_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'false?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_false(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_symbol_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'symbol?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_symbol(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_symbol(list args) {
-
-  if (!args || args->next) {
-    return make_error("'symbol': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (!is_string(val)) {
-    return make_error("'symbol': expected a string argument");
-  }
-  else {
-    return make_symbol(val->value.mal_string);
-  }
-}
-
-MalType* mal_keyword(list args) {
-
-  if (!args || args->next) {
-    return make_error("'keyword': expected a single argument");
-  }
-
-  MalType* val = args->data;
+  MalType val = eat_argument(args);
+  check_empty(args);
 
   if (!is_string(val) && !is_keyword(val)) {
-    return make_error("'keyword': expected a string argument");
+    return bad_type(val, "a keyword or string");
   }
   else {
     return make_keyword(val->value.mal_string);
   }
 }
 
-MalType* mal_keyword_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'keyword?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_keyword(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_vec(list args) {
+MalType mal_vec(list args) {
 
   /* Accepts a single argument */
 
-  if (!args || args->next) {
-    return make_error("'vec': expected a single argument");
+  MalType val = eat_argument(args);
+  check_empty(args);
+
+  if(!is_vector(val) && !is_list(val)) {
+    return bad_type(val, "a list or vector");
   }
 
-  MalType* val = args->data;
-
-  if (!is_vector(val) && !is_list(val) && !is_hashmap(val)) {
-    return make_error("'vec': expected a vector, list or hashmap");
-  }
-
-  MalType* new_val = copy_type(val);
-  new_val->type = MALTYPE_VECTOR;
+  MalType new_val = make_vector(val->value.mal_list);
 
   return new_val;
 }
 
-MalType* mal_vector(list args) {
-  /* Accepts any number and type of arguments */
-  return make_vector(args);
-}
-
-MalType* mal_vector_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'vector?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_vector(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_sequential_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'sequential?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_sequential(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_hash_map(list args) {
-
-  if (args && list_count(args) % 2 == 1) {
-    return make_error("'hashmap': odd number of arguments, expected key/value pairs");
-  }
-
-  list args_iterator = args;
-  while (args_iterator) {
-
-    MalType* val = args_iterator->data;
-
-    if (!is_keyword(val) && !is_string(val) && !is_symbol(val)) {
-      return make_error("'hashmap': keys must be keywords, symbols or strings");
-    }
-    args_iterator = args_iterator->next;
-    args_iterator = args_iterator->next;
-  }
-
-  return make_hashmap(args);
-}
-
-MalType* mal_map_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'map?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_hashmap(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-
-MalType* mal_get(list args) {
+MalType mal_get(list args) {
   /* TODO: implement a proper hashmap */
 
-  if (!args || args->next->next) {
-    return make_error("'get': expected exactly two arguments");
+  MalType map = eat_argument(args);
+  MalType key = eat_argument(args);
+  check_empty(args);
+
+  check_type(key, MALTYPE_KEYWORD | MALTYPE_STRING, "a keyword or string");
+
+  if(is_nil(map)) {
+    return make_nil();
+  }
+  else if(!is_hashmap(map)) {
+    return bad_type(map, "a map or nil");
   }
 
-  MalType* map = args->data;
-
-  if (!is_hashmap(map) && !is_nil(map)) {
-    return make_error("'get': expected a map for the first argument");
-  }
-
-  MalType* result = hashmap_getf(map->value.mal_list, get_fn(args->next->data), get_fn);
+  MalType result = hashmap_get(map->value.mal_list, key);
 
   if (!result) {
     return make_nil();
@@ -1296,19 +653,22 @@ MalType* mal_get(list args) {
   return result;
 }
 
-MalType* mal_contains_questionmark(list args) {
+MalType mal_contains_questionmark(list args) {
 
-  if (!args || args->next->next) {
-    return make_error("'contains?': expected exactly two arguments");
+  MalType map = eat_argument(args);
+  MalType key = eat_argument(args);
+  check_empty(args);
+
+  check_type(key, MALTYPE_KEYWORD | MALTYPE_STRING, "a keyword or string");
+
+  if(is_nil(map)) {
+    return make_nil();
   }
-
-  MalType* map = args->data;
-
   if (!is_hashmap(map)) {
-    return make_error("'contains?': expected a map for the first argument");
+    return bad_type(map, "a map or nil");
   }
 
-  MalType* result = hashmap_getf(map->value.mal_list, get_fn(args->next->data), get_fn);
+  MalType result = hashmap_get(map->value.mal_list, key);
 
   if (!result) {
     return make_false();
@@ -1318,59 +678,21 @@ MalType* mal_contains_questionmark(list args) {
   }
 }
 
-MalType* mal_assoc(list args) {
-
-  if (!args || !args->next || !args->next->next) {
-    return make_error("'assoc': expected at least three arguments");
-  }
-
-  MalType* map = args->data;
-
-  if (!is_hashmap(map)) {
-    return make_error("'assoc': expected a map for the first argument");
-  }
-
-  if (list_count(args->next)%2 != 0) {
-    return make_error("'assoc': expected even number of key/value pairs");
-  }
-
-
-  list new_lst = list_reverse(list_copy(map->value.mal_list));
-  args = args->next;
-
-  while (args) {
-
-    /* try to update copy in-place */
-    hashmap result = hashmap_updatef(new_lst, get_fn(args->data), args->next->data, get_fn);
-
-    if (result) {
-      new_lst = result;
-    }
-    /* add a new key/value pair */
-    else {
-      new_lst = list_push(new_lst,args->next->data);
-      new_lst = list_push(new_lst,args->data);
-    }
-    args = args->next->next;
-  }
-  return make_hashmap(new_lst);
+MalType mal_assoc(list args) {
+  MalType map = eat_argument(args);
+  return map_assoc(as_map(map), args);
 }
 
-MalType* mal_dissoc(list args) {
+MalType mal_dissoc(list args) {
 
-  if (!args || !args->next) {
-    return make_error("'dissoc': expected at least two arguments");
+  MalType map = eat_argument(args);
+  for(list p=args; p; p=p->next) {
+    check_type(p->data, MALTYPE_KEYWORD | MALTYPE_STRING,
+               "a keyword or string");
   }
 
-  MalType* map = args->data;
-
-  if (!is_hashmap(map)) {
-    return make_error("'dissoc': expected a map for the first argument");
-  }
-
-  list source_list = map->value.mal_list;
+  list source_list = as_map(map);
   list new_list = NULL;
-  args = args->next;
 
   while(source_list) {
 
@@ -1380,12 +702,7 @@ MalType* mal_dissoc(list args) {
 
     while(dis_args) {
 
-      list tmp = NULL;
-      tmp = list_push(tmp, source_list->data);
-      tmp = list_push(tmp, dis_args->data);
-      MalType* cmp = mal_equals(tmp);
-
-      if (is_true(cmp)) {
+      if(equal_forms(source_list->data, dis_args->data)) {
         dis = 1;
         break;
       }
@@ -1393,137 +710,50 @@ MalType* mal_dissoc(list args) {
     }
 
     if (!dis) {
-      new_list = list_push(new_list, source_list->data);
       new_list = list_push(new_list, source_list->next->data);
+      new_list = list_push(new_list, source_list->data);
     }
     source_list = source_list->next->next;
   }
 
-  return make_hashmap(list_reverse(new_list));
+  return make_hashmap(new_list);
 }
 
 
-MalType* mal_keys(list args) {
+ MalType mal_keys(list args) {
 
-  if (!args || args->next) {
-    return make_error("'keys': expected exactly one argument");
-  }
+  MalType map = eat_argument(args);
+  check_empty(args);
 
-  MalType* map = args->data;
+  list lst = as_map(map);
 
-  if (!is_hashmap(map)) {
-    return make_error("'keys': expected a map");
-  }
+  list result = NULL;
+  while(lst) {
 
-  list lst = map->value.mal_list;
-  if (!lst) {
-    return make_list(NULL);
-  }
-
-  list result = list_make(lst->data);
-  while(lst->next->next) {
-
-    lst = lst->next->next;
     result = list_push(result, lst->data);
+    lst = lst->next->next;
   }
   return make_list(result);
 }
 
-MalType* mal_vals(list args) {
+MalType mal_vals(list args) {
 
-  if (!args || args->next) {
-    return make_error("'vals': expected exactly one argument");
-  }
+  MalType map = eat_argument(args);
+  check_empty(args);
 
-  MalType* map = args->data;
+  list lst = as_map(map);
 
-  if (!is_hashmap(map)) {
-    return make_error("'vals': expected a map");
-  }
+  list result = NULL;
+  while(lst) {
 
-  list lst = map->value.mal_list;
-  if (!lst) {
-    return make_list(NULL);
-  }
-
-  lst = lst->next;
-  list result = list_make(lst->data);
-  while(lst->next) {
-
-    lst = lst->next->next;
-    result = list_push(result, lst->data);
+    result = list_push(result, lst->next->data);
+    lst=lst->next->next;
   }
   return make_list(result);
 }
 
-MalType* mal_string_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'string?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_string(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-
-MalType* mal_number_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'number?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_number(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-
-MalType* mal_fn_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'fn?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_callable(val) && !is_macro(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-MalType* mal_macro_questionmark(list args) {
-
-  if (!args || args->next) {
-    return make_error("'macro?': expected a single argument");
-  }
-
-  MalType* val = args->data;
-
-  if (is_macro(val)) {
-    return make_true();
-  }
-  else {
-    return make_false();
-  }
-}
-
-
-MalType* mal_time_ms(list args) {
+MalType mal_time_ms(list args) {
+  check_empty(args);
 
   struct timeval tv;
   gettimeofday(&tv, NULL);
@@ -1533,54 +763,46 @@ MalType* mal_time_ms(list args) {
 }
 
 
-MalType* mal_conj(list args) {
+MalType mal_conj(list args) {
 
-  if (!args || !args->next) {
-    return make_error("'conj': Expected at least two arguments");
-  }
+  MalType lst = eat_argument(args);
 
-  MalType* lst = args->data;
-
-  if (!is_sequential(lst)) {
-    return make_error_fmt("'conj': first argument is not a list or vector: '%s'\n", \
-                          pr_str(lst, UNREADABLY));
-  }
-
-  list rest = args->next;
+  list rest = args;
 
   if (is_list(lst)) {
 
-    list new_lst = list_reverse(list_copy(lst->value.mal_list));
-
-    while(rest) {
-      new_lst = list_push(new_lst, rest->data);
-      rest = rest->next;
-  }
-    return make_list(new_lst);
-  }
-  else /* is_vector(lst) */ {
-
-    list new_lst = list_copy(lst->value.mal_list);
+    list new_lst = lst->value.mal_list;
 
     while(rest) {
       new_lst = list_push(new_lst, rest->data);
       rest = rest->next;
     }
-    return make_vector(list_reverse(new_lst));
+    return make_list(new_lst);
+  }
+  else if(is_vector(lst)) {
+
+    list new_lst = NULL;
+    list* new_lst_last = &new_lst;
+    for(list v=lst->value.mal_list; v; v=v->next) {
+      *new_lst_last = list_push(NULL, v->data);
+      new_lst_last = &(*new_lst_last)->next;
+    }
+    *new_lst_last = rest;
+    return make_vector(new_lst);
+  }
+  else {
+    return bad_type(lst, "a list or vector");
   }
 }
 
-MalType* mal_seq(list args) {
+MalType mal_seq(list args) {
 
-  if (!args || args->next) {
-    return make_error("'seq': expected exactly one argument");
-  }
-
-  MalType* val = args->data;
+  MalType val = eat_argument(args);
+  check_empty(args);
 
   if (is_sequential(val)) {
 
-    /* empy list or vector */
+    /* empty list or vector */
     if (!val->value.mal_list) {
       return make_nil();
     }
@@ -1590,286 +812,175 @@ MalType* mal_seq(list args) {
   }
   else if (is_string(val)) {
 
+    const char* ch = val->value.mal_string;
+
     /* empty string */
-    if (*(val->value.mal_string) == '\0') {
+    if (*ch == '\0') {
       return make_nil();
     }
     else {
 
-      char* ch = val->value.mal_string;
       list lst = NULL;
+      list* lst_last = &lst;
 
       while(*ch != '\0') {
-        char* new_ch = GC_MALLOC(sizeof(*new_ch));
-        strncpy(new_ch, ch, 1);
+        char* new_ch = GC_MALLOC(2);
+        new_ch[0] = *ch;
+        new_ch[1] = 0;
 
-        lst = list_push(lst, make_string(new_ch));
+        *lst_last = list_push(NULL, make_string(new_ch));
+        lst_last = &(*lst_last)->next;
         ch++;
       }
-      return make_list(list_reverse(lst));
+      return make_list(lst);
     }
   }
   else if (is_nil(val)) {
     return make_nil();
   }
   else {
-    return make_error("'seq': expected a list, vector or string");
+    return bad_type(val, "nil, a list, vector or string");
   }
 }
 
-MalType* mal_meta(list args) {
+MalType mal_meta(list args) {
 
-  if (!args || args->next) {
-    return make_error("'meta': expected exactly one argument");
-  }
-
-  MalType* val = args->data;
+  MalType val = eat_argument(args);
+  check_empty(args);
 
   if (!is_sequential(val) && !is_hashmap(val) && !is_callable(val)) {
-    return make_error("'meta': metadata not supported for data type");
+    return bad_type(val, "a sequence, map or callable");
   }
-
-  if (!val->metadata) {
-    return make_nil();
-  } else {
     return val->metadata;
-  }
 }
 
-MalType* mal_with_meta(list args) {
+MalType mal_with_meta(list args) {
 
-  if (!args || !args->next || args->next->next) {
-    return make_error("'with-meta': expected exactly two arguments");
-  }
-
-  MalType* val = args->data;
+  MalType val = eat_argument(args);
+  MalType metadata = eat_argument(args);
+  check_empty(args);
 
   if (!is_sequential(val) && !is_hashmap(val) && !is_callable(val)) {
-    return make_error("'with-meta': metadata not supported for data type");
+    return bad_type(val, "a sequence, map or callable");
   }
 
-  MalType* metadata = args->next->data;
-
-  MalType* new_val = copy_type(val);
-  new_val->metadata = metadata;
+  MalType new_val = with_meta(val, metadata);
 
   return new_val;
+}
+
+MalType mal_readline(list args) {
+  MalType a1 = eat_argument(args);
+  check_empty(args);
+
+  char* str = readline(as_string(a1));
+  if(!str)
+    return make_nil();
+  add_history(str);
+  /* Copy the input into an area managed by libgc. */
+  size_t n = strlen(str) + 1;
+  char* result = GC_MALLOC(n);
+  memcpy(result, str, n);
+  free(str);
+  return make_string(result);
 }
 
 
 /* helper functions */
 
-MalType* as_str(list args, int readably, char* separator) {
-
-  long buffer_length = STRING_BUFFER_SIZE;
-  long separator_length = strlen(separator);
-  char* buffer = GC_MALLOC(sizeof(*buffer) * STRING_BUFFER_SIZE);
-  long char_count = 0;
-
-  while(args) {
-
-    MalType* arg = args->data;
-    char* str = pr_str(arg, readably);
-    int len = strlen(str);
-
-    char_count += len;
-    char_count += separator_length;
-    if (char_count >= buffer_length) {
-      buffer = GC_REALLOC(buffer, sizeof(*buffer) * char_count + 1);
-    }
-
-    strncat(buffer, str, char_count);
-    args = args->next;
-
-    if (args) {
-      strcat(buffer, separator);
-    }
-  }
-  return make_string(buffer);
+inline MalType make_boolean(bool x) {
+  return x ? make_true() : make_false();
 }
 
-MalType* print(list args, int readably, char* separator) {
+bool equal_lists(list first, list second) {
 
-  while(args) {
-
-    printf("%s", pr_str(args->data, readably));
-    args = args->next;
-
-    if (args) {
-      printf("%s", separator);
-    }
+  while(first != NULL) {
+    if(second == NULL || !equal_forms(first->data, second->data))
+      return false;
+    first = first->next;
+    second = second->next;
   }
-  printf("\n");
-
-  return make_nil();
+  return second == NULL;
 }
 
-MalType* equal_lists(MalType* list1, MalType* list2) {
+bool equal_hashmaps(list first, list second) {
 
-  list first = list1->value.mal_list;
-  list second = list2->value.mal_list;
-
-  if (list_count(first) != list_count(second)) {
-    return make_false();
-  }
-  else {
-
-    while(first && second) {
-
-      list args = NULL;
-      args = list_push(args, second->data);
-      args = list_push(args, first->data);
-
-      MalType* cmp = mal_equals(args);
-
-      if (is_false(cmp)) {
-        return make_false();
-        break;
-      }
-      first = first->next;
-      second = second->next;
+  //  Check that the lists have the same count.
+  if(list_count(first) != list_count(second))
+    return false;
+  while(first) {
+    MalType val = hashmap_get(second, first->data);
+    first = first->next;
+    if(!val || !equal_forms(first->data, val)) {
+      return false;
     }
-    return make_true();
+    first = first->next;
   }
+  return true;
 }
 
-MalType* equal_hashmaps(MalType* map1, MalType* map2) {
-
-  list first = map1->value.mal_list;
-  list second = map2->value.mal_list;
-
-  if (!first && !second) {
-    return make_true();
-  }
-
-  if (list_count(first) != list_count(second)) {
-    return make_false();
-  }
-
-  while (first) {
-
-    MalType* key1 = first->data;
-    MalType* val1 = first->next->data;
-    MalType* val2 = hashmap_getf(second, get_fn(key1), get_fn);
-
-    if (!val2) {
-      return make_false();
-    }
-
-    list args = NULL;
-    args = list_push(args, val1);
-    args = list_push(args, val2);
-
-    MalType* cmp = mal_equals(args);
-
-    if (is_false(cmp)) {
-      return make_false();
-      break;
-    }
-    first = first->next->next;
-  }
-  return make_true();
-}
-
-/* helper function for get */
-char* get_fn(gptr data) {
-
-  MalType* val = data;
-
-  switch (val->type) {
-
-  case MALTYPE_STRING:
-
-    return (val->value.mal_string);
-    break;
-
-  case MALTYPE_SYMBOL:
-
-    return (val->value.mal_symbol);
-    break;
-
-  case MALTYPE_KEYWORD:
-
-    return (val->value.mal_keyword);
-    break;
-
-  default:
-    return NULL;
-  }
-}
 
 #ifdef WITH_FFI
-MalType* mal_dot(list args) {
+MalType mal_dot(list args) {
 
   /* (. "lib" "return type" "function" "arg1 type" "arg 1" ...) */
 
-  if (!args || !args->next || !args->next->next) {
-    return make_error("'.': expected at least three arguments");
+  MalType lib_name = eat_argument(args);
+
+  const char* lib_name_str = NULL;
+  if (is_string(lib_name)) {
+    lib_name_str = lib_name->value.mal_string;
+  }
+  else if (!is_nil(lib_name)) {
+    return bad_type(lib_name, "a string or nil");
   }
 
-  MalType* lib_name = (MalType*)args->data;
+  MalType return_type = eat_argument(args);
 
-  if (!is_string(lib_name) && !is_nil(lib_name)) {
-    return make_error("'.': expected library name or nil for first argument");
-  }
+  const char* return_type_str = as_string(return_type);
 
-  MalType* return_type = (MalType*)args->next->data;
+  MalType fn_name = eat_argument(args);
 
-  if (!is_string(return_type)) {
-    return make_error("'.': expected string (return type) for second argument");
-  }
+  const char* fn_name_str = as_string(fn_name);
 
-  MalType* fn_name = (MalType*)args->next->next->data;
-
-  if (!is_string(fn_name)) {
-    return make_error("'.': expected string (function name) for third argument");
-  }
-
-  int args_count = list_count(args) - 3;
+  int args_count = list_count(args);
 
   if (args_count % 2 == 1) {
-    return make_error("'.': expected even number of argument types and values");
+    return make_error_fmt("expected even number of argument types and values");
   }
 
   list arg_types_list = NULL;
+  list* arg_types_list_last = &arg_types_list;
   list arg_vals_list = NULL;
+  list* arg_vals_list_last = &arg_vals_list;
 
-  args = args->next->next->next;
   while(args) {
 
-    MalType* val_type = (MalType*)args->data;
-    MalType* val = (MalType*)args->next->data;
+    MalType val_type = (MalType)args->data;
+    args = args->next;
+    MalType val = eat_argument(args);  // check that the argument is present
 
-    if (!is_string(val_type))  {
-      return make_error_fmt("'.': expected strings for argument types: '%s'", pr_str(val_type, UNREADABLY));
-    }
+    as_string(val_type);        // Just for the type check.
 
-    arg_types_list = list_push(arg_types_list, val_type);
-    arg_vals_list = list_push(arg_vals_list, val);
-
-    args = args->next->next;
+    *arg_types_list_last = list_push(NULL, val_type);
+    arg_types_list_last = &(*arg_types_list_last)->next;
+    *arg_vals_list_last = list_push(NULL, val);
+    arg_vals_list_last = &(*arg_vals_list_last)->next;
   }
-
-  arg_types_list = list_reverse(arg_types_list);
-  arg_vals_list = list_reverse(arg_vals_list);
 
   /* open a shared library dynamically and get hold of a function */
-  gptr lib_handle;
-  if (!is_nil(lib_name)) {
-    lib_handle = dlopen(lib_name->value.mal_string, RTLD_LAZY);
-  } else {
-    lib_handle = dlopen(NULL, RTLD_LAZY);
-  }
+  void* lib_handle = dlopen(lib_name_str, RTLD_LAZY);
 
   if (!lib_handle) {
-    return make_error_fmt("'ffi`' reports: %s", dlerror());
+    return make_error_fmt("%s", dlerror());
   }
 
-  gptr fn = dlsym(lib_handle, fn_name->value.mal_string);
+  void* fn = dlsym(lib_handle, fn_name_str);
 
   char* error;
   if ((error = dlerror()) != NULL) {
-    return make_error_fmt("'ffi' dlsym could not get handle to function '%s': %s", fn_name->value.mal_string, error);
+    return make_error_fmt("dlsym could not get handle to function '%s': %s",
+          fn_name_str, error);
   }
 
   /* use libffi to call function */
@@ -1879,28 +990,30 @@ MalType* mal_dot(list args) {
   ffi_type* arg_types[20];
   void* arg_vals[20];
   ffi_status status;
-  ffi_type* ffi_get_type(char *type, MalType* err);
+  ffi_type* ffi_get_type(const char *type, MalType* err);
 
-  MalType* mal_err = make_nil();
+  MalType mal_err = make_nil();
 
   /* set return type */
-  MalType* make_type(char *type);
-  MalType* retval = make_type(return_type->value.mal_string);
+  MalType make_type(const char *type);
+  MalType immutable_retval = make_type(return_type_str);
+  struct MalType_s* retval = GC_MALLOC(sizeof(*retval));
+  *retval = *immutable_retval;;
 
-  ret_type = ffi_get_type(return_type->value.mal_string, mal_err);
-  if (is_error(mal_err)) { return mal_err; }
+  ret_type = ffi_get_type(return_type_str, &mal_err);
+  if(is_error(mal_err)) { return mal_err; }
 
   int arg_count = list_count(arg_types_list);
 
   /* Set the argument types and values */
   for (int i = 0; i < arg_count; i++) {
 
-    MalType* val_type = (MalType*)arg_types_list->data;
-    arg_types[i] = ffi_get_type(val_type->value.mal_string, mal_err);
+    MalType val_type = (MalType)arg_types_list->data;
+    arg_types[i] = ffi_get_type(as_string(val_type), &mal_err);
     if (is_error(mal_err)) { return mal_err; }
 
-    MalType* val = (MalType*)arg_vals_list->data;
-    arg_vals[i] = &(val->value);
+    MalType val = (MalType)arg_vals_list->data;
+    arg_vals[i] = (void*)(&(val->value));
 
     arg_types_list = arg_types_list->next;
     arg_vals_list = arg_vals_list->next;
@@ -1910,7 +1023,7 @@ MalType* mal_dot(list args) {
   status = ffi_prep_cif(&cif, FFI_DEFAULT_ABI, arg_count, ret_type, arg_types);
 
   if (status != FFI_OK) {
-    return make_error_fmt("'ffi' call to ffi_prep_cif failed with code: %d\n", status);
+    return make_error_fmt("call to ffi_prep_cif failed with code: %d", status);
   }
 
   ffi_call(&cif, FFI_FN(fn), &retval->value, arg_vals);
@@ -1926,7 +1039,7 @@ MalType* mal_dot(list args) {
 }
 
 /* helper function for ffi */
-ffi_type* ffi_get_type(char *type, MalType* err) {
+ffi_type* ffi_get_type(const char *type, MalType* err) {
 
   if ((strcmp("void", type) == 0)) {
 
@@ -1955,13 +1068,13 @@ ffi_type* ffi_get_type(char *type, MalType* err) {
     return &ffi_type_float;
   }
   else {
-    err = make_error_fmt("'ffi' type not recognised '%'", type);
+    *err = make_error_fmt("type not recognised '%s'", type);
     return NULL;
   }
 }
 
 /* helper function for ffi */
-MalType* make_type(char *type) {
+MalType make_type(const char *type) {
 
   if ((strcmp("void", type) == 0)) {
 
@@ -1990,7 +1103,7 @@ MalType* make_type(char *type) {
     return make_float(0);
   }
   else {
-    return make_error_fmt("'ffi' type not supported '%s'", type);
+    return make_error_fmt("type not supported '%s'", type);
   }
 }
 #endif

--- a/impls/c.2/core.h
+++ b/impls/c.2/core.h
@@ -1,22 +1,17 @@
 #ifndef _MAL_CORE_H
 #define _MAL_CORE_H
 
-#include "libs/hashmap/hashmap.h"
 #include "types.h"
 
-typedef struct ns_s ns;
+typedef const struct ns_s* ns;
 
 struct ns_s {
 
-  hashmap mappings;
+  const char* key;
+  function_t value;
 
 };
 
-ns* ns_make_core();
-MalType* as_str(list args, int readably, char* separator);
-MalType* print(list args, int readably, char* separator);
-char* get_fn(gptr data);
-MalType* equal_lists(MalType* lst1, MalType* lst2);
-MalType* equal_hashmaps(MalType* map1, MalType* map2);
+void ns_make_core(ns* core, size_t* size);
 
 #endif

--- a/impls/c.2/env.c
+++ b/impls/c.2/env.c
@@ -1,50 +1,58 @@
-#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+
 #include <gc.h>
 
-#include "libs/hashmap/hashmap.h"
-#include "types.h"
 #include "env.h"
-#include "reader.h"
 
-/* Note: caller must make sure enough exprs to match symbols */
-Env* env_make(Env* outer, list symbol_list, list exprs_list, MalType* more_symbol) {
+// Binary trees here are much easyer than for hash maps because there
+// is one key type and we can update the structure in place.
+// This costs less than a hashmap for little dictionnaries,
+// while helping a lot for the REPL environment.
 
-  Env*  env = GC_MALLOC(sizeof(*env));
+struct bind_s {
+  const char* key;
+  MalType value;
+  struct bind_s* left;
+  struct bind_s* right;
+};
+
+struct Env_s {
+  const Env*     outer;
+  struct bind_s* data;
+};
+
+Env* env_make(const Env* outer) {
+  struct Env_s* env = GC_MALLOC(sizeof(*env));
   env->outer = outer;
   env->data = NULL;
-
-  while (symbol_list) {
-
-    env_set(env, ((MalType*)symbol_list->data)->value.mal_symbol, exprs_list->data);
-
-    symbol_list = symbol_list->next;
-    exprs_list = exprs_list->next;
-  }
-
-  /* set the 'more' symbol if there is one */
-  if (more_symbol) {
-    env_set(env, more_symbol->value.mal_symbol, make_list(exprs_list));
-  }
   return env;
 }
 
-void env_set(Env* current, char* symbol, MalType* value) {
+void env_set(Env* current, const char* symbol, MalType value) {
 
-  current->data = hashmap_put(current->data, symbol, value);
-
+  struct bind_s** p = &current->data;
+  while(*p) {
+    int cmp = strcmp(symbol, (*p)->key);
+    if(cmp == 0) {
+      (*p)->value = value;;
+      return;
+    }
+    p = cmp < 0 ? &((*p)->left) : &((*p)->right);
+  }
+  *p = GC_MALLOC(sizeof(**p));
+  **p = (struct bind_s){ .key=symbol, .value=value, .left=NULL, .right=NULL};
 }
 
-MalType* env_get(Env* current, char* symbol) {
-
-  MalType* val = hashmap_get(current->data, symbol);
-
-  if (val) {
-    return val;
-  }
-  else if (current->outer) {
-    return env_get(current->outer, symbol);
-  }
-  else {
-    return NULL; /* not found */
-  }
+MalType env_get(const Env* current, const char* symbol) {
+  do {
+    const struct bind_s* p = current->data;
+    while(p != NULL) {
+      int cmp = strcmp(symbol, p->key);
+      if(cmp == 0)
+        return p->value;
+      p = cmp < 0 ? p->left : p->right;
+    }
+  } while((current = current->outer));
+  return NULL;
 }

--- a/impls/c.2/env.h
+++ b/impls/c.2/env.h
@@ -1,21 +1,16 @@
 #ifndef _MAL_ENV_H
 #define _MAL_ENV_H
 
-#include "libs/linked_list/linked_list.h"
-#include "libs/hashmap/hashmap.h"
 #include "types.h"
 
-typedef struct Env_s Env;
+//  types.h defines Env as struct Env_s.
 
-struct Env_s {
+Env* env_make(const Env* outer);
 
-  struct Env_s* outer;
-  hashmap data;
+void env_set(Env* current, const char* symbol, MalType value);
+/* can be called at most max times. */
 
-};
-
-Env* env_make(Env* outer, list binds, list exprs, MalType* variadic_symbol);
-void env_set(Env* current, char* symbol, MalType* value);
-MalType* env_get(Env* current, char* symbol);
+MalType env_get(const Env* current, const char* symbol);
+/* Returns NULL if the symbol is not found. */
 
 #endif

--- a/impls/c.2/libs/hashmap/hashmap.h
+++ b/impls/c.2/libs/hashmap/hashmap.h
@@ -2,14 +2,23 @@
 #define _MAL_HASHMAP_H
 
 #include "../linked_list/linked_list.h"
+#include "../../types.h"
 
 /* a hashmap is just a list with alternating key/value pairs */
+//  Keys are strings or keywords.
+//  Each key appears only once.
 typedef list hashmap;
 
-hashmap hashmap_make(char* keystring, gptr data_ptr);
-hashmap hashmap_put(hashmap map, char* keystring, gptr data_ptr);
-gptr hashmap_get(hashmap map, char* keystring);
-gptr hashmap_getf(hashmap map, char* keystring, char*(*fn)(gptr));
-hashmap hashmap_updatef(hashmap map, char* keystring, gptr value, char*(*fn)(gptr));
+hashmap hashmap_put(hashmap, MalType, MalType);
+// Check the key type
+// Remove duplicates.
+
+MalType hashmap_get(hashmap, MalType);
+
+MalType map_assoc(hashmap, list);
+// Deliberately reverse the bindings so that the last key takes
+// precedence.  Remove duplicates.
+
+MalType mal_hash_map(list args);
 
 #endif

--- a/impls/c.2/libs/linked_list/linked_list.c
+++ b/impls/c.2/libs/linked_list/linked_list.c
@@ -1,171 +1,25 @@
-#include <stdio.h>
-#include <string.h>
 #include <gc.h>
+
 #include "linked_list.h"
 
-list list_make(gptr data_ptr) {
+list list_push(list lst, MalType data_ptr) {
 
-  return list_push(NULL, data_ptr);
-}
-
-list list_push(list lst, gptr data_ptr) {
-
-  pair* new_head = GC_malloc(sizeof(pair));
+  struct pair_s* new_head = GC_malloc(sizeof(*new_head));
   new_head->data = data_ptr;
   new_head->next = lst;
 
   return new_head;
 }
 
-gptr list_peek(list lst) {
+size_t list_count(list lst) {
 
-  return (lst ? lst->data : NULL);
-}
+  size_t counter = 0;
 
-list list_pop(list lst) {
-  return (lst ? lst->next : NULL);
-}
-
-long list_count(list lst) {
-
-  /* handle empty case */
-  if (!lst) {
-    return 0;
-  }
-
-  long counter = 1;
-
-  while(lst->next) {
+  while(lst) {
 
     counter++;
     lst = lst->next;
   }
 
   return counter;
-}
-
-list list_reverse(list lst) {
-
-  /* list is not empty and has more than one element */
-  if (lst && lst->next) {
-
-    pair *prev = NULL, *next = NULL, *current = lst;
-
-    while (current) {
-
-      /* stash current value of next pointer --> */
-      next = current->next;
-
-      /* reverse the next pointer on current pair <-- */
-      current->next = prev;
-
-      /* move on to next pair and repeat --> */
-      prev = current;
-      current = next;
-
-    }
-
-    lst = prev; /* head of list is in prev when current = NULL */
-  }
-
-  return lst;
-}
-
-list list_concatenate(list lst1, list lst2) {
-
-  list new_lst = NULL;
-  list iterator = NULL;
-
-  while (lst2) {
-
-    gptr val = lst2->data;
-    new_lst = list_push(new_lst, val);
-    lst2 = lst2->next;
-  }
-  new_lst = list_reverse(new_lst);
-
-  lst1 = list_reverse(lst1);
-
-  iterator = lst1;
-  while (iterator) {
-
-    gptr val = iterator->data;
-    new_lst = list_push(new_lst, val);
-    iterator = iterator->next;
-  }
-
-  lst1 = list_reverse(lst1);
-  return new_lst;
-}
-
-gptr list_nth(list lst, int n) {
-
-  int idx = 0;
-  while (lst) {
-
-    if (n == idx) {
-      return lst->data;
-    }
-    idx++;
-    lst = lst->next;
-  }
-  return NULL;
-}
-
-gptr list_first(list lst) {
-
-  if (lst) {
-    return lst->data;
-  }
-  else {
-    return NULL;
-  }
-}
-
-list list_rest(list lst) {
-
-  if (lst) {
-    return lst->next;
-  }
-  else {
-    return NULL;
-  }
-}
-
-list list_copy(list lst) {
-
-  if(!lst) {
-    return NULL;
-  }
-
-  list new_lst = NULL;
-  while(lst) {
-
-    new_lst = list_push(new_lst, lst->data);
-    lst = lst->next;
-  }
-  return new_lst;
-}
-
-long list_findf(list lst, char* keystring, char*(*fn)(gptr)) {
-
-  /* handle empty case */
-  if (!lst) {
-    return -1;
-  }
-
-  list current = lst;
-  while(current) {
-
-    /* apply fn to the data to get a string */
-    char* item = fn(current->data);
-
-    if (strcmp(keystring, item) == 0) {
-      return (current - lst); /* return the index of the first match */
-    }
-    else {
-      current = current->next; /* skip the next item in the list to*/
-    }
-  }
-  return -1; /* not found */
 }

--- a/impls/c.2/libs/linked_list/linked_list.h
+++ b/impls/c.2/libs/linked_list/linked_list.h
@@ -1,32 +1,19 @@
 #ifndef _MAL_LINKED_LIST_H
 #define _MAL_LINKED_LIST_H
 
-/* simplify references to void pointers */
-typedef void* gptr;
+#include "../../types.h"
 
 /* linked list is constructed of pairs */
-typedef struct pair_s {
-
-  gptr data;
-  struct pair_s *next;
-
-} pair;
-
 /* a list is just a pointer to the pair at the head of the list */
-typedef pair* list;
+struct pair_s {
+
+  MalType data;
+  list next;
+
+};
 
 /* interface */
-list list_make(gptr data_ptr);
-list list_push(list lst, gptr data_ptr);
-gptr list_peek(list lst);
-gptr list_nth(list lst, int n);
-gptr list_first(list lst);
-list list_rest(list lst);
-list list_pop(list lst);
-list list_reverse(list lst);
-long list_count(list lst);
-list list_concatenate(list lst1, list lst2);
-list list_copy(list lst);
-long list_findf(list lst, char* keystring, char*(*fn)(gptr));
+list list_push(list lst, MalType data_ptr);
+size_t list_count(list lst);
 
 #endif

--- a/impls/c.2/printer.h
+++ b/impls/c.2/printer.h
@@ -1,15 +1,24 @@
 #ifndef _PRINTER_H
 #define _PRINTER_H
 
-#include <stdarg.h>
 #include "types.h"
 
-#define UNREADABLY 0
-#define READABLY 1
+// This function must be called during startup.
+void printer_init();
+// It adds the following conversion specifiers (requires GNU libc).
+//   %M  for MalType
+//   ('#' means unreadably).
+//   %N  for list    ('#' means unreadably, ' ' requires space separators).
 
-char* pr_str(MalType* mal_val, int readably);
-char* pr_str_list(list lst, int readably, char* start_delimiter, char* end_delimiter, char* separator);
-char* escape_string(char* str);
-char* snprintfbuf(long initial_size, char* fmt, ...);
+// Both accept the '#' modifier, for which requires the strings to be
+// escaped/unreadably.
+
+// %N accepts the ' ' modifier, which requires that values are
+// %separated by spaces instead of directly concatenated.
+
+//  Similar to asprintf, except that
+//    the memory is allocated with GC_MALLOC instead of malloc,
+//    errors crash the program instead of being reported.
+const char* mal_printf(const char* fmt, ...);
 
 #endif

--- a/impls/c.2/reader.c
+++ b/impls/c.2/reader.c
@@ -1,21 +1,14 @@
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+
 #include <gc.h>
 
+#include "libs/hashmap/hashmap.h"
+#include "printer.h"
 #include "reader.h"
-
-#define TOKEN_SPECIAL_CHARACTER 1
-#define TOKEN_STRING 2
-#define TOKEN_INTEGER 3
-#define TOKEN_FLOAT 4
-#define TOKEN_SYMBOL 5
-#define TOKEN_COMMENT 6
-#define TOKEN_KEYWORD 7
-#define TOKEN_TRUE 8
-#define TOKEN_FALSE 9
-#define TOKEN_NIL 10
 
 #define SYMBOL_NIL "nil"
 #define SYMBOL_TRUE "true"
@@ -27,637 +20,297 @@
 #define SYMBOL_DEREF "deref"
 #define SYMBOL_WITH_META "with-meta"
 
-Reader* reader_make(long token_capacity) {
+#define DEBUG(...)
+// #define DEBUG(fmt, ...) printf("READER: %s \"%s\": " fmt "\n", __func__, *reader, ## __VA_ARGS__)
 
-  Reader* reader = GC_MALLOC(sizeof(*reader));
+typedef const char** Reader;
 
-  reader->max_tokens = token_capacity;
-  reader->position = 0;
-  reader->token_count = 0;
-  reader->token_data = GC_MALLOC(sizeof(Token*) * token_capacity);
-  reader->error = NULL;
+MalType read_form(Reader reader);
+MalType read_with_meta(Reader reader);
+MalType read_string(Reader reader);
+MalType read_number(Reader reader);
+const char* read_symbol (Reader reader);
+MalType read_matched_delimiters(Reader reader, char start_delimiter,
+                                char end_delimiter, function_t constructor);
+void skip_spaces(Reader reader);
+MalType make_symbol_list(Reader reader, const char* symbol_name);
 
-  return reader;
-}
+void skip_spaces(Reader reader) {
 
-Reader* reader_append(Reader* reader, Token* token) {
-
-  if (reader->token_count < reader->max_tokens) {
-
-    reader->token_data[reader->token_count] = token;
-    reader->token_count++;
-  }
-  else {
-    /* TODO: expand the storage more intelligently */
-    reader->max_tokens *= 2;
-    reader = GC_REALLOC(reader, sizeof(*reader) * reader->max_tokens);
-    reader->token_data[reader->token_count] = token;
-    reader->token_count++;
-  }
-  return reader;
-}
-
-Token* reader_peek(const Reader* reader) {
-
-  return (reader->token_data[reader->position]);
-}
-
-Token* reader_next(Reader* reader) {
-
-  Token* tok = reader->token_data[reader->position];
-
-  if (reader->position == -1) {
-    return NULL;
-  }
-  else if (reader->position < reader->token_count) {
-    (reader->position)++;
-    return tok;
-  }
-  else {
-    reader->position = -1;
-    return tok;
-  }
-}
-
-void reader_print(Reader* reader) {
-  /* NOTE: needed for debugging the reader only */
-
-  Token* tok;
-
-  for (long i = 0; i < reader->token_count; i++) {
-
-    tok =  reader_next(reader);
-
-    switch (tok->type) {
-    case TOKEN_SPECIAL_CHARACTER:
-      printf("special character: %s", tok->data);
-      break;
-    case TOKEN_STRING:
-      printf("string: %s", tok->data);
-      break;
-    case TOKEN_INTEGER:
-      printf("integer: %s", tok->data);
-      break;
-    case TOKEN_FLOAT:
-      printf("float: %s", tok->data);
-      break;
-    case TOKEN_SYMBOL:
-      printf("symbol: %s", tok->data);
-      break;
-    case TOKEN_COMMENT:
-      printf("comment: \"%s\"", tok->data);
-      break;
-    case TOKEN_KEYWORD:
-      printf("keyword: %s", tok->data);
-      break;
-    case TOKEN_TRUE:
-      printf("true: %s", tok->data);
-      break;
-    case TOKEN_FALSE:
-      printf("false: %s", tok->data);
-      break;
-    case TOKEN_NIL:
-      printf("nil: %s", tok->data);
-      break;
+  while(true) {
+    if(**reader == ';') {
+      do {
+        (*reader)++;
+        if(**reader == 0x00) return;
+      } while(**reader != 0x0A);
     }
-    /* print an error for any tokens with an error string */
-    tok->error ? printf(" - %s", tok->error) : 0;
+    else if((**reader != ',') && !isspace(**reader)) {
+      return;
+    }
+    (*reader)++;
   }
 }
 
-MalType* read_str(char* token_string) {
+MalType read_str(const char* source) {
 
-  Reader* reader = tokenize(token_string);
-
-  if (reader->error) {
-    return make_error_fmt("Reader error: %s", reader->error);
-  }
-  else if (reader->token_count == 0) {
-    return make_nil();
-  }
-  else {
-    return read_form(reader);
-  }
+  MalType result = read_form(&source);
+  if(is_error(result)) return result;
+  skip_spaces(&source);
+  if(*source)
+    return make_error_fmt("trailing characters (after %M): %s",
+                          result, source);
+  return result;
 }
 
-Reader* tokenize(char* token_string) {
+const char* read_symbol (Reader reader) {
 
-  /* allocate enough space for a Reader */
-  /* TODO: over-allocates space */
-  Reader* reader = reader_make(strlen(token_string));
+  DEBUG();
 
-  for (char* next = token_string; *next != '\0';) {
-
-    Token* token = NULL;
-
-    switch (*next) {
-      /* skip whitespace */
-    case ' ':
-    case ',':
-    case 0x0A: /* newline */
-      next++;
-      token = NULL; /* no token for whitespace */
-      break;
-
-      /* single character token */
+  const char* start = *reader;
+  while(true) {
+    switch(**reader) {
+    case 0:
+      return start;
     case '[':
-    case '\\':
-    case ']':
     case '{':
-    case '}':
     case '(':
+    case ']':
+    case '}':
     case ')':
     case '\'':
     case '@':
     case '`':
     case '^':
-      next = read_fixed_length_token(next, &token, 1);
-      break;
-
-      /* single or double character token */
     case '~':
-      if ( *(next + 1) == '@' ) {
-        next = read_fixed_length_token(next, &token, 2);
-      }
-      else {
-        next = read_fixed_length_token(next, &token, 1);
-      }
-      break;
-
-      /* read string of characters within double quotes */
     case '"':
-      next = read_string_token(next, &token);
-      break;
-
-      /* read a comment - all remaining input until newline */
+    case ',':
     case ';':
-      next = read_comment_token(next, &token);
-      token = NULL; /* skip token for comments */
-      break;
-
-      /* read an integer */
-    case '0':
-    case '1':
-    case '2':
-    case '3':
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-    case '8':
-    case '9':
-      next = read_number_token(next, &token);
-      //      next = read_integer_token(next, &token);
-      break;
-
-      /* integer may be prefixed with +/- */
-    case '+':
-    case '-':
-      if (isdigit(next[1])) {
-        next = read_number_token(next, &token);
-        //      next = read_integer_token(next, &token);
-      }
-      else { /* if not digits it is part of a symbol */
-        next = read_symbol_token(next, &token);
-      }
-      break;
-
-      /* read keyword */
-    case ':':
-      next = read_keyword_token(next, &token);
-      break;
-
-      /* read anything else as a symbol */
+      goto finished;
     default:
-      next = read_symbol_token(next, &token);
-      break;
-    }
-
-    if (!token) {
-      /* if no token was read (whitespace or comments)
-         continue the loop */
-      continue;
-    }
-    else {
-
-      if (token->error) {
-        /* report any errors with an early return */
-        reader = reader_append(reader, token);
-        reader->error = token->error;
-        return reader;
-      }
-      /* otherwise append the token and continue */
-      reader = reader_append(reader, token);
+      if(isspace(**reader))
+        goto finished;
+      (*reader)++;
     }
   }
-  return reader;
+ finished:
+  size_t len = *reader - start;
+  char* result = GC_MALLOC(len + 1);
+  strncpy(result, start, len);
+  return result;
 }
 
-char* read_fixed_length_token(char* current, Token** ptoken, int n) {
+MalType read_form(Reader reader) {
 
-  *ptoken = token_allocate(current, n, TOKEN_SPECIAL_CHARACTER, NULL);
-  return (current + n);
-}
+  DEBUG();
 
-char* read_terminated_token (char* current, Token** ptoken, int token_type) {
-
-  static char* const terminating_characters = " ,[](){};\n";
-
-  /* search for first terminating character */
-  char* end = strpbrk(current, terminating_characters);
-
-  /* if terminating character is not found it implies the end of the string */
-  long token_length = !end ? strlen(current) : (end - current);
-
-  /* next token starts with the terminating character */
-  *ptoken = token_allocate(current, token_length, token_type, NULL);
-  return (current + token_length);
-}
-
-char* read_symbol_token (char* current, Token** ptoken) {
-
-  char* next = read_terminated_token(current, ptoken, TOKEN_SYMBOL);
-
-  /* check for reserved symbols */
-  if (strcmp((*ptoken)->data, SYMBOL_NIL) == 0) {
-    (*ptoken)->type = TOKEN_NIL;
+  skip_spaces(reader);
+  switch (**reader) {
+  case 0:
+    return make_error_fmt("input string is empty");
+  case '[':
+    return read_matched_delimiters(reader, '[', ']', make_vector);
+  case '{':
+    return read_matched_delimiters(reader, '{', '}', mal_hash_map);
+  case '(':
+    return read_matched_delimiters(reader, '(', ')', make_list);
+  case ']':
+  case '}':
+  case ')':
+    return make_error_fmt("unmatched '%c'", **reader);
+  case '\'':
+    return make_symbol_list(reader, SYMBOL_QUOTE);
+  case '@':
+    return make_symbol_list(reader, SYMBOL_DEREF);
+  case '`':
+    return make_symbol_list(reader, SYMBOL_QUASIQUOTE);
+  case '^':
+    return read_with_meta(reader);
+  case '~':
+    if(*(*reader + 1) == '@') {
+      (*reader)++;
+      return make_symbol_list(reader, SYMBOL_SPLICE_UNQUOTE);
+    }
+    return make_symbol_list(reader, SYMBOL_UNQUOTE);
+  case '"':
+    return read_string(reader);
+  case '0':
+  case '1':
+  case '2':
+  case '3':
+  case '4':
+  case '5':
+  case '6':
+  case '7':
+  case '8':
+  case '9':
+    return read_number(reader);
+  case '+':
+  case '-':
+    if(isdigit(*(*reader + 1)))
+      return read_number(reader);
+    else
+      return make_symbol(read_symbol(reader));
+  case ':':
+    (*reader)++;
+    return make_keyword(read_symbol(reader));
+  default:
+    {
+      const char* sym = read_symbol(reader);
+      if(!strcmp(sym, SYMBOL_NIL))   return make_nil();
+      if(!strcmp(sym, SYMBOL_FALSE)) return make_false();
+      if(!strcmp(sym, SYMBOL_TRUE))  return make_true();
+      return make_symbol(sym);
+    }
   }
-  else if (strcmp((*ptoken)->data, SYMBOL_TRUE) == 0) {
-    (*ptoken)->type = TOKEN_TRUE;
-  }
-  else if (strcmp((*ptoken)->data, SYMBOL_FALSE) == 0) {
-    (*ptoken)->type = TOKEN_FALSE;
-  }
-
-  /* TODO: check for invalid characters */
-  return next;
 }
 
+MalType read_number(Reader reader) {
 
-char* read_keyword_token (char* current, Token** ptoken) {
+  DEBUG();
 
-  /* TODO: check for invalid characters */
-  return read_terminated_token(current + 1, ptoken, TOKEN_KEYWORD);
-}
-
-char* read_number_token(char* current, Token** ptoken) {
+  const char* start = *reader;
+  // Skip the initial character, which is a digit or a +- sign
+  // (followed by a digit).
+  (*reader)++;
 
   int has_decimal_point = 0;
 
-  char* next = read_terminated_token(current, ptoken, TOKEN_INTEGER);
-  long token_length = next - current;
-
-  /* first char is either digit or '+' or '-'
-     check the rest consists of valid characters */
-  for (long i = 1; i < token_length; i++) {
-
-    if ((*ptoken)->data[i] == '.' && has_decimal_point) {
-      (*ptoken)->error = "Invalid character reading number";
+  while(true) {
+    if(**reader == '.') {
+      if(has_decimal_point) break;
+      has_decimal_point = true;
+      (*reader)++;
+    }
+    else if(isdigit(**reader))
+      (*reader)++;
+    else
       break;
-    }
-    else if ((*ptoken)->data[i] == '.' && !has_decimal_point) {
-      has_decimal_point = 1;
-      (*ptoken)->type = TOKEN_FLOAT;
-      break;
-    }
-    else if (!(isdigit((*ptoken)->data[i]))) {
-      (*ptoken)->error = "Invalid character reading number";
-      break;
-    }
-  }
-  return next;
-}
-
-char* read_string_token(char* current, Token** ptoken) {
-
-  char *start, *end, *error = NULL;
-  long token_length = 0;
-
-  start = current + 1;
-
-  while(1) {
-    end = strchr(start, '"'); /* find the next " character */
-
-    /* handle failure to find closing quotes - implies end of input has been reached */
-    if (!end) {
-      end = current + strlen(current);
-      token_length =  strlen(current);
-
-      error = "EOF reached with unterminated string";
-      break;
-    }
-    /* if the character preceding the " is a '\' character (escape), need to check if it is escaping the " and if it
-       is then keep searching from the next character */
-    else if ( *(end - 1) == '\\') {
-
-      char* back_ptr = end - 1;
-      while (*back_ptr == '\\') {
-        back_ptr--; /* back up to count the escape characters '\' */
-      }
-
-      long escape_chars = (end - 1) - back_ptr;
-
-      if (escape_chars % 2 == 1) { /* odd number of '\' chars means " is not quoted */
-        start = end + 1; /* so keep searching */
-      } else {
-        /* even number of '\' characters means we found the terminating quote mark */
-        token_length =  (end - current - 1); /* quotes are excluded from string token */
-        break;
-      }
-    }
-    else {
-      token_length =  (end - current - 1); /* quotes are excluded from string token */
-      break;
-    }
   }
 
-  char* unescaped_string = unescape_string(current + 1, token_length);
-  *ptoken = token_allocate(unescaped_string, strlen(unescaped_string), TOKEN_STRING, error);
+  size_t len = *reader - start;
+  char buffer[len + 1];
+  strncpy(buffer, start, len);
+  buffer[len] = 0;
 
-  return (end + 1);
+  if(has_decimal_point)
+    return make_float(atof(buffer));
+  else
+    return make_integer(atol(buffer));
 }
 
-char* read_comment_token(char* current, Token** ptoken) {
-  /* comment includes all remaining characters to the next newline */
+MalType read_with_meta(Reader reader) {
 
-  /* search for newline character */
-  char* end = strchr(current, 0x0A);
+          DEBUG();
 
-  /* if newline is not found it implies the end of string is reached */
-  long token_chars = !end ? strlen(current) : (end - current);
-
-  *ptoken = token_allocate(current, token_chars, TOKEN_COMMENT, NULL);
-
-  return (current + token_chars + 1); /* next token starts with the char after the newline */
-}
-
-MalType* read_form(Reader* reader) {
-
-  if (reader->token_count > 0) {
-
-    Token* tok = reader_peek(reader);
-    if (tok->type == TOKEN_SPECIAL_CHARACTER) {
-
-      switch(tok->data[0]) {
-
-      case '(':
-        return read_list(reader);
-        break;
-
-      case '[':
-        return read_vector(reader);
-        break;
-
-      case '{':
-        return read_hashmap(reader);
-        break;
-
-      case '\'':
-        /* create and return a MalType list (quote read_form) */
-        return make_symbol_list(reader, SYMBOL_QUOTE);
-        break;
-
-      case '`':
-        /* create and return a MalType list (quasiquote read_form) */
-        return make_symbol_list(reader, SYMBOL_QUASIQUOTE);
-        break;
-
-      case '~':
-        if (tok->data[1] == '@') {
-          /* create and return a MalType list (splice-unquote read_form) */
-          return make_symbol_list(reader, SYMBOL_SPLICE_UNQUOTE);
-        }
-        else {
-          /* create and return a MalType list (unquote read_form) */
-          return make_symbol_list(reader, SYMBOL_UNQUOTE);
-        }
-      case '@':
-        /* create and return a MalType list (deref read_form) */
-        return make_symbol_list(reader, SYMBOL_DEREF);
-
-      case '^':
         /* create and return a MalType list (with-meta <second-form> <first-form>
            where first form should ne a metadata map and second form is somethingh
            that can have metadata attached */
-          reader_next(reader);
+          (*reader)++;
 
           /* grab the components of the list */
-          MalType* symbol = make_symbol(SYMBOL_WITH_META);
-          MalType* first_form = read_form(reader);
-          MalType* second_form = read_form(reader);
+          MalType symbol = make_symbol(SYMBOL_WITH_META);
+          MalType first_form = read_form(reader);
+          if(is_error(first_form)) return first_form;
+          MalType second_form = read_form(reader);
+          if(is_error(second_form)) return second_form;
 
           /* push the symbol and the following forms onto a list */
           list lst = NULL;
-          lst = list_push(lst, symbol);
-          lst = list_push(lst, second_form);
           lst = list_push(lst, first_form);
-          lst = list_reverse(lst);
+          lst = list_push(lst, second_form);
+          lst = list_push(lst, symbol);
 
           return make_list(lst);
+ }
 
-      default:
-        /* shouldn't happen */
-        return make_error_fmt("Reader error: Unknown special character '%c'", tok->data[0]);
-      }
-
-    } else { /* Not a special character */
-      return read_atom(reader);
-    }
-  }
-  else { /* no tokens */
-    return NULL;
-  }
-}
-
-MalType* read_list(Reader* reader) {
-
-  MalType* retval = read_matched_delimiters(reader, '(', ')' );
-
-  if (is_error(retval)) {
-    retval = make_error("Reader error: unbalanced parenthesis '()'");
-  }
-  else {
-    retval->type = MALTYPE_LIST;
-  }
-  return retval;
-}
-
-MalType* read_vector(Reader* reader) {
-
-  MalType* retval = read_matched_delimiters(reader, '[', ']' );
-
-  if (is_error(retval)) {
-    retval = make_error("Reader error: unbalanced brackets '[]'");
-  }
-  else {
-    retval->type = MALTYPE_VECTOR;
-  }
-  return retval;
-}
-
-MalType* read_hashmap(Reader* reader) {
-
-  MalType* retval = read_matched_delimiters(reader, '{', '}' );
-
-  if (is_error(retval)) {
-    retval = make_error("Reader error: unbalanced braces '{}'");
-  }
-  else if (list_count(retval->value.mal_list)%2 != 0) {
-    retval = make_error("Reader error: missing value in map literal");
-  }
-  else {
-    retval->type = MALTYPE_HASHMAP;
-  }
-  return retval;
-}
-
-MalType* read_matched_delimiters(Reader* reader, char start_delimiter, char end_delimiter) {
+MalType read_matched_delimiters(Reader reader, char start_delimiter,
+                                char end_delimiter, function_t constructor) {
 /* TODO: separate implementation of hashmap and vector */
 
-  Token* tok = reader_next(reader);
+  (*reader)++;
   list lst = NULL;
+  list* lst_last = &lst;
 
-  if (reader_peek(reader)->data[0] == end_delimiter) {
-    reader_next(reader);
-    return make_list(NULL);
-  }
-  else {
-    while (tok->data[0] != end_delimiter) {
+    while(true) {
+      DEBUG("searching '%c', already read: % N", end_delimiter, lst);
+      skip_spaces(reader);
 
-        MalType* val = read_form(reader);
-        lst = list_push(lst, (gptr)val);
-
-        tok = reader_peek(reader);
-
-        if (!tok) {
-          /* unbalanced parentheses */
-          return make_error("");
-        }
+      if(!**reader) {
+        /* unbalanced parentheses */
+        return make_error_fmt("unbalanced '%c'", start_delimiter);
       }
-    reader_next(reader);
 
-    return  make_list(list_reverse(lst));
-  }
+      if(**reader == end_delimiter)
+        break;
+      MalType val = read_form(reader);
+      if(is_error(val)) return val;
+      *lst_last = list_push(NULL, val);
+      lst_last = &(*lst_last)->next;
+    }
+  (*reader)++;
+  return constructor(lst);
 }
 
-MalType* read_atom(Reader* reader) {
+MalType make_symbol_list(Reader reader, const char* symbol_name) {
 
-  Token* tok = reader_next(reader);
+  DEBUG();
 
-  switch (tok->type) {
-
-  case TOKEN_SPECIAL_CHARACTER:
-    return make_symbol(tok->data);
-    break;
-
-  case TOKEN_COMMENT:
-    return make_error("Error: comment found in token strea");
-    break;
-
-  case TOKEN_STRING:
-    return make_string(tok->data);
-    break;
-
-  case TOKEN_INTEGER:
-    return make_integer(strtol(tok->data, NULL, 10));
-    break;
-
-  case TOKEN_FLOAT:
-    return make_float(atof(tok->data));
-    break;
-
-  case TOKEN_SYMBOL:
-    return make_symbol(tok->data);
-    break;
-
-  case TOKEN_KEYWORD:
-    return make_keyword(tok->data);
-    break;
-
-  case TOKEN_TRUE:
-    return make_true();
-    break;
-
-  case TOKEN_FALSE:
-    return make_false();
-    break;
-
-  case TOKEN_NIL:
-    return make_nil();
-    break;
-  }
-  return make_error("Reader error: Unknown atom type");
-}
-
-MalType* make_symbol_list(Reader* reader, char* symbol_name) {
-
-  reader_next(reader);
+  (*reader)++;
   list lst = NULL;
 
   /* push the symbol and the following form onto the list */
+  MalType form = read_form(reader);
+  if(is_error(form)) return form;
+  lst = list_push(lst, form);
   lst = list_push(lst, make_symbol(symbol_name));
-  lst = list_push(lst, read_form(reader));
 
-  return make_list(list_reverse(lst));
+  return make_list(lst);
 }
 
-Token* token_allocate(char* str, long num_chars, int type, char* error) {
+MalType read_string(Reader reader) {
 
-  /* allocate space for the string */
-  char* data = GC_MALLOC(sizeof(*data) * num_chars + 1); /* include space for null byte */
-  strncpy (data, str, num_chars);                        /* copy num_chars characters into data */
-  data[num_chars] = '\0';                                /* manually add the null byte */
+  DEBUG();
 
-  /* allocate space for the token struct */
-  Token* token = GC_MALLOC(sizeof(*token));
-  token->data = data;
-  token->type = type;
-  token->error = error;
+  (*reader)++; // initial '"'
+  size_t count = 0;
 
-  return token;
-}
-
-char* unescape_string(char* str, long length) {
-
-  char* dest = GC_MALLOC(sizeof(*dest)*length + 1);
-
-  long j = 0;
-  for (long i = 0; i < length; i++) {
-
-    /* look for the quoting character */
-    if (str[i] == '\\') {
-
-      switch (str[i+1]) {
-
-        /* replace '\"' with normal '"' */
-      case '"':
-        dest[j++]='"';
-        i++; /* skip extra char */
-        break;
-
-        /* replace '\n' with newline 0x0A */
-      case 'n':
-        dest[j++]= 0x0A;
-        i++; /* skip extra char */
-        break;
-
-        /* replace '\\' with '\' */
+  //  Compute the length.
+  for(const char* p=*reader; *p!='"'; p++) {
+    if(!*p)
+      return make_error_fmt("unbalanced '\"'");
+    if(*p == '\\') {
+      p++;
+      switch(*p) {
+      case 0:
+        return make_error_fmt("incomplete \\ escape sequence");
       case '\\':
-        dest[j++]= '\\';
-        i++; /* skip extra char */
+      case 'n':
+      case '"':
         break;
 
       default:
-        /* just a '\' symbol so copy it */
-              dest[j++]='\\';
+        return make_error_fmt("invalid escape sequence '\\%c'", *p);
       }
     }
-    /* not a quote so copy it */
-    else {
-        dest[j++] = str[i];
-    }
+    count++;
   }
-  dest[j] = '\0';
 
-  return dest;
+  //  Copy/unescape the characters, add final 0.
+  char* result = GC_MALLOC(count + 1);
+  const char* src;
+  char* dst = result;
+  for(src=*reader; *src!='"'; src++) {
+    if(*src == '\\') {
+      src++;
+      if(*src == 'n') {
+        *dst++ = 0x0A;
+        continue;
+      }
+    }
+    *dst++ = *src;
+  }
+  *dst = 0;
+
+  *reader = src + 1;
+  return make_string(result);
 }

--- a/impls/c.2/reader.h
+++ b/impls/c.2/reader.h
@@ -3,55 +3,6 @@
 
 #include "types.h"
 
-typedef struct Token_s {
-
-  int type;
-  char* data;
-  char* error;
-
-} Token;
-
-typedef struct Reader_s {
-
-  long position;      // current position in the array
-  long token_count;   // number of tokens in the array
-  long max_tokens;    // maximum number of tokens the array can hold
-  Token** token_data; // pointer to an array of Tokens
-  char* error;        // error message
-
-} Reader;
-
-/* reader object */
-Reader* reader_make(long token_capacity);
-Reader* reader_append(Reader* reader, Token* token);
-Token* reader_peek(const Reader* reader);
-Token* reader_next(Reader* reader);
-Token* reader_get_at(const Reader* reader, long i);
-void reader_print(Reader* reader);
-
-/* tokenizing the input */
-Reader* tokenize(char* token_string);
-char* read_fixed_length_token(char* current, Token** ptoken, int n);
-char* read_string_token(char* current, Token** ptoken);
-char* read_comment_token(char* current, Token** ptoken);
-//char* read_integer_token(char* current, Token** ptoken);
-char* read_number_token(char* current, Token** ptoken);
-char* read_symbol_token(char* current, Token** ptoken);
-char* read_keyword_token(char* current, Token** ptoken);
-
-/* reading the tokens into types */
-MalType* read_str(char* token_string);
-MalType* read_form(Reader* reader);
-MalType* read_atom(Reader* reader);
-MalType* read_list(Reader* reader);
-MalType* read_vector(Reader* reader);
-MalType* read_hashmap(Reader* reader);
-
-/* utility functions */
-char* read_terminated_token (char* current, Token** ptoken, int type);
-MalType* read_matched_delimiters(Reader* reader, char start_delimiter, char end_delimiter);
-MalType* make_symbol_list(Reader* reader, char* symbol_name);
-Token* token_allocate(char* str, long num_chars, int type, char* error);
-char* unescape_string(char* str, long length);
+MalType read_str(const char*);
 
 #endif

--- a/impls/c.2/run
+++ b/impls/c.2/run
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 exec $(dirname $0)/${STEP:-stepA_mal} "${@}"

--- a/impls/c.2/step0_repl.c
+++ b/impls/c.2/step0_repl.c
@@ -6,55 +6,43 @@
 
 #define PROMPT_STRING "user> "
 
-
-char* READ(char* str) {
-
-  return str;
-}
-
-char* EVAL(char* str) {
+const char* READ(const char* str) {
 
   return str;
 }
 
-void PRINT(char* str) {
+const char* EVAL(const char* str) {
+
+  return str;
+}
+
+void PRINT(const char* str) {
 
   printf("%s\n", str);
 }
 
-void rep(char* str) {
+void rep(const char* str) {
 
   PRINT(EVAL(READ(str)));
 }
 
+int main(int, char**) {
 
-int main(int argc, char** argv) {
+    char* input;
+    while((input = readline(PROMPT_STRING))) {
 
-  /* Greeting message */
-  puts("Make-a-lisp version 0.0.1\n");
-  puts("Press Ctrl+d to exit\n");
+      /* print prompt and get input*/
+      /* readline allocates memory for input */
+      /* Check for EOF (Ctrl-D) */
+      /* add input to history */
+      add_history(input);
 
-  while (1) {
+      /* call Read-Eval-Print */
+      rep(input);
 
-    /* print prompt and get input*/
-    /* readline allocates memory for input */
-    char* input = readline(PROMPT_STRING);
-
-    /* Check for EOF (Ctrl-D) */
-    if (!input) {
-      printf("\n");
-      return 0;
+      /* have to release the memory used by readline */
+      free(input);
     }
-
-    /* add input to history */
-    add_history(input);
-
-    /* call Read-Eval-Print */
-    rep(input);
-
-    /* have to release the memory used by readline */
-    free(input);
-  }
-
-  return 0;
+    printf("\n");
+  return EXIT_SUCCESS;
 }

--- a/impls/c.2/step1_read_print.c
+++ b/impls/c.2/step1_read_print.c
@@ -10,54 +10,45 @@
 
 #define PROMPT_STRING "user> "
 
-MalType* READ(char* str) {
+MalType READ(const char* str) {
 
   return read_str(str);
 }
 
-MalType* EVAL(MalType* val) {
+MalType EVAL(MalType val) {
 
   return val;
 }
 
-void PRINT(MalType* val) {
+void PRINT(MalType val) {
 
-  char* output = pr_str(val, READABLY);
-  printf("%s\n", output);
+  printf("%M\n", val);
 }
 
-void rep(char* str) {
+void rep(const char* str) {
 
   PRINT(EVAL(READ(str)));
 }
 
-int main(int argc, char** argv) {
+int main(int, char**) {
 
-  /* Greeting message */
-  puts("Make-a-lisp version 0.0.2\n");
-  puts("Press Ctrl+d to exit\n");
+  printer_init();
 
-  while (1) {
+    char* input;
+    while((input = readline(PROMPT_STRING))) {
 
-    /* print prompt and get input*/
-    /* readline allocates memory for input */
-    char* input = readline(PROMPT_STRING);
+      /* print prompt and get input*/
+      /* readline allocates memory for input */
+      /* Check for EOF (Ctrl-D) */
+      /* add input to history */
+      add_history(input);
 
-    /* Check for EOF (Ctrl-D) */
-    if (!input) {
-      printf("\n");
-      return 0;
+      /* call Read-Eval-Print */
+      rep(input);
+
+      /* have to release the memory used by readline */
+      free(input);
     }
-
-    /* add input to history */
-    add_history(input);
-
-    /* call Read-Eval-Print */
-    rep(input);
-
-    /* have to release the memory used by readline */
-    free(input);
-  }
-
-  return 0;
+    printf("\n");
+  return EXIT_SUCCESS;
 }

--- a/impls/c.2/step4_if_fn_do.c
+++ b/impls/c.2/step4_if_fn_do.c
@@ -1,11 +1,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gc.h>
 
+#include <gc.h>
 #include <editline/readline.h>
 #include <editline/history.h>
 
+#include "libs/linked_list/linked_list.h"
 #include "types.h"
 #include "reader.h"
 #include "printer.h"
@@ -14,453 +15,376 @@
 
 #define SYMBOL_DEFBANG "def!"
 #define SYMBOL_LETSTAR "let*"
+#define SYMBOL_DO "do"
 #define SYMBOL_IF "if"
 #define SYMBOL_FNSTAR "fn*"
-#define SYMBOL_DO "do"
 
 #define PROMPT_STRING "user> "
 
-MalType* READ(char* str) {
+MalType apply(MalType, list);
+MalType evaluate_list(list*, list, Env*);
+// Store the result into the first argument and return NULL
+// If an error occurs, it is returned.
+MalType evaluate_vector(list, Env*);
+MalType evaluate_hashmap(list, Env*);
+MalType eval_defbang(list, Env*);
+MalType eval_letstar(list, Env*);
+MalType eval_if(list, Env*);
+MalType eval_fnstar(list, const Env*);
+MalType eval_do(list, Env*);
+
+MalType READ(const char* str) {
 
   return read_str(str);
 }
 
-MalType* EVAL(MalType* ast, Env* env) {
+MalType env_apply(MalClosure closure, list args, Env** env) {
+  //  Return the closure definition and update env if all went OK,
+  //  else return an error.
+  Env* fn_env = env_make(closure->env);
+  for(size_t i=0; i<closure->param_len; i++) {
+    env_set(fn_env, closure->parameters[i], eat_argument(args));
+  }
+  /* set the 'more' symbol if there is one */
+  if (closure->more_symbol) {
+    env_set(fn_env, closure->more_symbol, make_list(args));
+  }
+  else {
+    check_empty(args);
+  }
+  *env = fn_env;
+  return closure->definition;
+}
 
-  /* forward references */
-  list evaluate_list(list lst, Env* env);
-  list evaluate_vector(list lst, Env* env);
-  list evaluate_hashmap(list lst, Env* env);
-  MalType* eval_defbang(MalType* ast, Env* env);
-  MalType* eval_letstar(MalType* ast, Env* env);
-  MalType* eval_if(MalType* ast, Env* env);
-  MalType* eval_fnstar(MalType* ast, Env* env);
-  MalType* eval_do(MalType* ast, Env* env);
+MalType EVAL(MalType ast, Env* env) {
 
-  MalType* dbgeval = env_get(env, "DEBUG-EVAL");
+  MalType dbgeval = env_get(env, "DEBUG-EVAL");
   if (dbgeval && ! is_false(dbgeval) && ! is_nil(dbgeval))
-    printf("EVAL: %s\n", pr_str(ast, READABLY));
-
-  /* NULL */
-  if (!ast) { return make_nil(); }
+    printf("EVAL: %M\n", ast);
 
   if (is_symbol(ast)) {
-    MalType* symbol_value = env_get(env, ast->value.mal_symbol);
+    MalType symbol_value = env_get(env, ast->value.mal_string);
     if (symbol_value)
       return symbol_value;
     else
-      return make_error_fmt("'%s' not found", ast->value.mal_symbol);
+      // make_error would prefix with EVAL: and break some tests
+      return wrap_error(make_string(mal_printf("'%M' not found", ast)));
   }
 
   if (is_vector(ast)) {
-    list result = evaluate_vector(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_vector(result);
+    return evaluate_vector(ast->value.mal_list, env);
   }
 
   if (is_hashmap(ast)) {
-    list result = evaluate_hashmap(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_hashmap(result);
+    return evaluate_hashmap(ast->value.mal_list, env);
   }
 
   /* not a list */
   if (!is_list(ast)) { return ast; }
 
+  list lst = ast->value.mal_list;
+
   /* empty list */
-  if (ast->value.mal_list == NULL) { return ast; }
+  if(lst == NULL) { return ast; }
 
   /* list */
-  MalType* first = (ast->value.mal_list)->data;
-  char* symbol = first->value.mal_symbol;
+  MalType first = lst->data;
+  lst = lst->next;
 
-  if (is_symbol(first)) {
+  if(is_symbol(first)) {
+    const char* symbol = first->value.mal_string;
 
     /* handle special symbols first */
     if (strcmp(symbol, SYMBOL_DEFBANG) == 0) {
-      return eval_defbang(ast, env);
+      return eval_defbang(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_LETSTAR) == 0) {
-      return eval_letstar(ast, env);
+      return eval_letstar(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_IF) == 0) {
-      return eval_if(ast, env);
+      return eval_if(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_FNSTAR) == 0) {
-      return eval_fnstar(ast, env);
+      return eval_fnstar(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_DO) == 0) {
-      return eval_do(ast, env);
+      return eval_do(lst, env);
     }
   }
   /* first element is not a special symbol */
-  list evlst = evaluate_list(ast->value.mal_list, env);
-  if (is_error(evlst->data)) return evlst->data;
+  MalType func = EVAL(first, env);
+  if (is_error(func)) { return func; }
+  //  Evaluate the arguments
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
 
   /* apply the first element of the list to the arguments */
-  MalType* func = evlst->data;
-
-  if (is_function(func)) {
-    return (*func->value.mal_function)(evlst->next);
-  }
-  else if (is_closure(func)) {
-
-    MalClosure* closure = func->value.mal_closure;
-    list params = (closure->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(evlst->next);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !closure->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
-
-      Env* new_env = env_make(closure->env, params, evlst->next, closure->more_symbol);
-      return EVAL(closure->definition, new_env);
-    }
-  }
-  else {
-    return make_error_fmt("Error: first item in list is not callable: %s.", \
-                          pr_str(func, UNREADABLY));
-  }
+  return apply(func, evlst);
 }
 
-void PRINT(MalType* val) {
+void PRINT(MalType val) {
 
-  char* output = pr_str(val, READABLY);
-  printf("%s\n", output);
+  printf("%M\n", val);
 }
 
-void rep(char* str, Env* env) {
+void rep(const char* str, Env* env) {
 
   PRINT(EVAL(READ(str), env));
 }
 
-int main(int argc, char** argv) {
-
-  /* Greeting message */
-  puts("Make-a-lisp version 0.0.4\n");
-  puts("Press Ctrl+d to exit\n");
-
-  Env* repl_env = env_make(NULL, NULL, NULL, NULL);
-
-  ns* core = ns_make_core();
-  hashmap mappings = core->mappings;
-
-  while (mappings) {
-    char* symbol = mappings->data;
-    MalType*(*function)(list) = (MalType*(*)(list))mappings->next->data;
-
-    env_set(repl_env, symbol, make_function(function));
-
-    /* pop symbol and function from hashmap/list */
-    mappings = mappings->next->next;
+//  Variant reporting errors during startup.
+void re(const char *str, Env* env) {
+  MalType result = EVAL(READ(str), env);
+  if(is_error(result)) {
+    printf("Error during startup: %M\n", result);
+    exit(EXIT_FAILURE);
   }
-
-  /* add not function */
-  /* not using rep as it prints the result */
-  EVAL(READ("(def! not (fn* (a) (if a false true)))"), repl_env);
-
-    while (1) {
-
-    /* print prompt and get input*/
-    /* readline allocates memory for input */
-    char* input = readline(PROMPT_STRING);
-
-    /* Check for EOF (Ctrl-D) */
-    if (!input) {
-      printf("\n");
-      return 0;
-    }
-
-    /* add input to history */
-    add_history(input);
-
-    /* call Read-Eval-Print */
-    rep(input, repl_env);
-
-    /* have to release the memory used by readline */
-    free(input);
-  }
-
-  return 0;
 }
 
-MalType* eval_defbang(MalType* ast, Env* env) {
+int main(int, char**) {
 
-  list lst = (ast->value.mal_list)->next;
+  printer_init();
 
-  if (!lst || !lst->next || lst->next->next) {
-    return make_error_fmt("'def!': expected exactly two arguments");
+  Env* repl_env = env_make(NULL);
+
+  ns core;
+  size_t core_size;
+  ns_make_core(&core, &core_size);
+  while(core_size--) {
+    const char* symbol = core[core_size].key;
+    function_t function = core[core_size].value;
+    env_set(repl_env, symbol, make_function(function));
   }
 
-  MalType* defbang_symbol = lst->data;
+  /* add functions written in mal - not using rep as it prints the result */
+  re("(def! not (fn* (a) (if a false true)))", repl_env);
 
-  if (!is_symbol(defbang_symbol)) {
-    return make_error_fmt("'def!': expected symbol for first argument");
-  }
+    char* input;
+    while((input = readline(PROMPT_STRING))) {
 
-  MalType* defbang_value = lst->next->data;
-  MalType* result = EVAL(defbang_value, env);
+      /* print prompt and get input*/
+      /* readline allocates memory for input */
+      /* Check for EOF (Ctrl-D) */
+      /* add input to history */
+      add_history(input);
 
+      /* call Read-Eval-Print */
+      rep(input, repl_env);
+
+      /* have to release the memory used by readline */
+      free(input);
+    }
+    printf("\n");
+  return EXIT_SUCCESS;
+}
+
+MalType eval_defbang(list lst, Env* env) {
+
+  MalType defbang_symbol = eat_argument(lst);
+  MalType defbang_value = eat_argument(lst);
+  check_empty(lst);
+
+  MalType result = EVAL(defbang_value, env);
   if (!is_error(result)){
-    env_set(env, defbang_symbol->value.mal_symbol, result);
+    env_set(env, as_symbol(defbang_symbol), result);
   }
   return result;
 }
 
-MalType* eval_letstar(MalType* ast, Env* env) {
+MalType eval_letstar(list lst, Env* env) {
 
-  list lst = ast->value.mal_list;
+  MalType bindings = eat_argument(lst);
+  MalType forms = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst->next) {
-    return make_error("'let*': missing bindings list");
-  }
-
-  MalType* bindings = lst->next->data;
-  MalType* forms = lst->next->next ? lst->next->next->data : make_nil();
-
-  if (!is_sequential(bindings)) {
-    return make_error("'let*': first argument is not list or vector");
-  }
-
-  list bindings_list = bindings->value.mal_list;
-  if (list_count(bindings_list) % 2 == 1) {
-    return  make_error("'let*': expected an even number of binding pairs");
-  }
-
-  Env* letstar_env = env_make(env, NULL, NULL, NULL);
+  list bindings_list = as_sequence(bindings);
+  Env* letstar_env = env_make(env);
 
   /* evaluate the bindings */
   while(bindings_list) {
 
-    MalType* symbol = bindings_list->data;
-    MalType* value = EVAL(bindings_list->next->data, letstar_env);
+    MalType symbol = bindings_list->data;
+    bindings_list = bindings_list->next;
+    if(!bindings_list) {
+      return make_error_fmt("expected an even number of binding pairs, got: %M",
+                            bindings);
+    }
+    MalType value = EVAL(bindings_list->data, letstar_env);
 
     /* early return from error */
-    if (is_error(value)) { return  value; }
+    if (is_error(value)) {
+      return value;
+    }
 
-    env_set(letstar_env, symbol->value.mal_symbol, value);
-    bindings_list = bindings_list->next->next;
+    env_set(letstar_env, as_symbol(symbol), value);
+    bindings_list = bindings_list->next;
   }
+
   return EVAL(forms, letstar_env);
 }
 
-MalType* eval_if(MalType* ast, Env* env) {
+MalType eval_if(list lst, Env* env) {
 
-  list lst = ast->value.mal_list;
-
-  if (!lst->next || !lst->next->next) {
-    return make_error("'if': too few arguments");
+  MalType raw_condition = eat_argument(lst);
+  MalType then_form = eat_argument(lst);
+  MalType else_form;
+  if(lst) {
+    else_form = lst->data;
+    lst = lst->next;
+    check_empty(lst);
+  }
+  else {
+    else_form = NULL;
   }
 
-  if (lst->next->next->next && lst->next->next->next->next) {
-    return make_error("'if': too many arguments");
+  MalType condition = EVAL(raw_condition, env);
+
+  if (is_error(condition)) {
+    return condition;
   }
-
-  MalType* condition = EVAL(lst->next->data, env);
-
-  if (is_error(condition)) { return condition; }
 
   if (is_false(condition) || is_nil(condition)) {
 
     /* check whether false branch is present */
-    if (lst->next->next->next) {
-      return EVAL(lst->next->next->next->data, env);
+    if(else_form) {
+      return EVAL(else_form, env);
     }
     else {
       return make_nil();
     }
 
   } else {
-    return EVAL(lst->next->next->data, env);
+    return EVAL(then_form, env);
   }
 }
 
-MalType* eval_fnstar(MalType* ast, Env* env) {
-
-  /* forward reference */
-  MalType* regularise_parameters(list* params, MalType** more);
-
-  list lst = ast->value.mal_list;
-
-  if (!lst->next) {
-    return make_error("'fn*': missing argument list");
-  }
-  else if (!lst->next->next) {
-    return make_error("'fn*': missing function body");
-  }
-
-  MalType* params = lst->next->data;
-  list params_list = params->value.mal_list;
-
-  MalType* more_symbol = NULL;
-
-  MalType* result = regularise_parameters(&params_list, &more_symbol);
-  if (is_error(result)) { return result; }
-
-  MalType* definition = lst->next->next->data;
-  MalType* regular_params = make_list(params_list);
-
-  return make_closure(env, regular_params, definition, more_symbol);
-}
-
-MalType* eval_do(MalType* ast, Env* env) {
-
-  list lst = ast->value.mal_list;
+MalType eval_do(list lst, Env* env) {
 
   /* handle empty 'do' */
-  if (!lst->next) { return make_nil(); }
-
-  /* evaluate all but the last form */
-  lst = lst->next;
-  while (lst->next) {
-
-    MalType* val = EVAL(lst->data, env);
-
+  MalType val = make_nil();
+  while(lst) {
+    val = EVAL(lst->data, env);
     /* return error early */
-    if (is_error(val)) { return val; }
+    if (is_error(val)) break;
     lst = lst->next;
   }
-  /* return the last value */
-  return EVAL(lst->data, env);
+  return val;
 }
 
-list evaluate_list(list lst, Env* env) {
+MalType evaluate_list(list* evlst, list lst, Env* env) {
 
-  list evlst = NULL;
+  *evlst = NULL;
+  list* evlst_last = evlst;
   while (lst) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     if (is_error(val)) {
-      return list_make(val);
+      return val;
     }
 
-    evlst = list_push(evlst, val);
+    *evlst_last = list_push(NULL, val);
+    evlst_last = &(*evlst_last)->next;
     lst = lst->next;
   }
-  return list_reverse(evlst);
+  return NULL;
 }
 
-list evaluate_vector(list lst, Env* env) {
+MalType evaluate_vector(list lst, Env* env) {
   /* TODO: implement a real vector */
-  list evlst = NULL;
-  while (lst) {
-
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_vector(evlst);
 }
 
-list evaluate_hashmap(list lst, Env* env) {
+MalType evaluate_hashmap(list lst, Env* env) {
   /* TODO: implement a real hashmap */
-  list evlst = NULL;
-  while (lst) {
-
-    /* keys are unevaluated */
-    evlst = list_push(evlst, lst->data);
-    lst = lst->next;
-
-    /* values are evaluated */
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_hashmap(evlst);
 }
 
-MalType* regularise_parameters(list* args, MalType** more_symbol) {
+MalType eval_fnstar(list lst, const Env* env) {
 
-  /* forward reference */
-  char* symbol_fn(gptr data);
+  MalType a1 = eat_argument(lst);
+  MalType definition = eat_argument(lst);
+  check_empty(lst);
+  list args = as_sequence(a1);
+  size_t param_len = 0;
+  const char** parameters = GC_MALLOC(list_count(args)*sizeof(char*));
+  const char* more_symbol = NULL;
 
-  list regular_args = NULL;
-  while (*args) {
+  while (args) {
 
-    MalType* val = (*args)->data;
+    MalType val = args->data;
 
-    if (!is_symbol(val)) {
-      return make_error_fmt("non-symbol found in fn argument list '%s'", \
-                            pr_str(val, UNREADABLY));
-    }
+    const char* val_sym = as_symbol(val);
 
-    if (val->value.mal_symbol[0] == '&') {
+    if(val_sym[0] == '&') {
 
       /* & is found but there is no symbol */
-      if (val->value.mal_symbol[1] == '\0' && !(*args)->next) {
-        return make_error("missing symbol after '&' in argument list");
-      }
+      if (val_sym[1] == '\0') {
+        if(!args->next) {
+          return make_error_fmt("missing symbol after '&' in argument list");
+        }
       /* & is found and there is a single symbol after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next &&
-                is_symbol((*args)->next->data) && !(*args)->next->next)) {
-
-        /* TODO: check symbol is no a duplicate of one already on the list */
-        *more_symbol = (*args)->next->data;
-        break;
-      }
+        else if(!args->next->next) {
+          more_symbol = as_symbol(args->next->data);
+          break;
+        }
       /* & is found and there extra symbols after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next && (*args)->next->next)) {
-        return make_error_fmt("unexpected symbol after '& %s' in argument list: '%s'", \
-                              pr_str((*args)->next->data, UNREADABLY),  \
-                              pr_str((*args)->next->next->data, UNREADABLY));
+        else {
+          return make_error_fmt("unexpected symbol after '& %M' in argument list: '%M'",
+                                args->next->data, args->next->next->data);
+        }
       }
       /* & is found as part of the symbol and no other symbols */
-      else if (val->value.mal_symbol[1] != '\0' && !(*args)->next) {
-        *more_symbol = make_symbol((val->value.mal_symbol + 1));
+      else if(!args->next) {
+        more_symbol = val_sym + 1;
         break;
       }
       /* & is found as part of the symbol but there are other symbols after */
-      else if (val->value.mal_symbol[1] != '\0' && (*args)->next) {
-        return make_error_fmt("unexpected symbol after '%s' in argument list: '%s'", \
-                              pr_str(val, UNREADABLY),  \
-                              pr_str((*args)->next->data, UNREADABLY));
-       }
+      else {
+        return make_error_fmt("unexpected symbol after '%s' in argument list: '%M'",
+                              val_sym, args->next->data);
+      }
     }
 
     /* & is not found - add the symbol to the regular argument list */
     else {
 
-      if (list_findf(regular_args, val->value.mal_symbol, symbol_fn) > 0) {
-        return make_error_fmt("duplicate symbol in argument list: '%s'", pr_str(val, UNREADABLY));
+      for(size_t i=0; i<param_len; i++) {
+        if(!strcmp(val_sym, parameters[i])) {
+          return make_error_fmt("duplicate symbol in argument list: '%s'",
+                                parameters[i]);
+        }
       }
-      else {
-        regular_args = list_push(regular_args, val);
-      }
+      parameters[param_len++] = val_sym;
     }
-    *args = (*args)->next;
+    args = args->next;
   }
 
-  *args = list_reverse(regular_args);
-  return make_nil();
+  return make_closure(env, param_len, parameters, definition, more_symbol);
 }
 
-char* symbol_fn(gptr data) {
-  MalType* val = data;
-  return (val->value.mal_symbol);
-}
+MalType apply(MalType fn, list args) {
 
-/* silence the compiler after swap!, apply, and map are added to the core */
-MalType* apply(MalType* ast, Env* env) {
-  return make_nil();
+  if (is_function(fn)) {
+
+    MalType(*fun_ptr)(list) = fn->value.mal_function;
+    return (*fun_ptr)(args);
+  }
+  else if(is_closure(fn)) {
+
+    Env* env;
+    MalType ast = env_apply(fn->value.mal_closure, args, &env);
+    if(is_error(ast)) return ast;
+    return EVAL(ast, env);
+  }
+  else {
+    return bad_type(fn, "a function or closure");
+  }
 }

--- a/impls/c.2/step5_tco.c
+++ b/impls/c.2/step5_tco.c
@@ -1,11 +1,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gc.h>
 
+#include <gc.h>
 #include <editline/readline.h>
 #include <editline/history.h>
 
+#include "libs/linked_list/linked_list.h"
 #include "types.h"
 #include "reader.h"
 #include "printer.h"
@@ -14,83 +15,96 @@
 
 #define SYMBOL_DEFBANG "def!"
 #define SYMBOL_LETSTAR "let*"
+#define SYMBOL_DO "do"
 #define SYMBOL_IF "if"
 #define SYMBOL_FNSTAR "fn*"
-#define SYMBOL_DO "do"
 
 #define PROMPT_STRING "user> "
 
-MalType* READ(char* str) {
+MalType apply(MalType, list);
+MalType evaluate_list(list*, list, Env*);
+// Store the result into the first argument and return NULL
+// If an error occurs, it is returned.
+MalType evaluate_vector(list, Env*);
+MalType evaluate_hashmap(list, Env*);
+MalType eval_defbang(list, Env*);
+MalType eval_letstar(list, Env**); // TCO
+MalType eval_if(list, Env**); // TCO unless the environment is set to NULL.
+MalType eval_fnstar(list, const Env*);
+MalType eval_do(list, Env*); // TCO in the same env
+
+MalType READ(const char* str) {
 
   return read_str(str);
 }
 
-MalType* EVAL(MalType* ast, Env* env) {
+MalType env_apply(MalClosure closure, list args, Env** env) {
+  //  Return the closure definition and update env if all went OK,
+  //  else return an error.
+  Env* fn_env = env_make(closure->env);
+  for(size_t i=0; i<closure->param_len; i++) {
+    env_set(fn_env, closure->parameters[i], eat_argument(args));
+  }
+  /* set the 'more' symbol if there is one */
+  if (closure->more_symbol) {
+    env_set(fn_env, closure->more_symbol, make_list(args));
+  }
+  else {
+    check_empty(args);
+  }
+  *env = fn_env;
+  return closure->definition;
+}
 
-  /* forward references */
-  list evaluate_list(list lst, Env* env);
-  list evaluate_vector(list lst, Env* env);
-  list evaluate_hashmap(list lst, Env* env);
-  MalType* eval_defbang(MalType* ast, Env** env);
-  void eval_letstar(MalType** ast, Env** env);
-  void eval_if(MalType** ast, Env** env);
-  MalType* eval_fnstar(MalType* ast, Env* env);
-  MalType* eval_do(MalType* ast, Env* env);
+MalType EVAL(MalType ast, Env* env) {
 
   /* Use goto to jump here rather than calling eval for tail-call elimination */
  TCE_entry_point:
 
-  MalType* dbgeval = env_get(env, "DEBUG-EVAL");
+  MalType dbgeval = env_get(env, "DEBUG-EVAL");
   if (dbgeval && ! is_false(dbgeval) && ! is_nil(dbgeval))
-    printf("EVAL: %s\n", pr_str(ast, READABLY));
-
-  /* NULL */
-  if (!ast) { return make_nil(); }
+    printf("EVAL: %M\n", ast);
 
   if (is_symbol(ast)) {
-    MalType* symbol_value = env_get(env, ast->value.mal_symbol);
+    MalType symbol_value = env_get(env, ast->value.mal_string);
     if (symbol_value)
       return symbol_value;
     else
-      return make_error_fmt("'%s' not found", ast->value.mal_symbol);
+      // make_error would prefix with EVAL: and break some tests
+      return wrap_error(make_string(mal_printf("'%M' not found", ast)));
   }
 
   if (is_vector(ast)) {
-    list result = evaluate_vector(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_vector(result);
+    return evaluate_vector(ast->value.mal_list, env);
   }
 
   if (is_hashmap(ast)) {
-    list result = evaluate_hashmap(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_hashmap(result);
+    return evaluate_hashmap(ast->value.mal_list, env);
   }
 
   /* not a list */
   if (!is_list(ast)) { return ast; }
 
+  list lst = ast->value.mal_list;
+
   /* empty list */
-  if (ast->value.mal_list == NULL) { return ast; }
+  if(lst == NULL) { return ast; }
 
   /* list */
-  MalType* first = (ast->value.mal_list)->data;
-  char* symbol = first->value.mal_symbol;
+  MalType first = lst->data;
+  lst = lst->next;
 
-  if (is_symbol(first)) {
+  if(is_symbol(first)) {
+    const char* symbol = first->value.mal_string;
 
     /* handle special symbols first */
     if (strcmp(symbol, SYMBOL_DEFBANG) == 0) {
-      return eval_defbang(ast, &env);
+      return eval_defbang(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_LETSTAR) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      eval_letstar(&ast, &env);
+      ast = eval_letstar(lst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
@@ -98,274 +112,194 @@ MalType* EVAL(MalType* ast, Env* env) {
     else if (strcmp(symbol, SYMBOL_IF) == 0) {
 
       /* TCE - modify ast directly and jump back to eval */
-      eval_if(&ast, &env);
+      ast = eval_if(lst, &env);
 
       if (is_error(ast)) { return ast; }
-      goto TCE_entry_point;
+      if(env) goto TCE_entry_point; else return ast;
     }
     else if (strcmp(symbol, SYMBOL_FNSTAR) == 0) {
-      return eval_fnstar(ast, env);
+      return eval_fnstar(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_DO) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(ast, env);
+      ast = eval_do(lst, env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
     }
   }
   /* first element is not a special symbol */
-  list evlst = evaluate_list(ast->value.mal_list, env);
-  if (is_error(evlst->data)) return evlst->data;
+  MalType func = EVAL(first, env);
+  if (is_error(func)) { return func; }
+  //  Evaluate the arguments
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
 
   /* apply the first element of the list to the arguments */
-  MalType* func = evlst->data;
+  if (is_closure(func)) {
 
-  if (is_function(func)) {
-    return (*func->value.mal_function)(evlst->next);
-  }
-  else if (is_closure(func)) {
-
-    MalClosure* closure = func->value.mal_closure;
-    list params = (closure->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(evlst->next);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !closure->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
+      MalClosure closure = func->value.mal_closure;
 
       /* TCE - modify ast and env directly and jump back to eval */
-      env = env_make(closure->env, params, evlst->next, closure->more_symbol);
-      ast = func->value.mal_closure->definition;
+      ast = env_apply(closure, evlst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
-    }
   }
-  else {
-    return make_error_fmt("first item in list is not callable: '%s'",   \
-                          pr_str(func, UNREADABLY));
-  }
+  return apply(func, evlst);
 }
 
-void PRINT(MalType* val) {
+void PRINT(MalType val) {
 
-  char* output = pr_str(val, READABLY);
-  printf("%s\n", output);
+  printf("%M\n", val);
 }
 
-void rep(char* str, Env* env) {
+void rep(const char* str, Env* env) {
 
   PRINT(EVAL(READ(str), env));
 }
 
-int main(int argc, char** argv) {
-
-  /* Greeting message */
-  puts("Make-a-lisp version 0.0.5\n");
-  puts("Press Ctrl+d to exit\n");
-
-  Env* repl_env = env_make(NULL, NULL, NULL, NULL);
-
-  ns* core = ns_make_core();
-  hashmap mappings = core->mappings;
-
-  while (mappings) {
-    char* symbol = mappings->data;
-    MalType*(*function)(list) = (MalType*(*)(list))mappings->next->data;
-
-    env_set(repl_env, symbol, make_function(function));
-
-    /* pop symbol and function from hashmap/list */
-    mappings = mappings->next->next;
+//  Variant reporting errors during startup.
+void re(const char *str, Env* env) {
+  MalType result = EVAL(READ(str), env);
+  if(is_error(result)) {
+    printf("Error during startup: %M\n", result);
+    exit(EXIT_FAILURE);
   }
-
-  /* add not function */
-  /* not using rep as it prints the result */
-  EVAL(READ("(def! not (fn* (a) (if a false true)))"), repl_env);
-
-    while (1) {
-
-    /* print prompt and get input*/
-    /* readline allocates memory for input */
-    char* input = readline(PROMPT_STRING);
-
-    /* Check for EOF (Ctrl-D) */
-    if (!input) {
-      printf("\n");
-      return 0;
-    }
-
-    /* add input to history */
-    add_history(input);
-
-    /* call Read-Eval-Print */
-    rep(input, repl_env);
-
-    /* have to release the memory used by readline */
-    free(input);
-  }
-
-  return 0;
 }
 
-MalType* eval_defbang(MalType* ast, Env** env) {
+int main(int, char**) {
 
-  list lst = (ast->value.mal_list)->next;
+  printer_init();
 
-  if (!lst || !lst->next || lst->next->next) {
-    return make_error_fmt("'def!': expected exactly two arguments");
+  Env* repl_env = env_make(NULL);
+
+  ns core;
+  size_t core_size;
+  ns_make_core(&core, &core_size);
+  while(core_size--) {
+    const char* symbol = core[core_size].key;
+    function_t function = core[core_size].value;
+    env_set(repl_env, symbol, make_function(function));
   }
 
-  MalType* defbang_symbol = lst->data;
+  /* add functions written in mal - not using rep as it prints the result */
+  re("(def! not (fn* (a) (if a false true)))", repl_env);
 
-  if (!is_symbol(defbang_symbol)) {
-    return make_error_fmt("'def!': expected symbol for first argument");
-  }
+    char* input;
+    while((input = readline(PROMPT_STRING))) {
 
-  MalType* defbang_value = lst->next->data;
-  MalType* result = EVAL(defbang_value, *env);
+      /* print prompt and get input*/
+      /* readline allocates memory for input */
+      /* Check for EOF (Ctrl-D) */
+      /* add input to history */
+      add_history(input);
 
+      /* call Read-Eval-Print */
+      rep(input, repl_env);
+
+      /* have to release the memory used by readline */
+      free(input);
+    }
+    printf("\n");
+  return EXIT_SUCCESS;
+}
+
+MalType eval_defbang(list lst, Env* env) {
+
+  MalType defbang_symbol = eat_argument(lst);
+  MalType defbang_value = eat_argument(lst);
+  check_empty(lst);
+
+  MalType result = EVAL(defbang_value, env);
   if (!is_error(result)){
-    env_set(*env, defbang_symbol->value.mal_symbol, result);
+    env_set(env, as_symbol(defbang_symbol), result);
   }
   return result;
 }
 
-void eval_letstar(MalType** ast, Env** env) {
+MalType eval_letstar(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
+  MalType bindings = eat_argument(lst);
+  MalType forms = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst->next) {
-    *ast = make_error("'let*': missing bindings list");
-    return;
-  }
-
-  MalType* bindings = lst->next->data;
-  MalType* forms = lst->next->next ? lst->next->next->data : make_nil();
-
-  if (!is_sequential(bindings)) {
-    *ast = make_error("'let*': first argument is not list or vector");
-    return;
-  }
-
-  list bindings_list = bindings->value.mal_list;
-  if (list_count(bindings_list) % 2 == 1) {
-    *ast = make_error("'let*': expected an even number of binding pairs");
-    return;
-  }
-
-  Env* letstar_env = env_make(*env, NULL, NULL, NULL);
+  list bindings_list = as_sequence(bindings);
+  Env* letstar_env = env_make(*env);
 
   /* evaluate the bindings */
   while(bindings_list) {
 
-    MalType* symbol = bindings_list->data;
-    MalType* value = EVAL(bindings_list->next->data, letstar_env);
+    MalType symbol = bindings_list->data;
+    bindings_list = bindings_list->next;
+    if(!bindings_list) {
+      return make_error_fmt("expected an even number of binding pairs, got: %M",
+                            bindings);
+    }
+    MalType value = EVAL(bindings_list->data, letstar_env);
 
     /* early return from error */
     if (is_error(value)) {
-      *ast = value;
-      return;
+      return value;
     }
 
-    env_set(letstar_env, symbol->value.mal_symbol, value);
-    bindings_list = bindings_list->next->next;
+    env_set(letstar_env, as_symbol(symbol), value);
+    bindings_list = bindings_list->next;
   }
 
   *env = letstar_env;
-  *ast = forms;
-  return;
+  return forms;
 }
 
-void eval_if(MalType** ast, Env** env) {
+MalType eval_if(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
-
-  if (!lst->next || !lst->next->next) {
-    *ast = make_error("'if': too few arguments");
-    return;
+  MalType raw_condition = eat_argument(lst);
+  MalType then_form = eat_argument(lst);
+  MalType else_form;
+  if(lst) {
+    else_form = lst->data;
+    lst = lst->next;
+    check_empty(lst);
+  }
+  else {
+    else_form = NULL;
   }
 
-  if (lst->next->next->next && lst->next->next->next->next) {
-    *ast = make_error("'if': too many arguments");
-    return;
-  }
-
-  MalType* condition = EVAL(lst->next->data, *env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (is_error(condition)) {
-    *ast = condition;
-    return;
+    return condition;
   }
 
   if (is_false(condition) || is_nil(condition)) {
 
     /* check whether false branch is present */
-    if (lst->next->next->next) {
-      *ast = lst->next->next->next->data;
-      return;
+    if(else_form) {
+      return else_form;
     }
     else {
-      *ast = make_nil();
-      return;
+      *env = NULL;              // prevent TCO
+      return make_nil();
     }
 
   } else {
-    *ast = lst->next->next->data;
-    return;
+    return then_form;
   }
 }
 
-MalType* eval_fnstar(MalType* ast, Env* env) {
-
-  /* forward reference */
-  MalType* regularise_parameters(list* params, MalType** more);
-
-  list lst = ast->value.mal_list;
-
-  if (!lst->next) {
-    return make_error("'fn*': missing argument list");
-  }
-  else if (!lst->next->next) {
-    return make_error("'fn*': missing function body");
-  }
-
-  MalType* params = lst->next->data;
-  list params_list = params->value.mal_list;
-
-  MalType* more_symbol = NULL;
-
-  MalType* result = regularise_parameters(&params_list, &more_symbol);
-  if (is_error(result)) { return result; }
-
-  MalType* definition = lst->next->next->data;
-  MalType* regular_params = make_list(params_list);
-
-  return make_closure(env, regular_params, definition, more_symbol);
-}
-
-MalType* eval_do(MalType* ast, Env* env) {
-
-  list lst = ast->value.mal_list;
+MalType eval_do(list lst, Env* env) {
 
   /* handle empty 'do' */
-  if (!lst->next) {
+  if (!lst) {
     return make_nil();
   }
 
   /* evaluate all but the last form */
-  lst = lst->next;
   while (lst->next) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     /* return error early */
     if (is_error(val)) {
@@ -377,134 +311,120 @@ MalType* eval_do(MalType* ast, Env* env) {
   return lst->data;
 }
 
-list evaluate_list(list lst, Env* env) {
+MalType evaluate_list(list* evlst, list lst, Env* env) {
 
-  list evlst = NULL;
+  *evlst = NULL;
+  list* evlst_last = evlst;
   while (lst) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     if (is_error(val)) {
-      return list_make(val);
+      return val;
     }
 
-    evlst = list_push(evlst, val);
+    *evlst_last = list_push(NULL, val);
+    evlst_last = &(*evlst_last)->next;
     lst = lst->next;
   }
-  return list_reverse(evlst);
+  return NULL;
 }
 
-list evaluate_vector(list lst, Env* env) {
+MalType evaluate_vector(list lst, Env* env) {
   /* TODO: implement a real vector */
-  list evlst = NULL;
-  while (lst) {
-
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_vector(evlst);
 }
 
-list evaluate_hashmap(list lst, Env* env) {
+MalType evaluate_hashmap(list lst, Env* env) {
   /* TODO: implement a real hashmap */
-  list evlst = NULL;
-  while (lst) {
-
-    /* keys are unevaluated */
-    evlst = list_push(evlst, lst->data);
-    lst = lst->next;
-
-    /* values are evaluated */
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_hashmap(evlst);
 }
 
-MalType* regularise_parameters(list* args, MalType** more_symbol) {
+MalType eval_fnstar(list lst, const Env* env) {
 
-  /* forward reference */
-  char* symbol_fn(gptr data);
+  MalType a1 = eat_argument(lst);
+  MalType definition = eat_argument(lst);
+  check_empty(lst);
+  list args = as_sequence(a1);
+  size_t param_len = 0;
+  const char** parameters = GC_MALLOC(list_count(args)*sizeof(char*));
+  const char* more_symbol = NULL;
 
-  list regular_args = NULL;
-  while (*args) {
+  while (args) {
 
-    MalType* val = (*args)->data;
+    MalType val = args->data;
 
-    if (!is_symbol(val)) {
-      return make_error_fmt("non-symbol found in fn argument list '%s'", \
-                            pr_str(val, UNREADABLY));
-    }
+    const char* val_sym = as_symbol(val);
 
-    if (val->value.mal_symbol[0] == '&') {
+    if(val_sym[0] == '&') {
 
       /* & is found but there is no symbol */
-      if (val->value.mal_symbol[1] == '\0' && !(*args)->next) {
-        return make_error("missing symbol after '&' in argument list");
-      }
+      if (val_sym[1] == '\0') {
+        if(!args->next) {
+          return make_error_fmt("missing symbol after '&' in argument list");
+        }
       /* & is found and there is a single symbol after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next &&
-                is_symbol((*args)->next->data) && !(*args)->next->next)) {
-
-        /* TODO: check symbol is no a duplicate of one already on the list */
-        *more_symbol = (*args)->next->data;
-        break;
-      }
+        else if(!args->next->next) {
+          more_symbol = as_symbol(args->next->data);
+          break;
+        }
       /* & is found and there extra symbols after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next && (*args)->next->next)) {
-        return make_error_fmt("unexpected symbol after '& %s' in argument list: '%s'", \
-                              pr_str((*args)->next->data, UNREADABLY),  \
-                              pr_str((*args)->next->next->data, UNREADABLY));
+        else {
+          return make_error_fmt("unexpected symbol after '& %M' in argument list: '%M'",
+                                args->next->data, args->next->next->data);
+        }
       }
       /* & is found as part of the symbol and no other symbols */
-      else if (val->value.mal_symbol[1] != '\0' && !(*args)->next) {
-        *more_symbol = make_symbol((val->value.mal_symbol + 1));
+      else if(!args->next) {
+        more_symbol = val_sym + 1;
         break;
       }
       /* & is found as part of the symbol but there are other symbols after */
-      else if (val->value.mal_symbol[1] != '\0' && (*args)->next) {
-        return make_error_fmt("unexpected symbol after '%s' in argument list: '%s'", \
-                              pr_str(val, UNREADABLY),  \
-                              pr_str((*args)->next->data, UNREADABLY));
-       }
+      else {
+        return make_error_fmt("unexpected symbol after '%s' in argument list: '%M'",
+                              val_sym, args->next->data);
+      }
     }
 
     /* & is not found - add the symbol to the regular argument list */
     else {
 
-      if (list_findf(regular_args, val->value.mal_symbol, symbol_fn) > 0) {
-        return make_error_fmt("duplicate symbol in argument list: '%s'", pr_str(val, UNREADABLY));
+      for(size_t i=0; i<param_len; i++) {
+        if(!strcmp(val_sym, parameters[i])) {
+          return make_error_fmt("duplicate symbol in argument list: '%s'",
+                                parameters[i]);
+        }
       }
-      else {
-        regular_args = list_push(regular_args, val);
-      }
+      parameters[param_len++] = val_sym;
     }
-    *args = (*args)->next;
+    args = args->next;
   }
 
-  *args = list_reverse(regular_args);
-  return make_nil();
+  return make_closure(env, param_len, parameters, definition, more_symbol);
 }
 
-char* symbol_fn(gptr data) {
-  MalType* val = data;
-  return (val->value.mal_symbol);
-}
+/* used by core functions but not EVAL as doesn't do TCE */
+MalType apply(MalType fn, list args) {
 
-/* silence the compiler after swap!, apply, and map
-   are added to the core */
-MalType* apply(MalType* ast, Env* env) {
-  return make_nil();
+  if (is_function(fn)) {
+
+    MalType(*fun_ptr)(list) = fn->value.mal_function;
+    return (*fun_ptr)(args);
+  }
+  else if(is_closure(fn)) {
+
+    Env* env;
+    MalType ast = env_apply(fn->value.mal_closure, args, &env);
+    if(is_error(ast)) return ast;
+    return EVAL(ast, env);
+  }
+  else {
+    return bad_type(fn, "a function or closure");
+  }
 }

--- a/impls/c.2/step6_file.c
+++ b/impls/c.2/step6_file.c
@@ -1,11 +1,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gc.h>
 
+#include <gc.h>
 #include <editline/readline.h>
 #include <editline/history.h>
 
+#include "libs/linked_list/linked_list.h"
 #include "types.h"
 #include "reader.h"
 #include "printer.h"
@@ -14,91 +15,96 @@
 
 #define SYMBOL_DEFBANG "def!"
 #define SYMBOL_LETSTAR "let*"
+#define SYMBOL_DO "do"
 #define SYMBOL_IF "if"
 #define SYMBOL_FNSTAR "fn*"
-#define SYMBOL_DO "do"
 
 #define PROMPT_STRING "user> "
 
-MalType* READ(char* str) {
+MalType apply(MalType, list); // For the apply phase and core apply/map/swap.
+MalType evaluate_list(list*, list, Env*);
+// Store the result into the first argument and return NULL
+// If an error occurs, it is returned.
+MalType evaluate_vector(list, Env*);
+MalType evaluate_hashmap(list, Env*);
+MalType eval_defbang(list, Env*);
+MalType eval_letstar(list, Env**); // TCO
+MalType eval_if(list, Env**); // TCO unless the environment is set to NULL.
+MalType eval_fnstar(list, const Env*);
+MalType eval_do(list, Env*); // TCO in the same env
+
+MalType READ(const char* str) {
 
   return read_str(str);
 }
 
-MalType* EVAL(MalType* ast, Env* env) {
+MalType env_apply(MalClosure closure, list args, Env** env) {
+  //  Return the closure definition and update env if all went OK,
+  //  else return an error.
+  Env* fn_env = env_make(closure->env);
+  for(size_t i=0; i<closure->param_len; i++) {
+    env_set(fn_env, closure->parameters[i], eat_argument(args));
+  }
+  /* set the 'more' symbol if there is one */
+  if (closure->more_symbol) {
+    env_set(fn_env, closure->more_symbol, make_list(args));
+  }
+  else {
+    check_empty(args);
+  }
+  *env = fn_env;
+  return closure->definition;
+}
 
-  /* forward references */
-  list evaluate_list(list lst, Env* env);
-  list evaluate_vector(list lst, Env* env);
-  list evaluate_hashmap(list lst, Env* env);
-  MalType* eval_defbang(MalType* ast, Env** env);
-  void eval_letstar(MalType** ast, Env** env);
-  void eval_if(MalType** ast, Env** env);
-  MalType* eval_fnstar(MalType* ast, Env* env);
-  MalType* eval_do(MalType* ast, Env* env);
+MalType EVAL(MalType ast, Env* env) {
 
   /* Use goto to jump here rather than calling eval for tail-call elimination */
  TCE_entry_point:
 
-  MalType* dbgeval = env_get(env, "DEBUG-EVAL");
+  MalType dbgeval = env_get(env, "DEBUG-EVAL");
   if (dbgeval && ! is_false(dbgeval) && ! is_nil(dbgeval))
-    printf("EVAL: %s\n", pr_str(ast, READABLY));
-
-  /* NULL */
-  if (!ast) { return make_nil(); }
+    printf("EVAL: %M\n", ast);
 
   if (is_symbol(ast)) {
-    MalType* symbol_value = env_get(env, ast->value.mal_symbol);
+    MalType symbol_value = env_get(env, ast->value.mal_string);
     if (symbol_value)
       return symbol_value;
     else
-      return make_error_fmt("'%s' not found", ast->value.mal_symbol);
+      // make_error would prefix with EVAL: and break some tests
+      return wrap_error(make_string(mal_printf("'%M' not found", ast)));
   }
 
   if (is_vector(ast)) {
-    list result = evaluate_vector(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_vector(result);
+    return evaluate_vector(ast->value.mal_list, env);
   }
 
   if (is_hashmap(ast)) {
-    list result = evaluate_hashmap(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_hashmap(result);
+    return evaluate_hashmap(ast->value.mal_list, env);
   }
 
   /* not a list */
   if (!is_list(ast)) { return ast; }
 
+  list lst = ast->value.mal_list;
+
   /* empty list */
-  if (ast->value.mal_list == NULL) { return ast; }
+  if(lst == NULL) { return ast; }
 
   /* list */
-  MalType* first = (ast->value.mal_list)->data;
-  char* symbol = first->value.mal_symbol;
+  MalType first = lst->data;
+  lst = lst->next;
 
-  if (is_symbol(first)) {
+  if(is_symbol(first)) {
+    const char* symbol = first->value.mal_string;
 
     /* handle special symbols first */
     if (strcmp(symbol, SYMBOL_DEFBANG) == 0) {
-      return eval_defbang(ast, &env);
+      return eval_defbang(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_LETSTAR) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      eval_letstar(&ast, &env);
-
-      if (is_error(ast)) { return ast; }
-      goto TCE_entry_point;
-    }
-    else if (strcmp(symbol, SYMBOL_DO) == 0) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(ast, env);
+      ast = eval_letstar(lst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
@@ -106,133 +112,119 @@ MalType* EVAL(MalType* ast, Env* env) {
     else if (strcmp(symbol, SYMBOL_IF) == 0) {
 
       /* TCE - modify ast directly and jump back to eval */
-      eval_if(&ast, &env);
+      ast = eval_if(lst, &env);
+
+      if (is_error(ast)) { return ast; }
+      if(env) goto TCE_entry_point; else return ast;
+    }
+    else if (strcmp(symbol, SYMBOL_FNSTAR) == 0) {
+      return eval_fnstar(lst, env);
+    }
+    else if (strcmp(symbol, SYMBOL_DO) == 0) {
+
+      /* TCE - modify ast and env directly and jump back to eval */
+      ast = eval_do(lst, env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
-    }
-    else if (strcmp(symbol, SYMBOL_FNSTAR) == 0) {
-      return eval_fnstar(ast, env);
     }
   }
   /* first element is not a special symbol */
-  list evlst = evaluate_list(ast->value.mal_list, env);
-  if (is_error(evlst->data)) return evlst->data;
+  MalType func = EVAL(first, env);
+  if (is_error(func)) { return func; }
+  //  Evaluate the arguments
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
 
   /* apply the first element of the list to the arguments */
-  MalType* func = evlst->data;
+  if (is_closure(func)) {
 
-  if (is_function(func)) {
-    return (*func->value.mal_function)(evlst->next);
-  }
-  else if (is_closure(func)) {
-
-    MalClosure* closure = func->value.mal_closure;
-    list params = (closure->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(evlst->next);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !closure->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
+      MalClosure closure = func->value.mal_closure;
 
       /* TCE - modify ast and env directly and jump back to eval */
-      env = env_make(closure->env, params, evlst->next, closure->more_symbol);
-      ast = func->value.mal_closure->definition;
+      ast = env_apply(closure, evlst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
-    }
   }
-  else {
-    return make_error_fmt("first item in list is not callable: '%s'",   \
-                          pr_str(func, UNREADABLY));
-  }
+  return apply(func, evlst);
 }
 
-void PRINT(MalType* val) {
+void PRINT(MalType val) {
 
-  char* output = pr_str(val, READABLY);
-  printf("%s\n", output);
+  printf("%M\n", val);
 }
 
-void rep(char* str, Env* env) {
+void rep(const char* str, Env* env) {
 
   PRINT(EVAL(READ(str), env));
+}
+
+//  Variant reporting errors during startup.
+void re(const char *str, Env* env) {
+  MalType result = EVAL(READ(str), env);
+  if(is_error(result)) {
+    printf("Error during startup: %M\n", result);
+    exit(EXIT_FAILURE);
+  }
 }
 
 /* declare as global so it can be accessed by mal_eval */
 Env* global_env;
 
-MalType* mal_eval(list args) {
+MalType mal_eval(list args) {
 
-  MalType* ast = args->data;
+  MalType ast = eat_argument(args);
+  check_empty(args);
   return EVAL(ast, global_env);
 }
 
 int main(int argc, char** argv) {
 
-  Env* repl_env = env_make(NULL, NULL, NULL, NULL);
+  printer_init();
+
+  Env* repl_env = env_make(NULL);
   global_env = repl_env;
 
-  ns* core = ns_make_core();
-  hashmap mappings = core->mappings;
-
-  while (mappings) {
-    char* symbol = mappings->data;
-    MalType*(*function)(list) = (MalType*(*)(list))mappings->next->data;
-
+  ns core;
+  size_t core_size;
+  ns_make_core(&core, &core_size);
+  while(core_size--) {
+    const char* symbol = core[core_size].key;
+    function_t function = core[core_size].value;
     env_set(repl_env, symbol, make_function(function));
-
-    /* pop symbol and function from hashmap/list */
-    mappings = mappings->next->next;
   }
 
   env_set(repl_env, "eval", make_function(mal_eval));
 
   /* add functions written in mal - not using rep as it prints the result */
-  EVAL(READ("(def! not (fn* (a) (if a false true)))"), repl_env);
-  EVAL(READ("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))"), repl_env);
-
+  re("(def! not (fn* (a) (if a false true)))", repl_env);
+  re("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))", repl_env);
 
   /* make command line arguments available in the environment */
   list lst = NULL;
-  for (int i = 2; i < argc; i++) {
-    lst = list_push(lst, make_string(argv[i]));
+  while(1 < --argc) {
+    lst = list_push(lst, make_string(argv[argc]));
   }
-  env_set(repl_env, "*ARGV*", make_list(list_reverse(lst)));
+  env_set(repl_env, "*ARGV*", make_list(lst));
 
   /* run in script mode if a filename is given */
-  if (argc > 1) {
+  if (argc) {
 
     /* first argument on command line is filename */
-    char* load_command = snprintfbuf(1024, "(load-file \"%s\")", argv[1]);
-    EVAL(READ(load_command), repl_env);
+    const char* load_command = mal_printf("(load-file \"%s\")", argv[1]);
+    re(load_command, repl_env);
   }
   /* run in repl mode when no cmd line args */
   else {
 
-    /* Greeting message */
-    puts("Make-a-lisp version 0.0.6\n");
-    puts("Press Ctrl+d to exit\n");
-
-    while (1) {
+    char* input;
+    while((input = readline(PROMPT_STRING))) {
 
       /* print prompt and get input*/
       /* readline allocates memory for input */
-      char* input = readline(PROMPT_STRING);
-
       /* Check for EOF (Ctrl-D) */
-      if (!input) {
-        printf("\n");
-        return 0;
-      }
-
       /* add input to history */
       add_history(input);
 
@@ -242,160 +234,104 @@ int main(int argc, char** argv) {
       /* have to release the memory used by readline */
       free(input);
     }
+    printf("\n");
   }
-  return 0;
+  return EXIT_SUCCESS;
 }
 
-MalType* eval_defbang(MalType* ast, Env** env) {
+MalType eval_defbang(list lst, Env* env) {
 
-  list lst = (ast->value.mal_list)->next;
+  MalType defbang_symbol = eat_argument(lst);
+  MalType defbang_value = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst || !lst->next || lst->next->next) {
-    return make_error_fmt("'def!': expected exactly two arguments");
-  }
-
-  MalType* defbang_symbol = lst->data;
-
-  if (!is_symbol(defbang_symbol)) {
-    return make_error_fmt("'def!': expected symbol for first argument");
-  }
-
-  MalType* defbang_value = lst->next->data;
-  MalType* result = EVAL(defbang_value, *env);
-
+  MalType result = EVAL(defbang_value, env);
   if (!is_error(result)){
-    env_set(*env, defbang_symbol->value.mal_symbol, result);
+    env_set(env, as_symbol(defbang_symbol), result);
   }
   return result;
 }
 
-void eval_letstar(MalType** ast, Env** env) {
+MalType eval_letstar(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
+  MalType bindings = eat_argument(lst);
+  MalType forms = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst->next) {
-    *ast = make_error("'let*': missing bindings list");
-    return;
-  }
-
-  MalType* bindings = lst->next->data;
-  MalType* forms = lst->next->next ? lst->next->next->data : make_nil();
-
-  if (!is_sequential(bindings)) {
-    *ast = make_error("'let*': first argument is not list or vector");
-    return;
-  }
-
-  list bindings_list = bindings->value.mal_list;
-  if (list_count(bindings_list) % 2 == 1) {
-    *ast = make_error("'let*': expected an even number of binding pairs");
-    return;
-  }
-
-  Env* letstar_env = env_make(*env, NULL, NULL, NULL);
+  list bindings_list = as_sequence(bindings);
+  Env* letstar_env = env_make(*env);
 
   /* evaluate the bindings */
   while(bindings_list) {
 
-    MalType* symbol = bindings_list->data;
-    MalType* value = EVAL(bindings_list->next->data, letstar_env);
+    MalType symbol = bindings_list->data;
+    bindings_list = bindings_list->next;
+    if(!bindings_list) {
+      return make_error_fmt("expected an even number of binding pairs, got: %M",
+                            bindings);
+    }
+    MalType value = EVAL(bindings_list->data, letstar_env);
 
     /* early return from error */
     if (is_error(value)) {
-      *ast = value;
-      return;
+      return value;
     }
 
-    env_set(letstar_env, symbol->value.mal_symbol, value);
-    bindings_list = bindings_list->next->next;
+    env_set(letstar_env, as_symbol(symbol), value);
+    bindings_list = bindings_list->next;
   }
 
   *env = letstar_env;
-  *ast = forms;
-  return;
+  return forms;
 }
 
-void eval_if(MalType** ast, Env** env) {
+MalType eval_if(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
-
-  if (!lst->next || !lst->next->next) {
-    *ast = make_error("'if': too few arguments");
-    return;
+  MalType raw_condition = eat_argument(lst);
+  MalType then_form = eat_argument(lst);
+  MalType else_form;
+  if(lst) {
+    else_form = lst->data;
+    lst = lst->next;
+    check_empty(lst);
+  }
+  else {
+    else_form = NULL;
   }
 
-  if (lst->next->next->next && lst->next->next->next->next) {
-    *ast = make_error("'if': too many arguments");
-    return;
-  }
-
-  MalType* condition = EVAL(lst->next->data, *env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (is_error(condition)) {
-    *ast = condition;
-    return;
+    return condition;
   }
 
   if (is_false(condition) || is_nil(condition)) {
 
     /* check whether false branch is present */
-    if (lst->next->next->next) {
-      *ast = lst->next->next->next->data;
-      return;
+    if(else_form) {
+      return else_form;
     }
     else {
-      *ast = make_nil();
-      return;
+      *env = NULL;              // prevent TCO
+      return make_nil();
     }
 
   } else {
-    *ast = lst->next->next->data;
-    return;
+    return then_form;
   }
 }
 
-MalType* eval_fnstar(MalType* ast, Env* env) {
-
-  /* forward reference */
-  MalType* regularise_parameters(list* params, MalType** more);
-
-  list lst = ast->value.mal_list;
-
-  if (!lst->next) {
-    return make_error("'fn*': missing argument list");
-  }
-  else if (!lst->next->next) {
-    return make_error("'fn*': missing function body");
-  }
-
-  MalType* params = lst->next->data;
-  list params_list = params->value.mal_list;
-
-  MalType* more_symbol = NULL;
-
-  MalType* result = regularise_parameters(&params_list, &more_symbol);
-  if (is_error(result)) { return result; }
-
-  MalType* definition = lst->next->next->data;
-  MalType* regular_params = make_list(params_list);
-
-  return make_closure(env, regular_params, definition, more_symbol);
-}
-
-MalType* eval_do(MalType* ast, Env* env) {
-
-  list lst = ast->value.mal_list;
+MalType eval_do(list lst, Env* env) {
 
   /* handle empty 'do' */
-  if (!lst->next) {
+  if (!lst) {
     return make_nil();
   }
 
   /* evaluate all but the last form */
-  lst = lst->next;
   while (lst->next) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     /* return error early */
     if (is_error(val)) {
@@ -407,156 +343,120 @@ MalType* eval_do(MalType* ast, Env* env) {
   return lst->data;
 }
 
-list evaluate_list(list lst, Env* env) {
+MalType evaluate_list(list* evlst, list lst, Env* env) {
 
-  list evlst = NULL;
+  *evlst = NULL;
+  list* evlst_last = evlst;
   while (lst) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     if (is_error(val)) {
-      return list_make(val);
+      return val;
     }
 
-    evlst = list_push(evlst, val);
+    *evlst_last = list_push(NULL, val);
+    evlst_last = &(*evlst_last)->next;
     lst = lst->next;
   }
-  return list_reverse(evlst);
+  return NULL;
 }
 
-list evaluate_vector(list lst, Env* env) {
+MalType evaluate_vector(list lst, Env* env) {
   /* TODO: implement a real vector */
-  list evlst = NULL;
-  while (lst) {
-
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_vector(evlst);
 }
 
-list evaluate_hashmap(list lst, Env* env) {
+MalType evaluate_hashmap(list lst, Env* env) {
   /* TODO: implement a real hashmap */
-  list evlst = NULL;
-  while (lst) {
-
-    /* keys are unevaluated */
-    evlst = list_push(evlst, lst->data);
-    lst = lst->next;
-
-    /* values are evaluated */
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_hashmap(evlst);
 }
 
-MalType* regularise_parameters(list* args, MalType** more_symbol) {
+MalType eval_fnstar(list lst, const Env* env) {
 
-  /* forward reference */
-  char* symbol_fn(gptr data);
+  MalType a1 = eat_argument(lst);
+  MalType definition = eat_argument(lst);
+  check_empty(lst);
+  list args = as_sequence(a1);
+  size_t param_len = 0;
+  const char** parameters = GC_MALLOC(list_count(args)*sizeof(char*));
+  const char* more_symbol = NULL;
 
-  list regular_args = NULL;
-  while (*args) {
+  while (args) {
 
-    MalType* val = (*args)->data;
+    MalType val = args->data;
 
-    if (!is_symbol(val)) {
-      return make_error_fmt("non-symbol found in fn argument list '%s'", \
-                            pr_str(val, UNREADABLY));
-    }
+    const char* val_sym = as_symbol(val);
 
-    if (val->value.mal_symbol[0] == '&') {
+    if(val_sym[0] == '&') {
 
       /* & is found but there is no symbol */
-      if (val->value.mal_symbol[1] == '\0' && !(*args)->next) {
-        return make_error("missing symbol after '&' in argument list");
-      }
+      if (val_sym[1] == '\0') {
+        if(!args->next) {
+          return make_error_fmt("missing symbol after '&' in argument list");
+        }
       /* & is found and there is a single symbol after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next &&
-                is_symbol((*args)->next->data) && !(*args)->next->next)) {
-
-        /* TODO: check symbol is no a duplicate of one already on the list */
-        *more_symbol = (*args)->next->data;
-        break;
-      }
+        else if(!args->next->next) {
+          more_symbol = as_symbol(args->next->data);
+          break;
+        }
       /* & is found and there extra symbols after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next && (*args)->next->next)) {
-        return make_error_fmt("unexpected symbol after '& %s' in argument list: '%s'", \
-                              pr_str((*args)->next->data, UNREADABLY),  \
-                              pr_str((*args)->next->next->data, UNREADABLY));
+        else {
+          return make_error_fmt("unexpected symbol after '& %M' in argument list: '%M'",
+                                args->next->data, args->next->next->data);
+        }
       }
       /* & is found as part of the symbol and no other symbols */
-      else if (val->value.mal_symbol[1] != '\0' && !(*args)->next) {
-        *more_symbol = make_symbol((val->value.mal_symbol + 1));
+      else if(!args->next) {
+        more_symbol = val_sym + 1;
         break;
       }
       /* & is found as part of the symbol but there are other symbols after */
-      else if (val->value.mal_symbol[1] != '\0' && (*args)->next) {
-        return make_error_fmt("unexpected symbol after '%s' in argument list: '%s'", \
-                              pr_str(val, UNREADABLY),  \
-                              pr_str((*args)->next->data, UNREADABLY));
-       }
+      else {
+        return make_error_fmt("unexpected symbol after '%s' in argument list: '%M'",
+                              val_sym, args->next->data);
+      }
     }
 
     /* & is not found - add the symbol to the regular argument list */
     else {
 
-      if (list_findf(regular_args, val->value.mal_symbol, symbol_fn) > 0) {
-        return make_error_fmt("duplicate symbol in argument list: '%s'", pr_str(val, UNREADABLY));
+      for(size_t i=0; i<param_len; i++) {
+        if(!strcmp(val_sym, parameters[i])) {
+          return make_error_fmt("duplicate symbol in argument list: '%s'",
+                                parameters[i]);
+        }
       }
-      else {
-        regular_args = list_push(regular_args, val);
-      }
+      parameters[param_len++] = val_sym;
     }
-    *args = (*args)->next;
+    args = args->next;
   }
 
-  *args = list_reverse(regular_args);
-  return make_nil();
-}
-
-char* symbol_fn(gptr data) {
-  return (((MalType*)data)->value.mal_symbol);
+  return make_closure(env, param_len, parameters, definition, more_symbol);
 }
 
 /* used by core functions but not EVAL as doesn't do TCE */
-MalType* apply(MalType* fn, list args) {
+MalType apply(MalType fn, list args) {
 
   if (is_function(fn)) {
 
-    MalType* (*fun_ptr)(list) = fn->value.mal_function;
+    MalType(*fun_ptr)(list) = fn->value.mal_function;
     return (*fun_ptr)(args);
   }
-  else { /* is_closure(fn) */
+  else if(is_closure(fn)) {
 
-    MalClosure* c = fn->value.mal_closure;
-    list params = (c->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(args);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !c->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
-      Env* env = env_make(c->env, params, args, c->more_symbol);
-      return EVAL(fn->value.mal_closure->definition, env);
-    }
+    Env* env;
+    MalType ast = env_apply(fn->value.mal_closure, args, &env);
+    if(is_error(ast)) return ast;
+    return EVAL(ast, env);
+  }
+  else {
+    return bad_type(fn, "a function or closure");
   }
 }

--- a/impls/c.2/step7_quote.c
+++ b/impls/c.2/step7_quote.c
@@ -1,11 +1,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gc.h>
 
+#include <gc.h>
 #include <editline/readline.h>
 #include <editline/history.h>
 
+#include "libs/linked_list/linked_list.h"
 #include "types.h"
 #include "reader.h"
 #include "printer.h"
@@ -24,79 +25,95 @@
 
 #define PROMPT_STRING "user> "
 
-MalType* READ(char* str) {
+MalType apply(MalType, list); // For the apply phase and core apply/map/swap.
+MalType evaluate_list(list*, list, Env*);
+// Store the result into the first argument and return NULL
+// If an error occurs, it is returned.
+MalType evaluate_vector(list, Env*);
+MalType evaluate_hashmap(list, Env*);
+MalType eval_defbang(list, Env*);
+MalType eval_letstar(list, Env**); // TCO
+MalType eval_if(list, Env**); // TCO unless the environment is set to NULL.
+MalType eval_fnstar(list, const Env*);
+MalType eval_do(list, Env*); // TCO in the same env
+MalType eval_quote(list);
+MalType eval_quasiquote(list);
+MalType quasiquote(MalType);
+MalType quasiquote_vector(list);
+MalType quasiquote_list(list);
+
+MalType READ(const char* str) {
 
   return read_str(str);
 }
 
-MalType* EVAL(MalType* ast, Env* env) {
+MalType env_apply(MalClosure closure, list args, Env** env) {
+  //  Return the closure definition and update env if all went OK,
+  //  else return an error.
+  Env* fn_env = env_make(closure->env);
+  for(size_t i=0; i<closure->param_len; i++) {
+    env_set(fn_env, closure->parameters[i], eat_argument(args));
+  }
+  /* set the 'more' symbol if there is one */
+  if (closure->more_symbol) {
+    env_set(fn_env, closure->more_symbol, make_list(args));
+  }
+  else {
+    check_empty(args);
+  }
+  *env = fn_env;
+  return closure->definition;
+}
 
-  /* forward references */
-  list evaluate_list(list lst, Env* env);
-  list evaluate_vector(list lst, Env* env);
-  list evaluate_hashmap(list lst, Env* env);
-  MalType* eval_defbang(MalType* ast, Env** env);
-  void eval_letstar(MalType** ast, Env** env);
-  void eval_if(MalType** ast, Env** env);
-  MalType* eval_fnstar(MalType* ast, Env* env);
-  MalType* eval_do(MalType* ast, Env* env);
-  MalType* eval_quote(MalType* ast);
-  MalType* eval_quasiquote(MalType* ast);
+MalType EVAL(MalType ast, Env* env) {
 
   /* Use goto to jump here rather than calling eval for tail-call elimination */
  TCE_entry_point:
 
-  MalType* dbgeval = env_get(env, "DEBUG-EVAL");
+  MalType dbgeval = env_get(env, "DEBUG-EVAL");
   if (dbgeval && ! is_false(dbgeval) && ! is_nil(dbgeval))
-    printf("EVAL: %s\n", pr_str(ast, READABLY));
-
-  /* NULL */
-  if (!ast) { return make_nil(); }
+    printf("EVAL: %M\n", ast);
 
   if (is_symbol(ast)) {
-    MalType* symbol_value = env_get(env, ast->value.mal_symbol);
+    MalType symbol_value = env_get(env, ast->value.mal_string);
     if (symbol_value)
       return symbol_value;
     else
-      return make_error_fmt("'%s' not found", ast->value.mal_symbol);
+      // make_error would prefix with EVAL: and break some tests
+      return wrap_error(make_string(mal_printf("'%M' not found", ast)));
   }
 
   if (is_vector(ast)) {
-    list result = evaluate_vector(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_vector(result);
+    return evaluate_vector(ast->value.mal_list, env);
   }
 
   if (is_hashmap(ast)) {
-    list result = evaluate_hashmap(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_hashmap(result);
+    return evaluate_hashmap(ast->value.mal_list, env);
   }
 
   /* not a list */
   if (!is_list(ast)) { return ast; }
 
+  list lst = ast->value.mal_list;
+
   /* empty list */
-  if (ast->value.mal_list == NULL) { return ast; }
+  if(lst == NULL) { return ast; }
 
   /* list */
-  MalType* first = (ast->value.mal_list)->data;
-  char* symbol = first->value.mal_symbol;
+  MalType first = lst->data;
+  lst = lst->next;
 
-  if (is_symbol(first)) {
+  if(is_symbol(first)) {
+    const char* symbol = first->value.mal_string;
 
     /* handle special symbols first */
     if (strcmp(symbol, SYMBOL_DEFBANG) == 0) {
-      return eval_defbang(ast, &env);
+      return eval_defbang(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_LETSTAR) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      eval_letstar(&ast, &env);
+      ast = eval_letstar(lst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
@@ -104,152 +121,129 @@ MalType* EVAL(MalType* ast, Env* env) {
     else if (strcmp(symbol, SYMBOL_IF) == 0) {
 
       /* TCE - modify ast directly and jump back to eval */
-      eval_if(&ast, &env);
+      ast = eval_if(lst, &env);
 
       if (is_error(ast)) { return ast; }
-      goto TCE_entry_point;
+      if(env) goto TCE_entry_point; else return ast;
     }
     else if (strcmp(symbol, SYMBOL_FNSTAR) == 0) {
-      return eval_fnstar(ast, env);
+      return eval_fnstar(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_DO) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(ast, env);
+      ast = eval_do(lst, env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
     }
     else if (strcmp(symbol, SYMBOL_QUOTE) == 0) {
-      return eval_quote(ast);
+      return eval_quote(lst);
     }
     else if (strcmp(symbol, SYMBOL_QUASIQUOTE) == 0) {
 
-      ast = eval_quasiquote(ast);
+      ast = eval_quasiquote(lst);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
     }
   }
-
   /* first element is not a special symbol */
-  list evlst = evaluate_list(ast->value.mal_list, env);
-  if (is_error(evlst->data)) return evlst->data;
+  MalType func = EVAL(first, env);
+  if (is_error(func)) { return func; }
+  //  Evaluate the arguments
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
 
   /* apply the first element of the list to the arguments */
-  MalType* func = evlst->data;
+  if (is_closure(func)) {
 
-  if (is_function(func)) {
-    return (*func->value.mal_function)(evlst->next);
-  }
-  else if (is_closure(func)) {
-
-    MalClosure* closure = func->value.mal_closure;
-    list params = (closure->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(evlst->next);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !closure->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
+      MalClosure closure = func->value.mal_closure;
 
       /* TCE - modify ast and env directly and jump back to eval */
-      env = env_make(closure->env, params, evlst->next, closure->more_symbol);
-      ast = func->value.mal_closure->definition;
+      ast = env_apply(closure, evlst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
-    }
   }
-  else {
-    return make_error_fmt("first item in list is not callable: '%s'",   \
-                          pr_str(func, UNREADABLY));
-  }
+  return apply(func, evlst);
 }
 
-void PRINT(MalType* val) {
+void PRINT(MalType val) {
 
-  char* output = pr_str(val, READABLY);
-  printf("%s\n", output);
+  printf("%M\n", val);
 }
 
-void rep(char* str, Env* env) {
+void rep(const char* str, Env* env) {
 
   PRINT(EVAL(READ(str), env));
+}
+
+//  Variant reporting errors during startup.
+void re(const char *str, Env* env) {
+  MalType result = EVAL(READ(str), env);
+  if(is_error(result)) {
+    printf("Error during startup: %M\n", result);
+    exit(EXIT_FAILURE);
+  }
 }
 
 /* declare as global so it can be accessed by mal_eval */
 Env* global_env;
 
-MalType* mal_eval(list args) {
+MalType mal_eval(list args) {
 
-  MalType* ast = args->data;
+  MalType ast = eat_argument(args);
+  check_empty(args);
   return EVAL(ast, global_env);
 }
 
 int main(int argc, char** argv) {
 
-  Env* repl_env = env_make(NULL, NULL, NULL, NULL);
+  printer_init();
+
+  Env* repl_env = env_make(NULL);
   global_env = repl_env;
 
-  ns* core = ns_make_core();
-  hashmap mappings = core->mappings;
-
-  while (mappings) {
-    char* symbol = mappings->data;
-    MalType*(*function)(list) = (MalType*(*)(list))mappings->next->data;
-
+  ns core;
+  size_t core_size;
+  ns_make_core(&core, &core_size);
+  while(core_size--) {
+    const char* symbol = core[core_size].key;
+    function_t function = core[core_size].value;
     env_set(repl_env, symbol, make_function(function));
-
-    /* pop symbol and function from hashmap/list */
-    mappings = mappings->next->next;
   }
 
   env_set(repl_env, "eval", make_function(mal_eval));
 
   /* add functions written in mal - not using rep as it prints the result */
-  EVAL(READ("(def! not (fn* (a) (if a false true)))"), repl_env);
-  EVAL(READ("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))"), repl_env);
-
+  re("(def! not (fn* (a) (if a false true)))", repl_env);
+  re("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))", repl_env);
 
   /* make command line arguments available in the environment */
   list lst = NULL;
-  for (long i = 2; i < argc; i++) {
-    lst = list_push(lst, make_string(argv[i]));
+  while(1 < --argc) {
+    lst = list_push(lst, make_string(argv[argc]));
   }
-  env_set(repl_env, "*ARGV*", make_list(list_reverse(lst)));
+  env_set(repl_env, "*ARGV*", make_list(lst));
 
   /* run in script mode if a filename is given */
-  if (argc > 1) {
+  if (argc) {
 
     /* first argument on command line is filename */
-    char* load_command = snprintfbuf(1024, "(load-file \"%s\")", argv[1]);
-    EVAL(READ(load_command), repl_env);
+    const char* load_command = mal_printf("(load-file \"%s\")", argv[1]);
+    re(load_command, repl_env);
   }
   /* run in repl mode when no cmd line args */
   else {
 
-    /* Greeting message */
-    puts("Make-a-lisp version 0.0.7\n");
-    puts("Press Ctrl+d to exit\n");
-
-    while (1) {
+    char* input;
+    while((input = readline(PROMPT_STRING))) {
 
       /* print prompt and get input*/
       /* readline allocates memory for input */
-      char* input = readline(PROMPT_STRING);
-
       /* Check for EOF (Ctrl-D) */
-      if (!input) {
-        printf("\n\n");
-        return 0;
-      }
-
       /* add input to history */
       add_history(input);
 
@@ -259,160 +253,104 @@ int main(int argc, char** argv) {
       /* have to release the memory used by readline */
       free(input);
     }
+    printf("\n");
   }
-  return 0;
+  return EXIT_SUCCESS;
 }
 
-MalType* eval_defbang(MalType* ast, Env** env) {
+MalType eval_defbang(list lst, Env* env) {
 
-  list lst = (ast->value.mal_list)->next;
+  MalType defbang_symbol = eat_argument(lst);
+  MalType defbang_value = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst || !lst->next || lst->next->next) {
-    return make_error_fmt("'def!': expected exactly two arguments");
-  }
-
-  MalType* defbang_symbol = lst->data;
-
-  if (!is_symbol(defbang_symbol)) {
-    return make_error_fmt("'def!': expected symbol for first argument");
-  }
-
-  MalType* defbang_value = lst->next->data;
-  MalType* result = EVAL(defbang_value, *env);
-
+  MalType result = EVAL(defbang_value, env);
   if (!is_error(result)){
-    env_set(*env, defbang_symbol->value.mal_symbol, result);
+    env_set(env, as_symbol(defbang_symbol), result);
   }
   return result;
 }
 
-void eval_letstar(MalType** ast, Env** env) {
+MalType eval_letstar(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
+  MalType bindings = eat_argument(lst);
+  MalType forms = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst->next) {
-    *ast = make_error("'let*': missing bindings list");
-    return;
-  }
-
-  MalType* bindings = lst->next->data;
-  MalType* forms = lst->next->next ? lst->next->next->data : make_nil();
-
-  if (!is_sequential(bindings)) {
-    *ast = make_error("'let*': first argument is not list or vector");
-    return;
-  }
-
-  list bindings_list = bindings->value.mal_list;
-  if (list_count(bindings_list) % 2 == 1) {
-    *ast = make_error("'let*': expected an even number of binding pairs");
-    return;
-  }
-
-  Env* letstar_env = env_make(*env, NULL, NULL, NULL);
+  list bindings_list = as_sequence(bindings);
+  Env* letstar_env = env_make(*env);
 
   /* evaluate the bindings */
   while(bindings_list) {
 
-    MalType* symbol = bindings_list->data;
-    MalType* value = EVAL(bindings_list->next->data, letstar_env);
+    MalType symbol = bindings_list->data;
+    bindings_list = bindings_list->next;
+    if(!bindings_list) {
+      return make_error_fmt("expected an even number of binding pairs, got: %M",
+                            bindings);
+    }
+    MalType value = EVAL(bindings_list->data, letstar_env);
 
     /* early return from error */
     if (is_error(value)) {
-      *ast = value;
-      return;
+      return value;
     }
 
-    env_set(letstar_env, symbol->value.mal_symbol, value);
-    bindings_list = bindings_list->next->next;
+    env_set(letstar_env, as_symbol(symbol), value);
+    bindings_list = bindings_list->next;
   }
 
   *env = letstar_env;
-  *ast = forms;
-  return;
+  return forms;
 }
 
-void eval_if(MalType** ast, Env** env) {
+MalType eval_if(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
-
-  if (!lst->next || !lst->next->next) {
-    *ast = make_error("'if': too few arguments");
-    return;
+  MalType raw_condition = eat_argument(lst);
+  MalType then_form = eat_argument(lst);
+  MalType else_form;
+  if(lst) {
+    else_form = lst->data;
+    lst = lst->next;
+    check_empty(lst);
+  }
+  else {
+    else_form = NULL;
   }
 
-  if (lst->next->next->next && lst->next->next->next->next) {
-    *ast = make_error("'if': too many arguments");
-    return;
-  }
-
-  MalType* condition = EVAL(lst->next->data, *env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (is_error(condition)) {
-    *ast = condition;
-    return;
+    return condition;
   }
 
   if (is_false(condition) || is_nil(condition)) {
 
     /* check whether false branch is present */
-    if (lst->next->next->next) {
-      *ast = lst->next->next->next->data;
-      return;
+    if(else_form) {
+      return else_form;
     }
     else {
-      *ast = make_nil();
-      return;
+      *env = NULL;              // prevent TCO
+      return make_nil();
     }
 
   } else {
-    *ast = lst->next->next->data;
-    return;
+    return then_form;
   }
 }
 
-MalType* eval_fnstar(MalType* ast, Env* env) {
-
-  /* forward reference */
-  MalType* regularise_parameters(list* params, MalType** more);
-
-  list lst = ast->value.mal_list;
-
-  if (!lst->next) {
-    return make_error("'fn*': missing argument list");
-  }
-  else if (!lst->next->next) {
-    return make_error("'fn*': missing function body");
-  }
-
-  MalType* params = lst->next->data;
-  list params_list = params->value.mal_list;
-
-  MalType* more_symbol = NULL;
-
-  MalType* result = regularise_parameters(&params_list, &more_symbol);
-  if (is_error(result)) { return result; }
-
-  MalType* definition = lst->next->next->data;
-  MalType* regular_params = make_list(params_list);
-
-  return make_closure(env, regular_params, definition, more_symbol);
-}
-
-MalType* eval_do(MalType* ast, Env* env) {
-
-  list lst = ast->value.mal_list;
+MalType eval_do(list lst, Env* env) {
 
   /* handle empty 'do' */
-  if (!lst->next) {
+  if (!lst) {
     return make_nil();
   }
 
   /* evaluate all but the last form */
-  lst = lst->next;
   while (lst->next) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     /* return error early */
     if (is_error(val)) {
@@ -424,113 +362,75 @@ MalType* eval_do(MalType* ast, Env* env) {
   return lst->data;
 }
 
-MalType* eval_quote(MalType* ast) {
+MalType eval_quote(list lst) {
 
-  list lst = (ast->value.mal_list)->next;
-
-  if (!lst) {
-    return make_nil();
-  }
-  else if (lst->next) {
-    return make_error("'quote': expected exactly one argument");
-  }
-  else {
-    return lst->data;
-  }
+  MalType form = eat_argument(lst);
+  check_empty(lst);
+  return form;
 }
 
-MalType* eval_quasiquote(MalType* ast) {
-
-  /* forward reference */
-  MalType* quasiquote(MalType* ast);
-
-  list lst = ast->value.mal_list;
-
-  /* no arguments (quasiquote) */
-  if (!lst->next) {
-    return make_nil();
-  }
-
-  /* too many arguments */
-  else if (lst->next->next) {
-    return make_error("'quasiquote': expected exactly one argument");
-  }
-  return quasiquote(lst->next->data);
+MalType eval_quasiquote(list lst) {
+  MalType form = eat_argument(lst);
+  check_empty(lst);
+  return quasiquote(form);
 }
 
-MalType* quasiquote(MalType* ast) {
-
-  /* forward references */
-  MalType* quasiquote_list(MalType* ast);
-  MalType* quasiquote_vector(MalType* ast);
-
-  /* argument to quasiquote is self-evaluating: (quasiquote val)
-     => val */
-  if (is_self_evaluating(ast)) {
-    return ast;
-  }
+MalType quasiquote(MalType ast) {
 
   /* argument to quasiquote is a vector: (quasiquote [first rest]) */
-  else if (is_vector(ast)) {
+  if (is_vector(ast)) {
 
-    return quasiquote_vector(ast);
+    return quasiquote_vector(ast->value.mal_list);
   }
 
   /* argument to quasiquote is a list: (quasiquote (first rest)) */
   else if (is_list(ast)){
 
-    return quasiquote_list(ast);
+    list lst = ast->value.mal_list;
+    if(lst) {
+      MalType first = lst->data;
+      if(is_symbol(first)
+         && !strcmp(first->value.mal_string, SYMBOL_UNQUOTE)) {
+        lst = lst->next;
+        MalType unquoted = eat_argument(lst);
+        check_empty(lst);
+        return unquoted;
+      }
+    }
+    return quasiquote_list(lst);
   }
   /* argument to quasiquote is not self-evaluating and isn't sequential: (quasiquote val)
      => (quote val) */
-  else {
+  else if(is_hashmap(ast) || is_symbol(ast)) {
 
-    list lst = list_make(ast);
+    list lst = NULL;
+    lst = list_push(lst, ast);
     lst = list_push(lst, make_symbol("quote"));
     return make_list(lst);
   }
+  /* argument to quasiquote is self-evaluating: (quasiquote val)
+     => val */
+  else {
+    return ast;
+  }
 }
 
-MalType* quasiquote_vector(MalType* ast) {
+MalType quasiquote_vector(list args) {
 
-  /* forward references */
-  MalType* quasiquote_list(MalType* ast);
-
-  list args = ast->value.mal_list;
-
-  if (args) {
-
-    MalType* first = args->data;
-
-    /* if first element is unquote return quoted */
-    if (is_symbol(first) && strcmp(first->value.mal_symbol, SYMBOL_UNQUOTE) == 0) {
-
-      list lst = list_make(ast);
-      lst = list_push(lst, make_symbol("quote"));
-
-      return make_list(lst);
-    }
-  }
-
-  /* otherwise process like a list */
-
-  list lst = list_make(make_symbol("vec"));
-
-  MalType* result = quasiquote_list(ast);
+  MalType result = quasiquote_list(args);
 
   if (is_error(result)) {
     return result;
   } else {
+    list lst = NULL;
     lst = list_push(lst, result);
-  }
+    lst = list_push(lst, make_symbol("vec"));
 
-  lst = list_reverse(lst);
-  return make_list(lst);
+    return make_list(lst);
+  }
 }
 
-MalType* quasiquote_list(MalType* ast) {
-
-    list args = ast->value.mal_list;
+MalType quasiquote_list(list args) {
 
     /* handle empty list: (quasiquote ())
        => () */
@@ -538,220 +438,149 @@ MalType* quasiquote_list(MalType* ast) {
       return make_list(NULL);
     }
 
-    MalType* first = args->data;
+    MalType first = args->data;
 
-    /* handle unquote: (quasiquote (unquote second))
-       => second */
-     if (is_symbol(first) && strcmp(first->value.mal_symbol, SYMBOL_UNQUOTE) == 0 && args->next) {
-
-      if (args->next->next) {
-    	return make_error("'quasiquote': unquote expected exactly one argument");
-      }
-      else {
-    	return args->next->data;
-      }
-    }
+    MalType qq_rest = quasiquote_list(args->next);
+    if(is_error(qq_rest)) return qq_rest;
 
     /* handle splice-unquote: (quasiquote ((splice-unquote first-second) rest))
        => (concat first-second (quasiquote rest)) */
-    else if (is_list(first) &&
-	     first->value.mal_list != NULL &&
-	     is_symbol(first->value.mal_list->data) &&
-             strcmp(((MalType*)first->value.mal_list->data)->value.mal_symbol, SYMBOL_SPLICE_UNQUOTE) == 0) {
-
-      if (!first->value.mal_list->next) {
-        return make_error("'quasiquote': splice-unquote expected exactly one argument");
+    if(is_list(first)) {
+      list lst = first->value.mal_list;
+      if(lst) {
+        MalType lst_first = lst->data;
+        if(is_symbol(lst_first)
+           && !strcmp(lst_first->value.mal_string, SYMBOL_SPLICE_UNQUOTE)) {
+          lst = lst->next;
+          MalType unquoted = eat_argument(lst);
+          check_empty(lst);
+          return make_list(list_push(list_push(list_push(NULL, qq_rest),
+                                               unquoted),
+                                     make_symbol("concat")));
+        }
       }
-
-      MalType* first_second = first->value.mal_list->next->data;
-      list lst = list_make(make_symbol("concat"));
-      lst = list_push(lst, first_second);
-
-      MalType* rest = quasiquote(make_list(args->next));
-      if (is_error(rest)) {
-        return rest;
-      }
-
-      lst = list_push(lst, rest);
-      lst = list_reverse(lst);
-
-      return make_list(lst);
     }
-    /* handle all other lists recursively: (quasiquote (first rest))
-       => (cons (quasiquote first) (quasiquote rest)) */
-    else {
-
-      list lst = list_make(make_symbol("cons"));
-
-      MalType* first = quasiquote(args->data);
-      if (is_error(first)) {
-        return first;
-      } else {
-        lst = list_push(lst, first);
-      }
-
-      MalType* rest = quasiquote(make_list(args->next));
-      if (is_error(rest)) {
-        return rest;
-      } else {
-        lst = list_push(lst, rest);
-      }
-
-      lst = list_reverse(lst);
-      return make_list(lst);
-    }
+    MalType qqted = quasiquote(first);
+    if(is_error(qqted)) return qqted;
+    return make_list(list_push(list_push(list_push(NULL, qq_rest),
+                                         quasiquote(first)),
+                               make_symbol("cons")));
 }
 
-list evaluate_list(list lst, Env* env) {
+MalType evaluate_list(list* evlst, list lst, Env* env) {
 
-  list evlst = NULL;
+  *evlst = NULL;
+  list* evlst_last = evlst;
   while (lst) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     if (is_error(val)) {
-      return list_make(val);
+      return val;
     }
 
-    evlst = list_push(evlst, val);
+    *evlst_last = list_push(NULL, val);
+    evlst_last = &(*evlst_last)->next;
     lst = lst->next;
   }
-  return list_reverse(evlst);
+  return NULL;
 }
 
-list evaluate_vector(list lst, Env* env) {
+MalType evaluate_vector(list lst, Env* env) {
   /* TODO: implement a real vector */
-  list evlst = NULL;
-  while (lst) {
-
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_vector(evlst);
 }
 
-list evaluate_hashmap(list lst, Env* env) {
+MalType evaluate_hashmap(list lst, Env* env) {
   /* TODO: implement a real hashmap */
-  list evlst = NULL;
-  while (lst) {
-
-    /* keys are unevaluated */
-    evlst = list_push(evlst, lst->data);
-    lst = lst->next;
-
-    /* values are evaluated */
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_hashmap(evlst);
 }
 
-MalType* regularise_parameters(list* args, MalType** more_symbol) {
+MalType eval_fnstar(list lst, const Env* env) {
 
-  /* forward reference */
-  char* symbol_fn(gptr data);
+  MalType a1 = eat_argument(lst);
+  MalType definition = eat_argument(lst);
+  check_empty(lst);
+  list args = as_sequence(a1);
+  size_t param_len = 0;
+  const char** parameters = GC_MALLOC(list_count(args)*sizeof(char*));
+  const char* more_symbol = NULL;
 
-  list regular_args = NULL;
-  while (*args) {
+  while (args) {
 
-    MalType* val = (*args)->data;
+    MalType val = args->data;
 
-    if (!is_symbol(val)) {
-      return make_error_fmt("non-symbol found in fn argument list '%s'", \
-                            pr_str(val, UNREADABLY));
-    }
+    const char* val_sym = as_symbol(val);
 
-    if (val->value.mal_symbol[0] == '&') {
+    if(val_sym[0] == '&') {
 
       /* & is found but there is no symbol */
-      if (val->value.mal_symbol[1] == '\0' && !(*args)->next) {
-        return make_error("missing symbol after '&' in argument list");
-      }
+      if (val_sym[1] == '\0') {
+        if(!args->next) {
+          return make_error_fmt("missing symbol after '&' in argument list");
+        }
       /* & is found and there is a single symbol after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next &&
-                is_symbol((*args)->next->data) && !(*args)->next->next)) {
-
-        /* TODO: check symbol is no a duplicate of one already on the list */
-        *more_symbol = (*args)->next->data;
-        break;
-      }
+        else if(!args->next->next) {
+          more_symbol = as_symbol(args->next->data);
+          break;
+        }
       /* & is found and there extra symbols after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next && (*args)->next->next)) {
-        return make_error_fmt("unexpected symbol after '& %s' in argument list: '%s'", \
-                              pr_str((*args)->next->data, UNREADABLY),  \
-                              pr_str((*args)->next->next->data, UNREADABLY));
+        else {
+          return make_error_fmt("unexpected symbol after '& %M' in argument list: '%M'",
+                                args->next->data, args->next->next->data);
+        }
       }
       /* & is found as part of the symbol and no other symbols */
-      else if (val->value.mal_symbol[1] != '\0' && !(*args)->next) {
-        *more_symbol = make_symbol((val->value.mal_symbol + 1));
+      else if(!args->next) {
+        more_symbol = val_sym + 1;
         break;
       }
       /* & is found as part of the symbol but there are other symbols after */
-      else if (val->value.mal_symbol[1] != '\0' && (*args)->next) {
-        return make_error_fmt("unexpected symbol after '%s' in argument list: '%s'", \
-                              pr_str(val, UNREADABLY),  \
-                              pr_str((*args)->next->data, UNREADABLY));
-       }
+      else {
+        return make_error_fmt("unexpected symbol after '%s' in argument list: '%M'",
+                              val_sym, args->next->data);
+      }
     }
 
     /* & is not found - add the symbol to the regular argument list */
     else {
 
-      if (list_findf(regular_args, val->value.mal_symbol, symbol_fn) > 0) {
-        return make_error_fmt("duplicate symbol in argument list: '%s'", pr_str(val, UNREADABLY));
+      for(size_t i=0; i<param_len; i++) {
+        if(!strcmp(val_sym, parameters[i])) {
+          return make_error_fmt("duplicate symbol in argument list: '%s'",
+                                parameters[i]);
+        }
       }
-      else {
-        regular_args = list_push(regular_args, val);
-      }
+      parameters[param_len++] = val_sym;
     }
-    *args = (*args)->next;
+    args = args->next;
   }
 
-  *args = list_reverse(regular_args);
-  return make_nil();
-}
-
-char* symbol_fn(gptr data) {
-  return (((MalType*)data)->value.mal_symbol);
+  return make_closure(env, param_len, parameters, definition, more_symbol);
 }
 
 /* used by core functions but not EVAL as doesn't do TCE */
-MalType* apply(MalType* fn, list args) {
+MalType apply(MalType fn, list args) {
 
   if (is_function(fn)) {
 
-    MalType* (*fun_ptr)(list) = fn->value.mal_function;
+    MalType(*fun_ptr)(list) = fn->value.mal_function;
     return (*fun_ptr)(args);
   }
-  else { /* is_closure(fn) */
+  else if(is_closure(fn)) {
 
-    MalClosure* c = fn->value.mal_closure;
-    list params = (c->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(args);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !c->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
-      Env* env = env_make(c->env, params, args, c->more_symbol);
-      return EVAL(fn->value.mal_closure->definition, env);
-    }
+    Env* env;
+    MalType ast = env_apply(fn->value.mal_closure, args, &env);
+    if(is_error(ast)) return ast;
+    return EVAL(ast, env);
+  }
+  else {
+    return bad_type(fn, "a function or closure");
   }
 }

--- a/impls/c.2/step8_macros.c
+++ b/impls/c.2/step8_macros.c
@@ -1,11 +1,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gc.h>
 
+#include <gc.h>
 #include <editline/readline.h>
 #include <editline/history.h>
 
+#include "libs/linked_list/linked_list.h"
 #include "types.h"
 #include "reader.h"
 #include "printer.h"
@@ -25,81 +26,96 @@
 
 #define PROMPT_STRING "user> "
 
-MalType* READ(char* str) {
+MalType apply(MalType, list); // For the apply phase and core apply/map/swap.
+MalType evaluate_list(list*, list, Env*);
+// Store the result into the first argument and return NULL
+// If an error occurs, it is returned.
+MalType evaluate_vector(list, Env*);
+MalType evaluate_hashmap(list, Env*);
+MalType eval_defbang(list, Env*);
+MalType eval_letstar(list, Env**); // TCO
+MalType eval_if(list, Env**); // TCO unless the environment is set to NULL.
+MalType eval_fnstar(list, const Env*);
+MalType eval_do(list, Env*); // TCO in the same env
+MalType eval_quote(list);
+MalType eval_quasiquote(list);
+MalType quasiquote(MalType);
+MalType quasiquote_vector(list);
+MalType quasiquote_list(list);
+MalType eval_defmacrobang(list, Env*);
+
+MalType READ(const char* str) {
 
   return read_str(str);
 }
 
-MalType* EVAL(MalType* ast, Env* env) {
+MalType env_apply(MalClosure closure, list args, Env** env) {
+  //  Return the closure definition and update env if all went OK,
+  //  else return an error.
+  Env* fn_env = env_make(closure->env);
+  for(size_t i=0; i<closure->param_len; i++) {
+    env_set(fn_env, closure->parameters[i], eat_argument(args));
+  }
+  /* set the 'more' symbol if there is one */
+  if (closure->more_symbol) {
+    env_set(fn_env, closure->more_symbol, make_list(args));
+  }
+  else {
+    check_empty(args);
+  }
+  *env = fn_env;
+  return closure->definition;
+}
 
-  /* forward references */
-  MalType* apply(MalType* fn, list args);
-  list evaluate_list(list lst, Env* env);
-  list evaluate_vector(list lst, Env* env);
-  list evaluate_hashmap(list lst, Env* env);
-  MalType* eval_defbang(MalType* ast, Env** env);
-  void eval_letstar(MalType** ast, Env** env);
-  void eval_if(MalType** ast, Env** env);
-  MalType* eval_fnstar(MalType* ast, Env* env);
-  MalType* eval_do(MalType* ast, Env* env);
-  MalType* eval_quote(MalType* ast);
-  MalType* eval_quasiquote(MalType* ast);
-  MalType* eval_defmacrobang(MalType*, Env** env);
+MalType EVAL(MalType ast, Env* env) {
 
   /* Use goto to jump here rather than calling eval for tail-call elimination */
  TCE_entry_point:
 
-  MalType* dbgeval = env_get(env, "DEBUG-EVAL");
+  MalType dbgeval = env_get(env, "DEBUG-EVAL");
   if (dbgeval && ! is_false(dbgeval) && ! is_nil(dbgeval))
-    printf("EVAL: %s\n", pr_str(ast, READABLY));
-
-   /* NULL */
-  if (!ast) { return make_nil(); }
+    printf("EVAL: %M\n", ast);
 
   if (is_symbol(ast)) {
-    MalType* symbol_value = env_get(env, ast->value.mal_symbol);
+    MalType symbol_value = env_get(env, ast->value.mal_string);
     if (symbol_value)
       return symbol_value;
     else
-      return make_error_fmt("'%s' not found", ast->value.mal_symbol);
+      // make_error would prefix with EVAL: and break some tests
+      return wrap_error(make_string(mal_printf("'%M' not found", ast)));
   }
 
   if (is_vector(ast)) {
-    list result = evaluate_vector(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_vector(result);
+    return evaluate_vector(ast->value.mal_list, env);
   }
 
   if (is_hashmap(ast)) {
-    list result = evaluate_hashmap(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_hashmap(result);
+    return evaluate_hashmap(ast->value.mal_list, env);
   }
 
   /* not a list */
   if (!is_list(ast)) { return ast; }
 
+  list lst = ast->value.mal_list;
+
   /* empty list */
-  if (ast->value.mal_list == NULL) { return ast; }
+  if(lst == NULL) { return ast; }
 
   /* list */
-  MalType* first = (ast->value.mal_list)->data;
-  char* symbol = first->value.mal_symbol;
+  MalType first = lst->data;
+  lst = lst->next;
 
-  if (is_symbol(first)) {
+  if(is_symbol(first)) {
+    const char* symbol = first->value.mal_string;
 
     /* handle special symbols first */
     if (strcmp(symbol, SYMBOL_DEFBANG) == 0) {
-      return eval_defbang(ast, &env);
+      return eval_defbang(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_LETSTAR) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      eval_letstar(&ast, &env);
+      ast = eval_letstar(lst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
@@ -107,160 +123,138 @@ MalType* EVAL(MalType* ast, Env* env) {
     else if (strcmp(symbol, SYMBOL_IF) == 0) {
 
       /* TCE - modify ast directly and jump back to eval */
-      eval_if(&ast, &env);
+      ast = eval_if(lst, &env);
 
       if (is_error(ast)) { return ast; }
-      goto TCE_entry_point;
+      if(env) goto TCE_entry_point; else return ast;
     }
     else if (strcmp(symbol, SYMBOL_FNSTAR) == 0) {
-      return eval_fnstar(ast, env);
+      return eval_fnstar(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_DO) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(ast, env);
+      ast = eval_do(lst, env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
     }
     else if (strcmp(symbol, SYMBOL_QUOTE) == 0) {
-      return eval_quote(ast);
+      return eval_quote(lst);
     }
     else if (strcmp(symbol, SYMBOL_QUASIQUOTE) == 0) {
 
-      ast = eval_quasiquote(ast);
+      ast = eval_quasiquote(lst);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
     }
     else if (strcmp(symbol, SYMBOL_DEFMACROBANG) == 0) {
-      return eval_defmacrobang(ast, &env);
+      return eval_defmacrobang(lst, env);
     }
   }
-
   /* first element is not a special symbol */
-  MalType* func = EVAL(first, env);
+  MalType func = EVAL(first, env);
   if (is_error(func)) { return func; }
-  if (func->is_macro) {
-    ast = apply(func, ast->value.mal_list->next);
+  if(func->type == MALTYPE_MACRO) {
+    ast = apply(func, lst);
     if (is_error(ast)) { return ast; }
     goto TCE_entry_point;
   }
-  list evlst = evaluate_list(ast->value.mal_list->next, env);
-  if (evlst && is_error(evlst->data)) { return evlst->data; }
+  //  Evaluate the arguments
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
 
   /* apply the first element of the list to the arguments */
-  if (is_function(func)) {
-    return (*func->value.mal_function)(evlst);
-  }
-  else if (is_closure(func)) {
+  if (is_closure(func)) {
 
-    MalClosure* closure = func->value.mal_closure;
-    list params = (closure->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(evlst);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !closure->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
+      MalClosure closure = func->value.mal_closure;
 
       /* TCE - modify ast and env directly and jump back to eval */
-      env = env_make(closure->env, params, evlst, closure->more_symbol);
-      ast = func->value.mal_closure->definition;
+      ast = env_apply(closure, evlst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
-    }
   }
-  else {
-    return make_error_fmt("first item in list is not callable: '%s'",   \
-                          pr_str(func, UNREADABLY));
-  }
+  return apply(func, evlst);
 }
 
-void PRINT(MalType* val) {
+void PRINT(MalType val) {
 
-  char* output = pr_str(val, READABLY);
-  printf("%s\n", output);
+  printf("%M\n", val);
 }
 
-void rep(char* str, Env* env) {
+void rep(const char* str, Env* env) {
 
   PRINT(EVAL(READ(str), env));
+}
+
+//  Variant reporting errors during startup.
+void re(const char *str, Env* env) {
+  MalType result = EVAL(READ(str), env);
+  if(is_error(result)) {
+    printf("Error during startup: %M\n", result);
+    exit(EXIT_FAILURE);
+  }
 }
 
 /* declare as global so it can be accessed by mal_eval */
 Env* global_env;
 
-MalType* mal_eval(list args) {
+MalType mal_eval(list args) {
 
-  MalType* ast = args->data;
+  MalType ast = eat_argument(args);
+  check_empty(args);
   return EVAL(ast, global_env);
 }
 
 int main(int argc, char** argv) {
 
-  Env* repl_env = env_make(NULL, NULL, NULL, NULL);
+  printer_init();
+
+  Env* repl_env = env_make(NULL);
   global_env = repl_env;
 
-  ns* core = ns_make_core();
-  hashmap mappings = core->mappings;
-
-  while (mappings) {
-    char* symbol = mappings->data;
-    MalType*(*function)(list) = (MalType*(*)(list))mappings->next->data;
-
+  ns core;
+  size_t core_size;
+  ns_make_core(&core, &core_size);
+  while(core_size--) {
+    const char* symbol = core[core_size].key;
+    function_t function = core[core_size].value;
     env_set(repl_env, symbol, make_function(function));
-
-    /* pop symbol and function from hashmap/list */
-    mappings = mappings->next->next;
   }
 
   env_set(repl_env, "eval", make_function(mal_eval));
 
   /* add functions written in mal - not using rep as it prints the result */
-  EVAL(READ("(def! not (fn* (a) (if a false true)))"), repl_env);
-  EVAL(READ("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))"), repl_env);
-  EVAL(READ("(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))"), repl_env);
+  re("(def! not (fn* (a) (if a false true)))", repl_env);
+  re("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))", repl_env);
+  re("(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))", repl_env);
 
   /* make command line arguments available in the environment */
   list lst = NULL;
-  for (long i = 2; i < argc; i++) {
-    lst = list_push(lst, make_string(argv[i]));
+  while(1 < --argc) {
+    lst = list_push(lst, make_string(argv[argc]));
   }
-  env_set(repl_env, "*ARGV*", make_list(list_reverse(lst)));
+  env_set(repl_env, "*ARGV*", make_list(lst));
 
   /* run in script mode if a filename is given */
-  if (argc > 1) {
+  if (argc) {
 
     /* first argument on command line is filename */
-    char* load_command = snprintfbuf(1024, "(load-file \"%s\")", argv[1]);
-    EVAL(READ(load_command), repl_env);
+    const char* load_command = mal_printf("(load-file \"%s\")", argv[1]);
+    re(load_command, repl_env);
   }
   /* run in repl mode when no cmd line args */
   else {
 
-    /* Greeting message */
-    puts("Make-a-lisp version 0.0.8\n");
-    puts("Press Ctrl+d to exit\n");
-
-    while (1) {
+    char* input;
+    while((input = readline(PROMPT_STRING))) {
 
       /* print prompt and get input*/
       /* readline allocates memory for input */
-      char* input = readline(PROMPT_STRING);
-
       /* Check for EOF (Ctrl-D) */
-      if (!input) {
-        printf("\n\n");
-        return 0;
-      }
-
       /* add input to history */
       add_history(input);
 
@@ -270,160 +264,104 @@ int main(int argc, char** argv) {
       /* have to release the memory used by readline */
       free(input);
     }
+    printf("\n");
   }
-  return 0;
+  return EXIT_SUCCESS;
 }
 
-MalType* eval_defbang(MalType* ast, Env** env) {
+MalType eval_defbang(list lst, Env* env) {
 
-  list lst = (ast->value.mal_list)->next;
+  MalType defbang_symbol = eat_argument(lst);
+  MalType defbang_value = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst || !lst->next || lst->next->next) {
-    return make_error_fmt("'def!': expected exactly two arguments");
-  }
-
-  MalType* defbang_symbol = lst->data;
-
-  if (!is_symbol(defbang_symbol)) {
-    return make_error_fmt("'def!': expected symbol for first argument");
-  }
-
-  MalType* defbang_value = lst->next->data;
-  MalType* result = EVAL(defbang_value, *env);
-
+  MalType result = EVAL(defbang_value, env);
   if (!is_error(result)){
-    env_set(*env, defbang_symbol->value.mal_symbol, result);
+    env_set(env, as_symbol(defbang_symbol), result);
   }
   return result;
 }
 
-void eval_letstar(MalType** ast, Env** env) {
+MalType eval_letstar(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
+  MalType bindings = eat_argument(lst);
+  MalType forms = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst->next) {
-    *ast = make_error("'let*': missing bindings list");
-    return;
-  }
-
-  MalType* bindings = lst->next->data;
-  MalType* forms = lst->next->next ? lst->next->next->data : make_nil();
-
-  if (!is_sequential(bindings)) {
-    *ast = make_error("'let*': first argument is not list or vector");
-    return;
-  }
-
-  list bindings_list = bindings->value.mal_list;
-  if (list_count(bindings_list) % 2 == 1) {
-    *ast = make_error("'let*': expected an even number of binding pairs");
-    return;
-  }
-
-  Env* letstar_env = env_make(*env, NULL, NULL, NULL);
+  list bindings_list = as_sequence(bindings);
+  Env* letstar_env = env_make(*env);
 
   /* evaluate the bindings */
   while(bindings_list) {
 
-    MalType* symbol = bindings_list->data;
-    MalType* value = EVAL(bindings_list->next->data, letstar_env);
+    MalType symbol = bindings_list->data;
+    bindings_list = bindings_list->next;
+    if(!bindings_list) {
+      return make_error_fmt("expected an even number of binding pairs, got: %M",
+                            bindings);
+    }
+    MalType value = EVAL(bindings_list->data, letstar_env);
 
     /* early return from error */
     if (is_error(value)) {
-      *ast = value;
-      return;
+      return value;
     }
 
-    env_set(letstar_env, symbol->value.mal_symbol, value);
-    bindings_list = bindings_list->next->next;
+    env_set(letstar_env, as_symbol(symbol), value);
+    bindings_list = bindings_list->next;
   }
 
   *env = letstar_env;
-  *ast = forms;
-  return;
+  return forms;
 }
 
-void eval_if(MalType** ast, Env** env) {
+MalType eval_if(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
-
-  if (!lst->next || !lst->next->next) {
-    *ast = make_error("'if': too few arguments");
-    return;
+  MalType raw_condition = eat_argument(lst);
+  MalType then_form = eat_argument(lst);
+  MalType else_form;
+  if(lst) {
+    else_form = lst->data;
+    lst = lst->next;
+    check_empty(lst);
+  }
+  else {
+    else_form = NULL;
   }
 
-  if (lst->next->next->next && lst->next->next->next->next) {
-    *ast = make_error("'if': too many arguments");
-    return;
-  }
-
-  MalType* condition = EVAL(lst->next->data, *env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (is_error(condition)) {
-    *ast = condition;
-    return;
+    return condition;
   }
 
   if (is_false(condition) || is_nil(condition)) {
 
     /* check whether false branch is present */
-    if (lst->next->next->next) {
-      *ast = lst->next->next->next->data;
-      return;
+    if(else_form) {
+      return else_form;
     }
     else {
-      *ast = make_nil();
-      return;
+      *env = NULL;              // prevent TCO
+      return make_nil();
     }
 
   } else {
-    *ast = lst->next->next->data;
-    return;
+    return then_form;
   }
 }
 
-MalType* eval_fnstar(MalType* ast, Env* env) {
-
-  /* forward reference */
-  MalType* regularise_parameters(list* params, MalType** more);
-
-  list lst = ast->value.mal_list;
-
-  if (!lst->next) {
-    return make_error("'fn*': missing argument list");
-  }
-  else if (!lst->next->next) {
-    return make_error("'fn*': missing function body");
-  }
-
-  MalType* params = lst->next->data;
-  list params_list = params->value.mal_list;
-
-  MalType* more_symbol = NULL;
-
-  MalType* result = regularise_parameters(&params_list, &more_symbol);
-  if (is_error(result)) { return result; }
-
-  MalType* definition = lst->next->next->data;
-  MalType* regular_params = make_list(params_list);
-
-  return make_closure(env, regular_params, definition, more_symbol);
-}
-
-MalType* eval_do(MalType* ast, Env* env) {
-
-  list lst = ast->value.mal_list;
+MalType eval_do(list lst, Env* env) {
 
   /* handle empty 'do' */
-  if (!lst->next) {
+  if (!lst) {
     return make_nil();
   }
 
   /* evaluate all but the last form */
-  lst = lst->next;
   while (lst->next) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     /* return error early */
     if (is_error(val)) {
@@ -435,113 +373,75 @@ MalType* eval_do(MalType* ast, Env* env) {
   return lst->data;
 }
 
-MalType* eval_quote(MalType* ast) {
+MalType eval_quote(list lst) {
 
-  list lst = (ast->value.mal_list)->next;
-
-  if (!lst) {
-    return make_nil();
-  }
-  else if (lst->next) {
-    return make_error("'quote': expected exactly one argument");
-  }
-  else {
-    return lst->data;
-  }
+  MalType form = eat_argument(lst);
+  check_empty(lst);
+  return form;
 }
 
-MalType* eval_quasiquote(MalType* ast) {
-
-  /* forward reference */
-  MalType* quasiquote(MalType* ast);
-
-  list lst = ast->value.mal_list;
-
-  /* no arguments (quasiquote) */
-  if (!lst->next) {
-    return make_nil();
-  }
-
-  /* too many arguments */
-  else if (lst->next->next) {
-    return make_error("'quasiquote': expected exactly one argument");
-  }
-  return quasiquote(lst->next->data);
+MalType eval_quasiquote(list lst) {
+  MalType form = eat_argument(lst);
+  check_empty(lst);
+  return quasiquote(form);
 }
 
-MalType* quasiquote(MalType* ast) {
-
-  /* forward references */
-  MalType* quasiquote_list(MalType* ast);
-  MalType* quasiquote_vector(MalType* ast);
-
-  /* argument to quasiquote is self-evaluating: (quasiquote val)
-     => val */
-  if (is_self_evaluating(ast)) {
-    return ast;
-  }
+MalType quasiquote(MalType ast) {
 
   /* argument to quasiquote is a vector: (quasiquote [first rest]) */
-  else if (is_vector(ast)) {
+  if (is_vector(ast)) {
 
-    return quasiquote_vector(ast);
+    return quasiquote_vector(ast->value.mal_list);
   }
 
   /* argument to quasiquote is a list: (quasiquote (first rest)) */
   else if (is_list(ast)){
 
-    return quasiquote_list(ast);
+    list lst = ast->value.mal_list;
+    if(lst) {
+      MalType first = lst->data;
+      if(is_symbol(first)
+         && !strcmp(first->value.mal_string, SYMBOL_UNQUOTE)) {
+        lst = lst->next;
+        MalType unquoted = eat_argument(lst);
+        check_empty(lst);
+        return unquoted;
+      }
+    }
+    return quasiquote_list(lst);
   }
   /* argument to quasiquote is not self-evaluating and isn't sequential: (quasiquote val)
      => (quote val) */
-  else {
+  else if(is_hashmap(ast) || is_symbol(ast)) {
 
-    list lst = list_make(ast);
+    list lst = NULL;
+    lst = list_push(lst, ast);
     lst = list_push(lst, make_symbol("quote"));
     return make_list(lst);
   }
+  /* argument to quasiquote is self-evaluating: (quasiquote val)
+     => val */
+  else {
+    return ast;
+  }
 }
 
-MalType* quasiquote_vector(MalType* ast) {
+MalType quasiquote_vector(list args) {
 
-  /* forward references */
-  MalType* quasiquote_list(MalType* ast);
-
-  list args = ast->value.mal_list;
-
-  if (args) {
-
-    MalType* first = args->data;
-
-    /* if first element is unquote return quoted */
-    if (is_symbol(first) && strcmp(first->value.mal_symbol, SYMBOL_UNQUOTE) == 0) {
-
-      list lst = list_make(ast);
-      lst = list_push(lst, make_symbol("quote"));
-
-      return make_list(lst);
-    }
-  }
-
-  /* otherwise process like a list */
-
-  list lst = list_make(make_symbol("vec"));
-
-  MalType* result = quasiquote_list(ast);
+  MalType result = quasiquote_list(args);
 
   if (is_error(result)) {
     return result;
   } else {
+    list lst = NULL;
     lst = list_push(lst, result);
-  }
+    lst = list_push(lst, make_symbol("vec"));
 
-  lst = list_reverse(lst);
-  return make_list(lst);
+    return make_list(lst);
+  }
 }
 
-MalType* quasiquote_list(MalType* ast) {
-
-    list args = ast->value.mal_list;
+MalType quasiquote_list(list args) {
 
     /* handle empty list: (quasiquote ())
        => () */
@@ -549,245 +449,164 @@ MalType* quasiquote_list(MalType* ast) {
       return make_list(NULL);
     }
 
-    MalType* first = args->data;
+    MalType first = args->data;
 
-    /* handle unquote: (quasiquote (unquote second))
-       => second */
-     if (is_symbol(first) && strcmp(first->value.mal_symbol, SYMBOL_UNQUOTE) == 0 && args->next) {
-
-      if (args->next->next) {
-    	return make_error("'quasiquote': unquote expected exactly one argument");
-      }
-      else {
-    	return args->next->data;
-      }
-    }
+    MalType qq_rest = quasiquote_list(args->next);
+    if(is_error(qq_rest)) return qq_rest;
 
     /* handle splice-unquote: (quasiquote ((splice-unquote first-second) rest))
        => (concat first-second (quasiquote rest)) */
-    else if (is_list(first) &&
-	     first->value.mal_list != NULL &&
-	     is_symbol(first->value.mal_list->data) &&
-             strcmp(((MalType*)first->value.mal_list->data)->value.mal_symbol, SYMBOL_SPLICE_UNQUOTE) == 0) {
-
-      if (!first->value.mal_list->next) {
-        return make_error("'quasiquote': splice-unquote expected exactly one argument");
+    if(is_list(first)) {
+      list lst = first->value.mal_list;
+      if(lst) {
+        MalType lst_first = lst->data;
+        if(is_symbol(lst_first)
+           && !strcmp(lst_first->value.mal_string, SYMBOL_SPLICE_UNQUOTE)) {
+          lst = lst->next;
+          MalType unquoted = eat_argument(lst);
+          check_empty(lst);
+          return make_list(list_push(list_push(list_push(NULL, qq_rest),
+                                               unquoted),
+                                     make_symbol("concat")));
+        }
       }
-
-      MalType* first_second = first->value.mal_list->next->data;
-      list lst = list_make(make_symbol("concat"));
-      lst = list_push(lst, first_second);
-
-      MalType* rest = quasiquote(make_list(args->next));
-      if (is_error(rest)) {
-        return rest;
-      }
-
-      lst = list_push(lst, rest);
-      lst = list_reverse(lst);
-
-      return make_list(lst);
     }
-    /* handle all other lists recursively: (quasiquote (first rest))
-       => (cons (quasiquote first) (quasiquote rest)) */
-    else {
-
-      list lst = list_make(make_symbol("cons"));
-
-      MalType* first = quasiquote(args->data);
-      if (is_error(first)) {
-        return first;
-      } else {
-        lst = list_push(lst, first);
-      }
-
-      MalType* rest = quasiquote(make_list(args->next));
-      if (is_error(rest)) {
-        return rest;
-      } else {
-        lst = list_push(lst, rest);
-      }
-
-      lst = list_reverse(lst);
-      return make_list(lst);
-    }
+    MalType qqted = quasiquote(first);
+    if(is_error(qqted)) return qqted;
+    return make_list(list_push(list_push(list_push(NULL, qq_rest),
+                                         quasiquote(first)),
+                               make_symbol("cons")));
 }
 
-MalType* eval_defmacrobang(MalType* ast, Env** env) {
+MalType eval_defmacrobang(list lst, Env* env) {
 
-  list lst = (ast->value.mal_list)->next;
+  MalType defbang_symbol = eat_argument(lst);
+  MalType defbang_value = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst || !lst->next || lst->next->next) {
-    return make_error_fmt("'defmacro!': expected exactly two arguments");
-  }
-
-  MalType* defbang_symbol = lst->data;
-
-  if (!is_symbol(defbang_symbol)) {
-    return make_error_fmt("'defmacro!': expected symbol for first argument");
-  }
-
-  MalType* defbang_value = lst->next->data;
-  MalType* result = EVAL(defbang_value, *env);
+  MalType result = EVAL(defbang_value, env);
 
   if (!is_error(result)) {
-    result = copy_type(result);
-    result->is_macro = 1;
-    env_set(*env, defbang_symbol->value.mal_symbol, result);
+    result = make_macro(as_closure(result));
+    env_set(env, as_symbol(defbang_symbol), result);
   }
   return result;
 }
 
-list evaluate_list(list lst, Env* env) {
+MalType evaluate_list(list* evlst, list lst, Env* env) {
 
-  list evlst = NULL;
+  *evlst = NULL;
+  list* evlst_last = evlst;
   while (lst) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     if (is_error(val)) {
-      return list_make(val);
+      return val;
     }
 
-    evlst = list_push(evlst, val);
+    *evlst_last = list_push(NULL, val);
+    evlst_last = &(*evlst_last)->next;
     lst = lst->next;
   }
-  return list_reverse(evlst);
+  return NULL;
 }
 
-list evaluate_vector(list lst, Env* env) {
+MalType evaluate_vector(list lst, Env* env) {
   /* TODO: implement a real vector */
-  list evlst = NULL;
-  while (lst) {
-
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_vector(evlst);
 }
 
-list evaluate_hashmap(list lst, Env* env) {
+MalType evaluate_hashmap(list lst, Env* env) {
   /* TODO: implement a real hashmap */
-  list evlst = NULL;
-  while (lst) {
-
-    /* keys are unevaluated */
-    evlst = list_push(evlst, lst->data);
-    lst = lst->next;
-
-    /* values are evaluated */
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_hashmap(evlst);
 }
 
-MalType* regularise_parameters(list* args, MalType** more_symbol) {
+MalType eval_fnstar(list lst, const Env* env) {
 
-  /* forward reference */
-  char* symbol_fn(gptr data);
+  MalType a1 = eat_argument(lst);
+  MalType definition = eat_argument(lst);
+  check_empty(lst);
+  list args = as_sequence(a1);
+  size_t param_len = 0;
+  const char** parameters = GC_MALLOC(list_count(args)*sizeof(char*));
+  const char* more_symbol = NULL;
 
-  list regular_args = NULL;
-  while (*args) {
+  while (args) {
 
-    MalType* val = (*args)->data;
+    MalType val = args->data;
 
-    if (!is_symbol(val)) {
-      return make_error_fmt("non-symbol found in fn argument list '%s'", \
-                            pr_str(val, UNREADABLY));
-    }
+    const char* val_sym = as_symbol(val);
 
-    if (val->value.mal_symbol[0] == '&') {
+    if(val_sym[0] == '&') {
 
       /* & is found but there is no symbol */
-      if (val->value.mal_symbol[1] == '\0' && !(*args)->next) {
-        return make_error("missing symbol after '&' in argument list");
-      }
+      if (val_sym[1] == '\0') {
+        if(!args->next) {
+          return make_error_fmt("missing symbol after '&' in argument list");
+        }
       /* & is found and there is a single symbol after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next &&
-                is_symbol((*args)->next->data) && !(*args)->next->next)) {
-
-        /* TODO: check symbol is no a duplicate of one already on the list */
-        *more_symbol = (*args)->next->data;
-        break;
-      }
+        else if(!args->next->next) {
+          more_symbol = as_symbol(args->next->data);
+          break;
+        }
       /* & is found and there extra symbols after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next && (*args)->next->next)) {
-        return make_error_fmt("unexpected symbol after '& %s' in argument list: '%s'", \
-                              pr_str((*args)->next->data, UNREADABLY),  \
-                              pr_str((*args)->next->next->data, UNREADABLY));
+        else {
+          return make_error_fmt("unexpected symbol after '& %M' in argument list: '%M'",
+                                args->next->data, args->next->next->data);
+        }
       }
       /* & is found as part of the symbol and no other symbols */
-      else if (val->value.mal_symbol[1] != '\0' && !(*args)->next) {
-        *more_symbol = make_symbol((val->value.mal_symbol + 1));
+      else if(!args->next) {
+        more_symbol = val_sym + 1;
         break;
       }
       /* & is found as part of the symbol but there are other symbols after */
-      else if (val->value.mal_symbol[1] != '\0' && (*args)->next) {
-        return make_error_fmt("unexpected symbol after '%s' in argument list: '%s'", \
-                              pr_str(val, UNREADABLY),  \
-                              pr_str((*args)->next->data, UNREADABLY));
-       }
+      else {
+        return make_error_fmt("unexpected symbol after '%s' in argument list: '%M'",
+                              val_sym, args->next->data);
+      }
     }
 
     /* & is not found - add the symbol to the regular argument list */
     else {
 
-      if (list_findf(regular_args, val->value.mal_symbol, symbol_fn) > 0) {
-        return make_error_fmt("duplicate symbol in argument list: '%s'", pr_str(val, UNREADABLY));
+      for(size_t i=0; i<param_len; i++) {
+        if(!strcmp(val_sym, parameters[i])) {
+          return make_error_fmt("duplicate symbol in argument list: '%s'",
+                                parameters[i]);
+        }
       }
-      else {
-        regular_args = list_push(regular_args, val);
-      }
+      parameters[param_len++] = val_sym;
     }
-    *args = (*args)->next;
+    args = args->next;
   }
 
-  *args = list_reverse(regular_args);
-  return make_nil();
-}
-
-char* symbol_fn(gptr data) {
-  return (((MalType*)data)->value.mal_symbol);
+  return make_closure(env, param_len, parameters, definition, more_symbol);
 }
 
 /* used by core functions but not EVAL as doesn't do TCE */
-MalType* apply(MalType* fn, list args) {
+MalType apply(MalType fn, list args) {
 
   if (is_function(fn)) {
 
-    MalType* (*fun_ptr)(list) = fn->value.mal_function;
+    MalType(*fun_ptr)(list) = fn->value.mal_function;
     return (*fun_ptr)(args);
   }
-  else { /* is_closure(fn) */
+  else if(is_closure(fn) || is_macro(fn)) {
 
-    MalClosure* c = fn->value.mal_closure;
-    list params = (c->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(args);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !c->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
-      Env* env = env_make(c->env, params, args, c->more_symbol);
-      return EVAL(fn->value.mal_closure->definition, env);
-    }
+    Env* env;
+    MalType ast = env_apply(fn->value.mal_closure, args, &env);
+    if(is_error(ast)) return ast;
+    return EVAL(ast, env);
+  }
+  else {
+    return bad_type(fn, "a function, closure or macro");
   }
 }

--- a/impls/c.2/step9_try.c
+++ b/impls/c.2/step9_try.c
@@ -1,11 +1,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gc.h>
 
+#include <gc.h>
 #include <editline/readline.h>
 #include <editline/history.h>
 
+#include "libs/linked_list/linked_list.h"
 #include "types.h"
 #include "reader.h"
 #include "printer.h"
@@ -27,82 +28,97 @@
 
 #define PROMPT_STRING "user> "
 
-MalType* READ(char* str) {
+MalType apply(MalType, list); // For the apply phase and core apply/map/swap.
+MalType evaluate_list(list*, list, Env*);
+// Store the result into the first argument and return NULL
+// If an error occurs, it is returned.
+MalType evaluate_vector(list, Env*);
+MalType evaluate_hashmap(list, Env*);
+MalType eval_defbang(list, Env*);
+MalType eval_letstar(list, Env**); // TCO
+MalType eval_if(list, Env**); // TCO unless the environment is set to NULL.
+MalType eval_fnstar(list, const Env*);
+MalType eval_do(list, Env*); // TCO in the same env
+MalType eval_quote(list);
+MalType eval_quasiquote(list);
+MalType quasiquote(MalType);
+MalType quasiquote_vector(list);
+MalType quasiquote_list(list);
+MalType eval_defmacrobang(list, Env*);
+MalType eval_try(list, Env**); // TCO unless the environment is set to NULL.
+
+MalType READ(const char* str) {
 
   return read_str(str);
 }
 
-MalType* EVAL(MalType* ast, Env* env) {
+MalType env_apply(MalClosure closure, list args, Env** env) {
+  //  Return the closure definition and update env if all went OK,
+  //  else return an error.
+  Env* fn_env = env_make(closure->env);
+  for(size_t i=0; i<closure->param_len; i++) {
+    env_set(fn_env, closure->parameters[i], eat_argument(args));
+  }
+  /* set the 'more' symbol if there is one */
+  if (closure->more_symbol) {
+    env_set(fn_env, closure->more_symbol, make_list(args));
+  }
+  else {
+    check_empty(args);
+  }
+  *env = fn_env;
+  return closure->definition;
+}
 
-  /* forward references */
-  MalType* apply(MalType* fn, list args);
-  list evaluate_list(list lst, Env* env);
-  list evaluate_vector(list lst, Env* env);
-  list evaluate_hashmap(list lst, Env* env);
-  MalType* eval_defbang(MalType* ast, Env** env);
-  void eval_letstar(MalType** ast, Env** env);
-  void eval_if(MalType** ast, Env** env);
-  MalType* eval_fnstar(MalType* ast, Env* env);
-  MalType* eval_do(MalType* ast, Env* env);
-  MalType* eval_quote(MalType* ast);
-  MalType* eval_quasiquote(MalType* ast);
-  MalType* eval_defmacrobang(MalType*, Env** env);
-  int eval_try(MalType** ast, Env** env);
+MalType EVAL(MalType ast, Env* env) {
 
   /* Use goto to jump here rather than calling eval for tail-call elimination */
  TCE_entry_point:
 
-  MalType* dbgeval = env_get(env, "DEBUG-EVAL");
+  MalType dbgeval = env_get(env, "DEBUG-EVAL");
   if (dbgeval && ! is_false(dbgeval) && ! is_nil(dbgeval))
-    printf("EVAL: %s\n", pr_str(ast, READABLY));
-
-  /* NULL */
-  if (!ast) { return make_nil(); }
+    printf("EVAL: %M\n", ast);
 
   if (is_symbol(ast)) {
-    MalType* symbol_value = env_get(env, ast->value.mal_symbol);
+    MalType symbol_value = env_get(env, ast->value.mal_string);
     if (symbol_value)
       return symbol_value;
     else
-      return make_error_fmt("'%s' not found", ast->value.mal_symbol);
+      // make_error would prefix with EVAL: and break some tests
+      return wrap_error(make_string(mal_printf("'%M' not found", ast)));
   }
 
   if (is_vector(ast)) {
-    list result = evaluate_vector(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_vector(result);
+    return evaluate_vector(ast->value.mal_list, env);
   }
 
   if (is_hashmap(ast)) {
-    list result = evaluate_hashmap(ast->value.mal_list, env);
-    if (result && is_error(result->data))
-      return result->data;
-    else
-      return make_hashmap(result);
+    return evaluate_hashmap(ast->value.mal_list, env);
   }
 
   /* not a list */
   if (!is_list(ast)) { return ast; }
 
+  list lst = ast->value.mal_list;
+
   /* empty list */
-  if (ast->value.mal_list == NULL) { return ast; }
+  if(lst == NULL) { return ast; }
 
   /* list */
-  MalType* first = (ast->value.mal_list)->data;
-  char* symbol = first->value.mal_symbol;
+  MalType first = lst->data;
+  lst = lst->next;
 
-  if (is_symbol(first)) {
+  if(is_symbol(first)) {
+    const char* symbol = first->value.mal_string;
 
     /* handle special symbols first */
     if (strcmp(symbol, SYMBOL_DEFBANG) == 0) {
-      return eval_defbang(ast, &env);
+      return eval_defbang(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_LETSTAR) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      eval_letstar(&ast, &env);
+      ast = eval_letstar(lst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
@@ -110,168 +126,147 @@ MalType* EVAL(MalType* ast, Env* env) {
     else if (strcmp(symbol, SYMBOL_IF) == 0) {
 
       /* TCE - modify ast directly and jump back to eval */
-      eval_if(&ast, &env);
+      ast = eval_if(lst, &env);
 
       if (is_error(ast)) { return ast; }
-      goto TCE_entry_point;
+      if(env) goto TCE_entry_point; else return ast;
     }
     else if (strcmp(symbol, SYMBOL_FNSTAR) == 0) {
-      return eval_fnstar(ast, env);
+      return eval_fnstar(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_DO) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(ast, env);
+      ast = eval_do(lst, env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
     }
     else if (strcmp(symbol, SYMBOL_QUOTE) == 0) {
-      return eval_quote(ast);
+      return eval_quote(lst);
     }
     else if (strcmp(symbol, SYMBOL_QUASIQUOTE) == 0) {
 
-      ast = eval_quasiquote(ast);
+      ast = eval_quasiquote(lst);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
     }
     else if (strcmp(symbol, SYMBOL_DEFMACROBANG) == 0) {
-      return eval_defmacrobang(ast, &env);
+      return eval_defmacrobang(lst, env);
     }
     else if (strcmp(symbol, SYMBOL_TRYSTAR) == 0) {
 
       /* TCE - modify ast and env directly and jump back to eval */
-      int tce = eval_try(&ast, &env);
+      ast = eval_try(lst, &env);
+      if(is_error(ast)) return ast;
 
-      if (!tce) { return ast; }
+      if(!env) { return ast; }
       goto TCE_entry_point;
     }
   }
   /* first element is not a special symbol */
-  MalType* func = EVAL(first, env);
+  MalType func = EVAL(first, env);
   if (is_error(func)) { return func; }
-  if (func->is_macro) {
-    ast = apply(func, ast->value.mal_list->next);
+  if(func->type == MALTYPE_MACRO) {
+    ast = apply(func, lst);
     if (is_error(ast)) { return ast; }
     goto TCE_entry_point;
   }
-  list evlst = evaluate_list(ast->value.mal_list->next, env);
-  if (evlst && is_error(evlst->data)) { return evlst->data; }
+  //  Evaluate the arguments
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
 
   /* apply the first element of the list to the arguments */
-  if (is_function(func)) {
-    return (*func->value.mal_function)(evlst);
-  }
-  else if (is_closure(func)) {
+  if (is_closure(func)) {
 
-    MalClosure* closure = func->value.mal_closure;
-    list params = (closure->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(evlst);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !closure->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
+      MalClosure closure = func->value.mal_closure;
 
       /* TCE - modify ast and env directly and jump back to eval */
-      env = env_make(closure->env, params, evlst, closure->more_symbol);
-      ast = func->value.mal_closure->definition;
+      ast = env_apply(closure, evlst, &env);
 
       if (is_error(ast)) { return ast; }
       goto TCE_entry_point;
-    }
   }
-  else {
-    return make_error_fmt("first item in list is not callable: '%s'",   \
-                          pr_str(func, UNREADABLY));
-  }
+  return apply(func, evlst);
 }
 
-void PRINT(MalType* val) {
+void PRINT(MalType val) {
 
-  char* output = pr_str(val, READABLY);
-  printf("%s\n", output);
+  printf("%M\n", val);
 }
 
-void rep(char* str, Env* env) {
+void rep(const char* str, Env* env) {
 
   PRINT(EVAL(READ(str), env));
+}
+
+//  Variant reporting errors during startup.
+void re(const char *str, Env* env) {
+  MalType result = EVAL(READ(str), env);
+  if(is_error(result)) {
+    printf("Error during startup: %M\n", result);
+    exit(EXIT_FAILURE);
+  }
 }
 
 /* declare as global so it can be accessed by mal_eval */
 Env* global_env;
 
-MalType* mal_eval(list args) {
+MalType mal_eval(list args) {
 
-  MalType* ast = args->data;
+  MalType ast = eat_argument(args);
+  check_empty(args);
   return EVAL(ast, global_env);
 }
 
-
 int main(int argc, char** argv) {
 
-  Env* repl_env = env_make(NULL, NULL, NULL, NULL);
+  printer_init();
+
+  Env* repl_env = env_make(NULL);
   global_env = repl_env;
 
-  ns* core = ns_make_core();
-  hashmap mappings = core->mappings;
-
-  while (mappings) {
-    char* symbol = mappings->data;
-    MalType*(*function)(list) = (MalType*(*)(list))mappings->next->data;
-
+  ns core;
+  size_t core_size;
+  ns_make_core(&core, &core_size);
+  while(core_size--) {
+    const char* symbol = core[core_size].key;
+    function_t function = core[core_size].value;
     env_set(repl_env, symbol, make_function(function));
-
-    /* pop symbol and function from hashmap/list */
-    mappings = mappings->next->next;
   }
 
   env_set(repl_env, "eval", make_function(mal_eval));
 
   /* add functions written in mal - not using rep as it prints the result */
-  EVAL(READ("(def! not (fn* (a) (if a false true)))"), repl_env);
-  EVAL(READ("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))"), repl_env);
-  EVAL(READ("(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))"), repl_env);
+  re("(def! not (fn* (a) (if a false true)))", repl_env);
+  re("(def! load-file (fn* (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))", repl_env);
+  re("(defmacro! cond (fn* (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))", repl_env);
 
   /* make command line arguments available in the environment */
   list lst = NULL;
-  for (long i = 2; i < argc; i++) {
-    lst = list_push(lst, make_string(argv[i]));
+  while(1 < --argc) {
+    lst = list_push(lst, make_string(argv[argc]));
   }
-  env_set(repl_env, "*ARGV*", make_list(list_reverse(lst)));
+  env_set(repl_env, "*ARGV*", make_list(lst));
 
   /* run in script mode if a filename is given */
-  if (argc > 1) {
+  if (argc) {
 
     /* first argument on command line is filename */
-    char* load_command = snprintfbuf(1024, "(load-file \"%s\")", argv[1]);
-    EVAL(READ(load_command), repl_env);
+    const char* load_command = mal_printf("(load-file \"%s\")", argv[1]);
+    re(load_command, repl_env);
   }
   /* run in repl mode when no cmd line args */
   else {
 
-    /* Greeting message */
-    puts("Make-a-lisp version 0.0.9\n");
-    puts("Press Ctrl+d to exit\n");
-
-    while (1) {
+    char* input;
+    while((input = readline(PROMPT_STRING))) {
 
       /* print prompt and get input*/
       /* readline allocates memory for input */
-      char* input = readline(PROMPT_STRING);
-
       /* Check for EOF (Ctrl-D) */
-      if (!input) {
-        printf("\n");
-        return 0;
-      }
-
       /* add input to history */
       add_history(input);
 
@@ -281,160 +276,104 @@ int main(int argc, char** argv) {
       /* have to release the memory used by readline */
       free(input);
     }
+    printf("\n");
   }
-  return 0;
+  return EXIT_SUCCESS;
 }
 
-MalType* eval_defbang(MalType* ast, Env** env) {
+MalType eval_defbang(list lst, Env* env) {
 
-  list lst = (ast->value.mal_list)->next;
+  MalType defbang_symbol = eat_argument(lst);
+  MalType defbang_value = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst || !lst->next || lst->next->next) {
-    return make_error_fmt("'def!': expected exactly two arguments");
-  }
-
-  MalType* defbang_symbol = lst->data;
-
-  if (!is_symbol(defbang_symbol)) {
-    return make_error_fmt("'def!': expected symbol for first argument");
-  }
-
-  MalType* defbang_value = lst->next->data;
-  MalType* result = EVAL(defbang_value, *env);
-
+  MalType result = EVAL(defbang_value, env);
   if (!is_error(result)){
-    env_set(*env, defbang_symbol->value.mal_symbol, result);
+    env_set(env, as_symbol(defbang_symbol), result);
   }
   return result;
 }
 
-void eval_letstar(MalType** ast, Env** env) {
+MalType eval_letstar(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
+  MalType bindings = eat_argument(lst);
+  MalType forms = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst->next) {
-    *ast = make_error("'let*': missing bindings list");
-    return;
-  }
-
-  MalType* bindings = lst->next->data;
-  MalType* forms = lst->next->next ? lst->next->next->data : make_nil();
-
-  if (!is_sequential(bindings)) {
-    *ast = make_error("'let*': first argument is not list or vector");
-    return;
-  }
-
-  list bindings_list = bindings->value.mal_list;
-  if (list_count(bindings_list) % 2 == 1) {
-    *ast = make_error("'let*': expected an even number of binding pairs");
-    return;
-  }
-
-  Env* letstar_env = env_make(*env, NULL, NULL, NULL);
+  list bindings_list = as_sequence(bindings);
+  Env* letstar_env = env_make(*env);
 
   /* evaluate the bindings */
   while(bindings_list) {
 
-    MalType* symbol = bindings_list->data;
-    MalType* value = EVAL(bindings_list->next->data, letstar_env);
+    MalType symbol = bindings_list->data;
+    bindings_list = bindings_list->next;
+    if(!bindings_list) {
+      return make_error_fmt("expected an even number of binding pairs, got: %M",
+                            bindings);
+    }
+    MalType value = EVAL(bindings_list->data, letstar_env);
 
     /* early return from error */
     if (is_error(value)) {
-      *ast = value;
-      return;
+      return value;
     }
 
-    env_set(letstar_env, symbol->value.mal_symbol, value);
-    bindings_list = bindings_list->next->next;
+    env_set(letstar_env, as_symbol(symbol), value);
+    bindings_list = bindings_list->next;
   }
 
   *env = letstar_env;
-  *ast = forms;
-  return;
+  return forms;
 }
 
-void eval_if(MalType** ast, Env** env) {
+MalType eval_if(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
-
-  if (!lst->next || !lst->next->next) {
-    *ast = make_error("'if': too few arguments");
-    return;
+  MalType raw_condition = eat_argument(lst);
+  MalType then_form = eat_argument(lst);
+  MalType else_form;
+  if(lst) {
+    else_form = lst->data;
+    lst = lst->next;
+    check_empty(lst);
+  }
+  else {
+    else_form = NULL;
   }
 
-  if (lst->next->next->next && lst->next->next->next->next) {
-    *ast = make_error("'if': too many arguments");
-    return;
-  }
-
-  MalType* condition = EVAL(lst->next->data, *env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (is_error(condition)) {
-    *ast = condition;
-    return;
+    return condition;
   }
 
   if (is_false(condition) || is_nil(condition)) {
 
     /* check whether false branch is present */
-    if (lst->next->next->next) {
-      *ast = lst->next->next->next->data;
-      return;
+    if(else_form) {
+      return else_form;
     }
     else {
-      *ast = make_nil();
-      return;
+      *env = NULL;              // prevent TCO
+      return make_nil();
     }
 
   } else {
-    *ast = lst->next->next->data;
-    return;
+    return then_form;
   }
 }
 
-MalType* eval_fnstar(MalType* ast, Env* env) {
-
-  /* forward reference */
-  MalType* regularise_parameters(list* params, MalType** more);
-
-  list lst = ast->value.mal_list;
-
-  if (!lst->next) {
-    return make_error("'fn*': missing argument list");
-  }
-  else if (!lst->next->next) {
-    return make_error("'fn*': missing function body");
-  }
-
-  MalType* params = lst->next->data;
-  list params_list = params->value.mal_list;
-
-  MalType* more_symbol = NULL;
-
-  MalType* result = regularise_parameters(&params_list, &more_symbol);
-  if (is_error(result)) { return result; }
-
-  MalType* definition = lst->next->next->data;
-  MalType* regular_params = make_list(params_list);
-
-  return make_closure(env, regular_params, definition, more_symbol);
-}
-
-MalType* eval_do(MalType* ast, Env* env) {
-
-  list lst = ast->value.mal_list;
+MalType eval_do(list lst, Env* env) {
 
   /* handle empty 'do' */
-  if (!lst->next) {
+  if (!lst) {
     return make_nil();
   }
 
   /* evaluate all but the last form */
-  lst = lst->next;
   while (lst->next) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     /* return error early */
     if (is_error(val)) {
@@ -446,113 +385,75 @@ MalType* eval_do(MalType* ast, Env* env) {
   return lst->data;
 }
 
-MalType* eval_quote(MalType* ast) {
+MalType eval_quote(list lst) {
 
-  list lst = (ast->value.mal_list)->next;
-
-  if (!lst) {
-    return make_nil();
-  }
-  else if (lst->next) {
-    return make_error("'quote': expected exactly one argument");
-  }
-  else {
-    return lst->data;
-  }
+  MalType form = eat_argument(lst);
+  check_empty(lst);
+  return form;
 }
 
-MalType* eval_quasiquote(MalType* ast) {
-
-  /* forward reference */
-  MalType* quasiquote(MalType* ast);
-
-  list lst = ast->value.mal_list;
-
-  /* no arguments (quasiquote) */
-  if (!lst->next) {
-    return make_nil();
-  }
-
-  /* too many arguments */
-  else if (lst->next->next) {
-    return make_error("'quasiquote': expected exactly one argument");
-  }
-  return quasiquote(lst->next->data);
+MalType eval_quasiquote(list lst) {
+  MalType form = eat_argument(lst);
+  check_empty(lst);
+  return quasiquote(form);
 }
 
-MalType* quasiquote(MalType* ast) {
-
-  /* forward references */
-  MalType* quasiquote_list(MalType* ast);
-  MalType* quasiquote_vector(MalType* ast);
-
-  /* argument to quasiquote is self-evaluating: (quasiquote val)
-     => val */
-  if (is_self_evaluating(ast)) {
-    return ast;
-  }
+MalType quasiquote(MalType ast) {
 
   /* argument to quasiquote is a vector: (quasiquote [first rest]) */
-  else if (is_vector(ast)) {
+  if (is_vector(ast)) {
 
-    return quasiquote_vector(ast);
+    return quasiquote_vector(ast->value.mal_list);
   }
 
   /* argument to quasiquote is a list: (quasiquote (first rest)) */
   else if (is_list(ast)){
 
-    return quasiquote_list(ast);
+    list lst = ast->value.mal_list;
+    if(lst) {
+      MalType first = lst->data;
+      if(is_symbol(first)
+         && !strcmp(first->value.mal_string, SYMBOL_UNQUOTE)) {
+        lst = lst->next;
+        MalType unquoted = eat_argument(lst);
+        check_empty(lst);
+        return unquoted;
+      }
+    }
+    return quasiquote_list(lst);
   }
   /* argument to quasiquote is not self-evaluating and isn't sequential: (quasiquote val)
      => (quote val) */
-  else {
+  else if(is_hashmap(ast) || is_symbol(ast)) {
 
-    list lst = list_make(ast);
+    list lst = NULL;
+    lst = list_push(lst, ast);
     lst = list_push(lst, make_symbol("quote"));
     return make_list(lst);
   }
+  /* argument to quasiquote is self-evaluating: (quasiquote val)
+     => val */
+  else {
+    return ast;
+  }
 }
 
-MalType* quasiquote_vector(MalType* ast) {
+MalType quasiquote_vector(list args) {
 
-  /* forward references */
-  MalType* quasiquote_list(MalType* ast);
-
-  list args = ast->value.mal_list;
-
-  if (args) {
-
-    MalType* first = args->data;
-
-    /* if first element is unquote return quoted */
-    if (is_symbol(first) && strcmp(first->value.mal_symbol, SYMBOL_UNQUOTE) == 0) {
-
-      list lst = list_make(ast);
-      lst = list_push(lst, make_symbol("quote"));
-
-      return make_list(lst);
-    }
-  }
-
-  /* otherwise process like a list */
-
-  list lst = list_make(make_symbol("vec"));
-
-  MalType* result = quasiquote_list(ast);
+  MalType result = quasiquote_list(args);
 
   if (is_error(result)) {
     return result;
   } else {
+    list lst = NULL;
     lst = list_push(lst, result);
-  }
+    lst = list_push(lst, make_symbol("vec"));
 
-  lst = list_reverse(lst);
-  return make_list(lst);
+    return make_list(lst);
+  }
 }
 
-MalType* quasiquote_list(MalType* ast) {
-
-    list args = ast->value.mal_list;
+MalType quasiquote_list(list args) {
 
     /* handle empty list: (quasiquote ())
        => () */
@@ -560,304 +461,204 @@ MalType* quasiquote_list(MalType* ast) {
       return make_list(NULL);
     }
 
-    MalType* first = args->data;
+    MalType first = args->data;
 
-    /* handle unquote: (quasiquote (unquote second))
-       => second */
-     if (is_symbol(first) && strcmp(first->value.mal_symbol, SYMBOL_UNQUOTE) == 0 && args->next) {
-
-      if (args->next->next) {
-    	return make_error("'quasiquote': unquote expected exactly one argument");
-      }
-      else {
-    	return args->next->data;
-      }
-    }
+    MalType qq_rest = quasiquote_list(args->next);
+    if(is_error(qq_rest)) return qq_rest;
 
     /* handle splice-unquote: (quasiquote ((splice-unquote first-second) rest))
        => (concat first-second (quasiquote rest)) */
-    else if (is_list(first) &&
-	     first->value.mal_list != NULL &&
-	     is_symbol(first->value.mal_list->data) &&
-             strcmp(((MalType*)first->value.mal_list->data)->value.mal_symbol, SYMBOL_SPLICE_UNQUOTE) == 0) {
-
-      if (!first->value.mal_list->next) {
-        return make_error("'quasiquote': splice-unquote expected exactly one argument");
+    if(is_list(first)) {
+      list lst = first->value.mal_list;
+      if(lst) {
+        MalType lst_first = lst->data;
+        if(is_symbol(lst_first)
+           && !strcmp(lst_first->value.mal_string, SYMBOL_SPLICE_UNQUOTE)) {
+          lst = lst->next;
+          MalType unquoted = eat_argument(lst);
+          check_empty(lst);
+          return make_list(list_push(list_push(list_push(NULL, qq_rest),
+                                               unquoted),
+                                     make_symbol("concat")));
+        }
       }
-
-      MalType* first_second = first->value.mal_list->next->data;
-      list lst = list_make(make_symbol("concat"));
-      lst = list_push(lst, first_second);
-
-      MalType* rest = quasiquote(make_list(args->next));
-      if (is_error(rest)) {
-        return rest;
-      }
-
-      lst = list_push(lst, rest);
-      lst = list_reverse(lst);
-
-      return make_list(lst);
     }
-    /* handle all other lists recursively: (quasiquote (first rest))
-       => (cons (quasiquote first) (quasiquote rest)) */
-    else {
-
-      list lst = list_make(make_symbol("cons"));
-
-      MalType* first = quasiquote(args->data);
-      if (is_error(first)) {
-        return first;
-      } else {
-        lst = list_push(lst, first);
-      }
-
-      MalType* rest = quasiquote(make_list(args->next));
-      if (is_error(rest)) {
-        return rest;
-      } else {
-        lst = list_push(lst, rest);
-      }
-
-      lst = list_reverse(lst);
-      return make_list(lst);
-    }
+    MalType qqted = quasiquote(first);
+    if(is_error(qqted)) return qqted;
+    return make_list(list_push(list_push(list_push(NULL, qq_rest),
+                                         quasiquote(first)),
+                               make_symbol("cons")));
 }
 
-MalType* eval_defmacrobang(MalType* ast, Env** env) {
+MalType eval_defmacrobang(list lst, Env* env) {
 
-  list lst = (ast->value.mal_list)->next;
+  MalType defbang_symbol = eat_argument(lst);
+  MalType defbang_value = eat_argument(lst);
+  check_empty(lst);
 
-  if (!lst || !lst->next || lst->next->next) {
-    return make_error_fmt("'defmacro!': expected exactly two arguments");
-  }
-
-  MalType* defbang_symbol = lst->data;
-
-  if (!is_symbol(defbang_symbol)) {
-    return make_error_fmt("'defmacro!': expected symbol for first argument");
-  }
-
-  MalType* defbang_value = lst->next->data;
-  MalType* result = EVAL(defbang_value, *env);
+  MalType result = EVAL(defbang_value, env);
 
   if (!is_error(result)) {
-    result = copy_type(result);
-    result->is_macro = 1;
-    env_set(*env, defbang_symbol->value.mal_symbol, result);
+    result = make_macro(as_closure(result));
+    env_set(env, as_symbol(defbang_symbol), result);
   }
   return result;
 }
 
-int eval_try(MalType** ast, Env** env) {
+MalType eval_try(list lst, Env** env) {
 
-  list lst = (*ast)->value.mal_list;
+  MalType try_clause = eat_argument(lst);
 
-  if (!lst->next) {
-    *ast = make_nil();
-    return 0;
+  if(!lst) {
+    /* no catch* clause */
+    return try_clause;
   }
 
-  if (lst->next->next && lst->next->next->next) {
-    *ast = make_error("'try*': expected maximum of two arguments");
-    return 0;
-  }
-
-  MalType* try_clause = lst->next->data;
-  MalType* try_result = EVAL(try_clause, *env);
-
-  /* no catch* clause */
-  if (!is_error(try_result) || !lst->next->next) {
-    *ast = try_result;
-    return 0;
-  }
+  MalType catch_clause = lst->data;
+  lst = lst->next;
+  check_empty(lst);
 
   /* process catch* clause */
-  MalType* catch_clause = lst->next->next->data;
-  list catch_list = catch_clause->value.mal_list;
-
-  if (!catch_list) {
-    *ast = make_error("'try*': catch* clause is empty");
-    return 0;
+  list catch_list = as_list(catch_clause);
+  MalType catch_symbol = eat_argument(catch_list);
+  if(strcmp(as_symbol(catch_symbol), SYMBOL_CATCHSTAR)) {
+    return make_error_fmt("catch clause %M is missing catch* symbol",
+                          catch_clause);
   }
+  MalType a2 = eat_argument(catch_list);
+  MalType handler = eat_argument(catch_list);
+  check_empty(catch_list);
 
-  MalType* catch_symbol = catch_list->data;
-  if (strcmp(catch_symbol->value.mal_symbol, SYMBOL_CATCHSTAR) != 0) {
-    *ast = make_error("Error: catch clause is missing catch* symbol");
-    return 0;
-  }
-
-  if (!catch_list->next || !catch_list->next->next) {
-    *ast = make_error("Error: catch* clause expected two arguments");
-    return 0;
-  }
-
-  if (!is_symbol(catch_list->next->data)) {
-    *ast = make_error("Error: catch* clause expected a symbol");
-    return 0;
+  MalType try_result = EVAL(try_clause, *env);
+  if(!is_error(try_result)) {
+    *env = NULL;                // prevent TCO
+    return try_result;
   }
 
   /* bind the symbol to the exception */
-  Env* catch_env = env_make(*env, NULL, NULL, NULL);
+  Env* catch_env = env_make(*env);
   env_set(catch_env,
-          ((MalType*)catch_list->next->data)->value.mal_symbol,
+          as_symbol(a2),
           try_result->value.mal_error);
-  *ast = catch_list->next->next->data;
   *env = catch_env;
 
-  return 1;
+  return handler;
 }
 
-list evaluate_list(list lst, Env* env) {
+MalType evaluate_list(list* evlst, list lst, Env* env) {
 
-  list evlst = NULL;
+  *evlst = NULL;
+  list* evlst_last = evlst;
   while (lst) {
 
-    MalType* val = EVAL(lst->data, env);
+    MalType val = EVAL(lst->data, env);
 
     if (is_error(val)) {
-      return list_make(val);
+      return val;
     }
 
-    evlst = list_push(evlst, val);
+    *evlst_last = list_push(NULL, val);
+    evlst_last = &(*evlst_last)->next;
     lst = lst->next;
   }
-  return list_reverse(evlst);
+  return NULL;
 }
 
-list evaluate_vector(list lst, Env* env) {
+MalType evaluate_vector(list lst, Env* env) {
   /* TODO: implement a real vector */
-  list evlst = NULL;
-  while (lst) {
-
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_vector(evlst);
 }
 
-list evaluate_hashmap(list lst, Env* env) {
+MalType evaluate_hashmap(list lst, Env* env) {
   /* TODO: implement a real hashmap */
-  list evlst = NULL;
-  while (lst) {
-
-    /* keys are unevaluated */
-    evlst = list_push(evlst, lst->data);
-    lst = lst->next;
-
-    /* values are evaluated */
-    MalType* val = EVAL(lst->data, env);
-
-    if (is_error(val)) {
-      return list_make(val);
-    }
-
-    evlst = list_push(evlst, val);
-    lst = lst->next;
-  }
-  return list_reverse(evlst);
+  list evlst;
+  MalType error = evaluate_list(&evlst, lst, env);
+  if(error) return error;
+  return make_hashmap(evlst);
 }
 
-MalType* regularise_parameters(list* args, MalType** more_symbol) {
+MalType eval_fnstar(list lst, const Env* env) {
 
-  /* forward reference */
-  char* symbol_fn(gptr data);
+  MalType a1 = eat_argument(lst);
+  MalType definition = eat_argument(lst);
+  check_empty(lst);
+  list args = as_sequence(a1);
+  size_t param_len = 0;
+  const char** parameters = GC_MALLOC(list_count(args)*sizeof(char*));
+  const char* more_symbol = NULL;
 
-  list regular_args = NULL;
-  while (*args) {
+  while (args) {
 
-    MalType* val = (*args)->data;
+    MalType val = args->data;
 
-    if (!is_symbol(val)) {
-      return make_error_fmt("non-symbol found in fn argument list '%s'", \
-                            pr_str(val, UNREADABLY));
-    }
+    const char* val_sym = as_symbol(val);
 
-    if (val->value.mal_symbol[0] == '&') {
+    if(val_sym[0] == '&') {
 
       /* & is found but there is no symbol */
-      if (val->value.mal_symbol[1] == '\0' && !(*args)->next) {
-        return make_error("missing symbol after '&' in argument list");
-      }
+      if (val_sym[1] == '\0') {
+        if(!args->next) {
+          return make_error_fmt("missing symbol after '&' in argument list");
+        }
       /* & is found and there is a single symbol after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next &&
-                is_symbol((*args)->next->data) && !(*args)->next->next)) {
-
-        /* TODO: check symbol is no a duplicate of one already on the list */
-        *more_symbol = (*args)->next->data;
-        break;
-      }
+        else if(!args->next->next) {
+          more_symbol = as_symbol(args->next->data);
+          break;
+        }
       /* & is found and there extra symbols after */
-      else if ((val->value.mal_symbol[1] == '\0' && (*args)->next && (*args)->next->next)) {
-        return make_error_fmt("unexpected symbol after '& %s' in argument list: '%s'", \
-                              pr_str((*args)->next->data, UNREADABLY),  \
-                              pr_str((*args)->next->next->data, UNREADABLY));
+        else {
+          return make_error_fmt("unexpected symbol after '& %M' in argument list: '%M'",
+                                args->next->data, args->next->next->data);
+        }
       }
       /* & is found as part of the symbol and no other symbols */
-      else if (val->value.mal_symbol[1] != '\0' && !(*args)->next) {
-        *more_symbol = make_symbol((val->value.mal_symbol + 1));
+      else if(!args->next) {
+        more_symbol = val_sym + 1;
         break;
       }
       /* & is found as part of the symbol but there are other symbols after */
-      else if (val->value.mal_symbol[1] != '\0' && (*args)->next) {
-        return make_error_fmt("unexpected symbol after '%s' in argument list: '%s'", \
-                              pr_str(val, UNREADABLY),  \
-                              pr_str((*args)->next->data, UNREADABLY));
-       }
+      else {
+        return make_error_fmt("unexpected symbol after '%s' in argument list: '%M'",
+                              val_sym, args->next->data);
+      }
     }
 
     /* & is not found - add the symbol to the regular argument list */
     else {
 
-      if (list_findf(regular_args, val->value.mal_symbol, symbol_fn) > 0) {
-        return make_error_fmt("duplicate symbol in argument list: '%s'", pr_str(val, UNREADABLY));
+      for(size_t i=0; i<param_len; i++) {
+        if(!strcmp(val_sym, parameters[i])) {
+          return make_error_fmt("duplicate symbol in argument list: '%s'",
+                                parameters[i]);
+        }
       }
-      else {
-        regular_args = list_push(regular_args, val);
-      }
+      parameters[param_len++] = val_sym;
     }
-    *args = (*args)->next;
+    args = args->next;
   }
 
-  *args = list_reverse(regular_args);
-  return make_nil();
-}
-
-char* symbol_fn(gptr data) {
-  return (((MalType*)data)->value.mal_symbol);
+  return make_closure(env, param_len, parameters, definition, more_symbol);
 }
 
 /* used by core functions but not EVAL as doesn't do TCE */
-MalType* apply(MalType* fn, list args) {
+MalType apply(MalType fn, list args) {
 
   if (is_function(fn)) {
 
-    MalType* (*fun_ptr)(list) = fn->value.mal_function;
+    MalType(*fun_ptr)(list) = fn->value.mal_function;
     return (*fun_ptr)(args);
   }
-  else { /* is_closure(fn) */
+  else if(is_closure(fn) || is_macro(fn)) {
 
-    MalClosure* c = fn->value.mal_closure;
-    list params = (c->parameters)->value.mal_list;
-
-    long param_count = list_count(params);
-    long arg_count = list_count(args);
-
-    if (param_count > arg_count) {
-      return make_error("too few arguments supplied to function");
-    }
-    else if ((param_count < arg_count) && !c->more_symbol) {
-      return make_error("too many arguments supplied to function");
-    }
-    else {
-      Env* env = env_make(c->env, params, args, c->more_symbol);
-      return EVAL(fn->value.mal_closure->definition, env);
-    }
+    Env* env;
+    MalType ast = env_apply(fn->value.mal_closure, args, &env);
+    if(is_error(ast)) return ast;
+    return EVAL(ast, env);
+  }
+  else {
+    return bad_type(fn, "a function, closure or macro");
   }
 }

--- a/impls/c.2/types.c
+++ b/impls/c.2/types.c
@@ -1,283 +1,106 @@
 #include <stdarg.h>
 #include <stdio.h>
+
 #include <gc.h>
+
 #include "types.h"
 
-#define ERROR_BUFFER_SIZE 128
+struct MalType_s THE_NIL = { MALTYPE_NIL, &THE_NIL, {0}};
+struct MalType_s THE_TRUE = { MALTYPE_TRUE, &THE_NIL, {0}};
+struct MalType_s THE_FALSE = { MALTYPE_FALSE, &THE_NIL, {0}};
 
-MalType THE_TRUE = {MALTYPE_TRUE, 0, 0, {0}};
-MalType THE_FALSE = {MALTYPE_FALSE, 0, 0, {0}};
-MalType THE_NIL = {MALTYPE_NIL, 0, 0, {0}};
+#define generic_is(name, mask)         \
+  inline int is_##name(MalType val) { \
+    return val->type & (mask);         \
+  }
+generic_is(sequential, MALTYPE_LIST | MALTYPE_VECTOR)
+generic_is(list, MALTYPE_LIST);
+generic_is(vector, MALTYPE_VECTOR);
+generic_is(hashmap, MALTYPE_HASHMAP);
+generic_is(nil, MALTYPE_NIL);
+generic_is(string, MALTYPE_STRING);
+generic_is(false, MALTYPE_FALSE);
+generic_is(symbol, MALTYPE_SYMBOL);
+generic_is(keyword, MALTYPE_KEYWORD);
+generic_is(error, MALTYPE_ERROR);
+generic_is(callable, MALTYPE_CLOSURE | MALTYPE_FUNCTION | MALTYPE_MACRO);
+generic_is(function, MALTYPE_FUNCTION);
+generic_is(closure, MALTYPE_CLOSURE);
+generic_is(macro, MALTYPE_MACRO);
 
+#define generic_make(name, ctype, mtype, mfield)             \
+  MalType name(ctype value) {                                \
+    struct MalType_s* mal_val = GC_MALLOC(sizeof(*mal_val)); \
+    *mal_val = (struct MalType_s){                           \
+      .type     = mtype,                                     \
+      .metadata = &THE_NIL,                                  \
+      .value    = { .mal_##mfield = value },                 \
+    };                                                       \
+    return mal_val;                                          \
+  }
+generic_make(make_symbol,   const char*, MALTYPE_SYMBOL,   string)
+generic_make(make_integer,  long,        MALTYPE_INTEGER,  integer)
+generic_make(make_float,    double,      MALTYPE_FLOAT,    float)
+generic_make(make_keyword,  const char*, MALTYPE_KEYWORD,  string)
+generic_make(make_string,   const char*, MALTYPE_STRING,   string)
+generic_make(make_list,     list,        MALTYPE_LIST,     list)
+generic_make(make_vector,   list,        MALTYPE_VECTOR,   list)
+generic_make(make_hashmap,  list,        MALTYPE_HASHMAP,  list)
+generic_make(make_function, function_t,  MALTYPE_FUNCTION, function)
+generic_make(wrap_error,    MalType,     MALTYPE_ERROR,    error);
+generic_make(make_macro,    MalClosure,  MALTYPE_MACRO,    closure)
 
-inline int is_sequential(MalType* val) {
-  return (val->type == MALTYPE_LIST || val->type == MALTYPE_VECTOR);
-}
+MalType make_atom(MalType value) {
 
-inline int is_self_evaluating(MalType* val) {
-  return (val->type == MALTYPE_KEYWORD || val->type == MALTYPE_INTEGER ||
-	  val->type == MALTYPE_FLOAT || val->type == MALTYPE_STRING ||
-	  val->type == MALTYPE_TRUE || val->type == MALTYPE_FALSE ||
-	  val->type == MALTYPE_NIL);
-}
+  MalType* atm_val = GC_MALLOC(sizeof(*atm_val));
+  *atm_val = value;
 
-inline int is_list(MalType* val) {
-  return (val->type == MALTYPE_LIST);
-}
-
-inline int is_vector(MalType* val) {
-  return (val->type == MALTYPE_VECTOR);
-}
-
-inline int is_hashmap(MalType* val) {
-  return (val->type == MALTYPE_HASHMAP);
-}
-
-inline int is_nil(MalType* val) {
-  return (val->type == MALTYPE_NIL);
-}
-
-inline int is_string(MalType* val) {
-  return (val->type == MALTYPE_STRING);
-}
-
-inline int is_integer(MalType* val) {
-  return (val->type == MALTYPE_INTEGER);
-}
-
-inline int is_float(MalType* val) {
-  return (val->type == MALTYPE_FLOAT);
-}
-
-inline int is_number(MalType* val) {
-  return (val->type == MALTYPE_INTEGER || val->type == MALTYPE_FLOAT);
-}
-
-inline int is_true(MalType* val) {
-  return (val->type == MALTYPE_TRUE);
-}
-
-inline int is_false(MalType* val) {
-  return (val->type == MALTYPE_FALSE);
-}
-
-inline int is_symbol(MalType* val) {
-  return (val->type == MALTYPE_SYMBOL);
-}
-
-inline int is_keyword(MalType* val) {
-  return (val->type == MALTYPE_KEYWORD);
-}
-
-inline int is_atom(MalType* val) {
-  return (val->type == MALTYPE_ATOM);
-}
-
-inline int is_error(MalType* val) {
-  return (val->type == MALTYPE_ERROR);
-}
-
-inline int is_callable(MalType* val) {
-  return (val->type == MALTYPE_FUNCTION || val->type == MALTYPE_CLOSURE);
-}
-
-inline int is_function(MalType* val) {
-  return (val->type == MALTYPE_FUNCTION);
-}
-
-inline int is_closure(MalType* val) {
-  return (val->type == MALTYPE_CLOSURE);
-}
-
-inline int is_macro(MalType* val) {
-  return (val->is_macro);
-}
-
-
-MalType* make_symbol(char* value) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_SYMBOL;
-  mal_val->value.mal_symbol = value;
-  mal_val->metadata = NULL;
-
-  return mal_val;
-}
-
-MalType* make_integer(long value) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_INTEGER;
-  mal_val->value.mal_integer = value;
-  mal_val->metadata = NULL;
-
-  return mal_val;
-}
-
-MalType* make_float(double value) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_FLOAT;
-  mal_val->value.mal_float = value;
-  mal_val->metadata = NULL;
-
-  return mal_val;
-}
-
-MalType* make_keyword(char* value) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_KEYWORD;
-  mal_val->value.mal_keyword = value;
-  mal_val->metadata = NULL;
-
-  return mal_val;
-}
-
-MalType* make_string(char* value) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_STRING;
-  mal_val->value.mal_string = value;
-  mal_val->metadata = NULL;
-
-  return mal_val;
-}
-
-MalType* make_list(list value) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_LIST;
-  mal_val->value.mal_list = value;
-  mal_val->metadata = NULL;
-
-  return mal_val;
-}
-
-MalType* make_vector(list value) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_VECTOR;
-  mal_val->value.mal_list = value;
-  mal_val->metadata = NULL;
-
-  return mal_val;
-}
-
-MalType* make_hashmap(list value) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_HASHMAP;
-  mal_val->value.mal_list = value;
-  mal_val->metadata = NULL;
-
-  return mal_val;
-}
-
-MalType* make_atom(MalType* value) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
+  struct MalType_s* mal_val = GC_MALLOC(sizeof(*mal_val));
   mal_val->type = MALTYPE_ATOM;
-  mal_val->value.mal_atom = value;
-  mal_val->metadata = NULL;
+  mal_val->value.mal_atom = atm_val;
+  mal_val->metadata = &THE_NIL;
 
   return mal_val;
 }
 
-MalType* make_function(MalType*(*fn)(list args)) {
+MalType make_closure(const Env* env, size_t param_len,
+                     const char** parameters,
+                     MalType definition, const char* more_symbol) {
 
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_FUNCTION;
-  mal_val->value.mal_function = fn;
-  mal_val->is_macro = 0;
-  mal_val->metadata = NULL;
-
-  return mal_val;
-}
-
-MalType* make_closure(Env* env, MalType* parameters, MalType* definition, MalType* more_symbol) {
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
+  struct MalType_s* mal_val = GC_MALLOC(sizeof(*mal_val));
   mal_val->type = MALTYPE_CLOSURE;
-  mal_val->metadata = NULL;
+  mal_val->metadata = &THE_NIL;
 
   /* Allocate memory for embedded struct */
-  MalClosure* mc = GC_MALLOC(sizeof(*mc));
+  struct MalClosure_s* mc = GC_MALLOC(sizeof(*mc));
   mc->env = env;
+  mc->param_len = param_len;
   mc->parameters = parameters;
   mc->definition = definition;
   mc->more_symbol = more_symbol;
 
-  mal_val->is_macro = 0;
   mal_val->value.mal_closure = mc;
   return mal_val;
 }
 
-inline MalType* make_true() {
+inline MalType make_true() {
   return &THE_TRUE;
 }
 
-inline MalType* make_false() {
+inline MalType make_false() {
   return &THE_FALSE;
 }
 
-inline MalType* make_nil() {
+inline MalType make_nil() {
   return &THE_NIL;
 }
 
-MalType* make_error(char* msg) {
-
-  MalType* mal_string = GC_MALLOC(sizeof(*mal_string));
-  mal_string->type = MALTYPE_STRING;
-  mal_string->value.mal_string = msg;
-
-  MalType* mal_val = GC_MALLOC(sizeof(*mal_val));
-  mal_val->type = MALTYPE_ERROR;
-  mal_val->value.mal_error = mal_string;
-  mal_val->metadata = NULL;
-
+MalType with_meta(MalType data, MalType meta) {
+  struct MalType_s* mal_val = GC_MALLOC(sizeof(*mal_val));
+  *mal_val = (struct MalType_s){
+    .type     = data->type,
+    .metadata = meta,
+    .value    = data->value,
+  };
   return mal_val;
-}
-
-MalType* make_error_fmt(char* fmt, ...) {
-
-  va_list argptr;
-  va_start(argptr, fmt);
-
-  char* buffer = GC_MALLOC(sizeof(*buffer) * ERROR_BUFFER_SIZE);
-
-  long n = vsnprintf(buffer, ERROR_BUFFER_SIZE, fmt, argptr);
-  va_end(argptr);
-
-  if (n > ERROR_BUFFER_SIZE) {
-    va_start(argptr, fmt);
-
-    buffer = GC_REALLOC(buffer, sizeof(*buffer) * n);
-    vsnprintf(buffer, n, fmt, argptr);
-
-    va_end(argptr);
-  }
-  return make_error(buffer);
-}
-
-MalType* wrap_error(MalType* value) {
-
-  MalType* mal_error = GC_MALLOC(sizeof(*mal_error));
-  mal_error->type = MALTYPE_ERROR;
-  mal_error->metadata = NULL;
-  mal_error->value.mal_error = value;
-
-  return mal_error;
-}
-
-MalType* copy_type(MalType* value) {
-
-  MalType* new_val = GC_MALLOC(sizeof(*new_val));
-
-  new_val->type = value->type;
-  new_val->is_macro = value->is_macro;
-  new_val->value = value->value;
-  new_val->metadata = value->metadata;
-
-  return new_val;
 }

--- a/impls/c.2/types.h
+++ b/impls/c.2/types.h
@@ -1,100 +1,141 @@
 #ifndef _MAL_TYPES_H
 #define _MAL_TYPES_H
 
-#include "libs/linked_list/linked_list.h"
-#include "libs/hashmap/hashmap.h"
+#include <stdbool.h>
+#include <stddef.h>
 
-#define MALTYPE_SYMBOL 1
-#define MALTYPE_KEYWORD 2
-#define MALTYPE_INTEGER 3
-#define MALTYPE_FLOAT 4
-#define MALTYPE_STRING 5
-#define MALTYPE_TRUE 6
-#define MALTYPE_FALSE 7
-#define MALTYPE_NIL 8
-#define MALTYPE_LIST 9
-#define MALTYPE_VECTOR 10
-#define MALTYPE_HASHMAP 11
-#define MALTYPE_FUNCTION 12
-#define MALTYPE_CLOSURE 13
-#define MALTYPE_ERROR 14
-#define MALTYPE_ATOM 15
+enum mal_type_t {
+  MALTYPE_SYMBOL   = 1 <<  0,
+  MALTYPE_KEYWORD  = 1 <<  1,
+  MALTYPE_INTEGER  = 1 <<  2,
+  MALTYPE_FLOAT    = 1 <<  3,
+  MALTYPE_STRING   = 1 <<  4,
+  MALTYPE_TRUE     = 1 <<  5,
+  MALTYPE_FALSE    = 1 <<  6,
+  MALTYPE_NIL      = 1 <<  7,
+  MALTYPE_LIST     = 1 <<  8,
+  MALTYPE_VECTOR   = 1 <<  9,
+  MALTYPE_HASHMAP  = 1 << 10,
+  MALTYPE_FUNCTION = 1 << 11,
+  MALTYPE_CLOSURE  = 1 << 12,
+  MALTYPE_ERROR    = 1 << 13,
+  MALTYPE_ATOM     = 1 << 14,
+  MALTYPE_MACRO    = 1 << 15,
+};
 
-typedef struct MalType_s MalType;
-typedef struct MalClosure_s MalClosure;
+typedef const struct MalType_s* MalType;
+typedef const struct MalClosure_s* MalClosure;
+typedef struct pair_s* list;
+typedef MalType(*function_t)(list);
 typedef struct Env_s Env;
 
-struct MalType_s {
-
-  int type;
-  int is_macro;
-  MalType* metadata;
-
-  union MalValue {
+union MalType_u {
 
     long mal_integer;
     double mal_float;
-    char* mal_symbol;
-    char* mal_string;
-    char* mal_keyword;
+    const char* mal_string;
     list mal_list;
     /* vector mal_vector;  TODO: implement a real vector */
     /* hashmap mal_hashmap; TODO: implement a real hashmap */
-    MalType* (*mal_function)(list);
-    MalClosure* mal_closure;
+    function_t mal_function;
+    MalClosure mal_closure;
     MalType* mal_atom;
-    MalType* mal_error;
+    MalType mal_error;
 
-  } value;
+};
+struct MalType_s {
+  enum mal_type_t type;
+  MalType metadata;
+  union MalType_u value;
 };
 
 struct MalClosure_s {
 
-  Env* env;
-  MalType* parameters;
-  MalType* more_symbol;
-  MalType* definition;
+  const Env* env;
+  size_t param_len;
+  const char** parameters;
+  const char* more_symbol;
+  MalType definition;
 
 };
 
-MalType* make_symbol(char* value);
-MalType* make_integer(long value);
-MalType* make_float(double value);
-MalType* make_keyword(char* value);
-MalType* make_string(char* value);
-MalType* make_list(list value);
-MalType* make_vector(list value);
-MalType* make_hashmap(list value);
-MalType* make_true();
-MalType* make_false();
-MalType* make_nil();
-MalType* make_atom(MalType* value);
-MalType* make_error(char* msg);
-MalType* make_error_fmt(char* fmt, ...);
-MalType* wrap_error(MalType* value);
-MalType* make_function(MalType*(*fn)(list args));
-MalType* make_closure(Env* env, MalType* parameters, MalType* definition, MalType* more_symbol);
-MalType* copy_type(MalType* value);
+MalType make_symbol(const char* value);
+MalType make_integer(long value);
+MalType make_float(double value);
+MalType make_keyword(const char* value);
+MalType make_string(const char* value);
+MalType make_list(list value);
+MalType make_vector(list value);
+MalType make_hashmap(list value);
+MalType make_true();
+MalType make_false();
+MalType make_nil();
+MalType make_atom(MalType value);
+#define make_error_fmt(fmt, ...)                                        \
+  wrap_error(make_string(mal_printf("%s: " fmt, __func__, ## __VA_ARGS__)));
+MalType wrap_error(MalType value);;
+MalType make_function(function_t value);
+MalType make_closure(const Env* env, size_t param_len,
+                     const char** parameters,
+                     MalType definition, const char* more_symbol);
+MalType make_macro(MalClosure value);
+MalType with_meta(MalType data, MalType meta);
 
-int is_sequential(MalType* val);
-int is_self_evaluating(MalType* val);
-int is_list(MalType* val);
-int is_vector(MalType* val);
-int is_hashmap(MalType* val);
-int is_nil(MalType* val);
-int is_string(MalType* val);
-int is_integer(MalType* val);
-int is_float(MalType* val);
-int is_number(MalType* val);
-int is_true(MalType* val);
-int is_false(MalType* val);
-int is_symbol(MalType* val);
-int is_keyword(MalType* val);
-int is_atom(MalType* val);
-int is_error(MalType* val);
-int is_callable(MalType* val);
-int is_function(MalType* val);
-int is_closure(MalType* val);
-int is_macro(MalType* val);
+int is_sequential(MalType val);
+int is_list(MalType val);
+int is_vector(MalType val);
+int is_hashmap(MalType val);
+int is_nil(MalType val);
+int is_string(MalType val);
+int is_false(MalType val);
+int is_symbol(MalType val);
+int is_keyword(MalType val);
+int is_error(MalType val);
+int is_callable(MalType val);
+int is_function(MalType val);
+int is_closure(MalType val);
+int is_macro(MalType val);
+
+
+//  Return an exception if the list is empty.
+//  Else, return the first element and move it forward.
+//  Mutates the argument.
+#define eat_argument(args)                        \
+  ({                                              \
+    if(!(args))                                   \
+      return make_error_fmt("too_few_arguments"); \
+    MalType _tmp = args->data;                    \
+    args = args->next;                            \
+    _tmp;                                         \
+  })
+
+#define check_empty(lst)                                            \
+  if(lst)                                                           \
+    return make_error_fmt("unexpected trailing arguments: % N", lst);
+
+#define bad_type(form, expected)                                        \
+  make_error_fmt("expected %s, got: %M", expected, form);
+
+#define check_type(form, mask, expected)                   \
+  if(form->type & ~(mask)) return bad_type(form, expected)
+
+//  Beware that this evaluates the argument twice.
+#define as_string(f)                                                 \
+  ({ check_type(f, MALTYPE_STRING,  "a string");   f->value.mal_string;  })
+#define as_symbol(f)                                                  \
+  ({ check_type(f, MALTYPE_SYMBOL,  "a symbol");   f->value.mal_string;  })
+#define as_list(f)                                                    \
+  ({ check_type(f, MALTYPE_LIST,    "a list");     f->value.mal_list;    })
+#define as_map(f)                                                     \
+  ({ check_type(f, MALTYPE_HASHMAP, "a map");      f->value.mal_list   ; })
+#define as_closure(f)                                                 \
+  ({ check_type(f, MALTYPE_CLOSURE, "a closure");  f->value.mal_closure; })
+#define as_integer(f)                                                 \
+  ({ check_type(f, MALTYPE_INTEGER, "an integer"); f->value.mal_integer; })
+#define as_atom(f)                                                    \
+  ({ check_type(f, MALTYPE_ATOM,    "an atom");    f->value.mal_atom;    })
+#define as_sequence(f)                                                \
+  ({ check_type(f, MALTYPE_LIST | MALTYPE_VECTOR, "a sequence");      \
+    f->value.mal_list; })
 
 #endif


### PR DESCRIPTION
* Define MalType as a pointer type, instead of an alias for a struct. It is now possible to declare it constant.
* Use macros to avoid lots of code duplication.
* Avoid redundant tests when possible.
* Avoid implicit signed/unsigned conversions.
* Use the const modifier whenever possible.
* Move private forward declarations from .h to .c, and forward declarations on the top of the .c.

Makefile:
  enable more warnings avoid recompiling each .o for each step fix .PHONY usage

core.c:
  Link mal_list/vector/hash_map directly to make_*. Move mal_readline from stepA (reallocate with GC).
  + - * /: exactly two arguments. =: without memory allocation, stop comparing functions and closures. Stop assuming that nil contains a valid list(first/rest/get). throw: the argument should never be an exception. vec: refuse maps. seq: fix allocation of single character-strings.

core.h:
  Represent the namespace as a static array instead of a linked list.

list:
* Avoid reversals, either by modifying the last link or simply by inserting elements in the right order,
* Avoid void*, the benefit of genericity here is small compared to the benefits of type checking.
* Store a pointer to nil as default metadata, instead of NULL.

env:
* Implement with binary trees.  This is easy for a mutable structure, and helps a lot the performance of accessing REPL keys.
* move repeated calls to env_set to steps.

maps:
* Check type of map keys.
* Remove the confusing in-place mutations.

printer:
  Replace most string allocations with idiomatic printf-style specifiers.

reader:
  Rewrite without intermediate tokenizer. Propagate more errors. Merge list/vector/hasmap handling.

run:
  does not need bash.

steps:
 * reduce diff between steps.
 * Add an env_apply helper, reducing duplication.
 * Merge regularise_parameters into eval_fnstar (propagating errors was a burden compared to the benefit).
 * Use the same function for eval_vector, eval_hashmap and apply arguments. Return an error directly, not a list containing an error.
 * Rewrite quasiquote, fixing some misplaced unquotes.
 * Clarify return value of TCO helpers.
 * Report errors during startup.

types:
* Try to merge type selection and value extraction, for concision and safety.
* In the union, use one name per type (mal_string/keyword/symbol were confused in several places anyway).
* Represent atoms as a double pointer, and macros with a type.
* Prefer enums to macros.
* Represent function parameters as a static array instead of a linked list.
