### PR TITLE
c.2: improve performance

### DIFF
--- a/impls/c.2/Makefile
+++ b/impls/c.2/Makefile
@@ -21,7 +21,7 @@ ifndef no_fast
   CFLAGS  += -flto -O3 -DNDEBUG
   LDFLAGS += -flto
 endif
-ifdef profilie
+ifdef profile
   CFLAGS  += -pg
   LDFLAGS += -pg
 endif
@@ -71,6 +71,6 @@ deps:
 	$(CC) -MM -MF- *.c > $@
 
 clean:
-	rm -f $(S0+) *.o deps
+	rm -f $(S0+) *.o deps gmon.out
 
 .PHONY: all clean

--- a/impls/c.2/README
+++ b/impls/c.2/README
@@ -1,0 +1,13 @@
+make -Cimpls/c.2/ clean
+make -Cimpls/c.2/ no_fast=1
+make test^c.2 HARD=1 REGRESS=1
+make test^mal HARD=1 MAL_IMPL=c.2
+
+make -Cimpls/c.2/ clean
+make -Cimpls/c.2/
+make perf^c.2
+
+make -Cimpls/c.2/ clean
+make -Cimpls/c.2/ stepA_mal profile=1
+make perf^c.2
+(cd impls/c.2/ && gprof stepA_mal | less)

--- a/impls/c.2/error.h
+++ b/impls/c.2/error.h
@@ -7,7 +7,7 @@ extern MalType mal_error;
 
 #define make_error(...) {                             \
     mal_error = make_string(mal_printf(__VA_ARGS__)); \
-    return NULL;                                      \
+    return 0;                                         \
   }
 
 #define bad_type(context, mask, form)                     \

--- a/impls/c.2/hashmap.c
+++ b/impls/c.2/hashmap.c
@@ -40,7 +40,7 @@ struct map {
   size_t size;
   struct bucket {
     MalType key;
-    MalType value;
+    void*   value;
   } buckets[];
 };
 
@@ -102,7 +102,7 @@ size_t search(hashmap map, MalType key) {
   return index;
 }
 
-void put(struct map* map, MalType key, MalType value) {
+void put(struct map* map, MalType key, void* value) {
   size_t i = search(map, key);
   if (!map->buckets[i].key) {
     map->used++;
@@ -112,7 +112,8 @@ void put(struct map* map, MalType key, MalType value) {
   map->buckets[i].value = value;
 }
 
-struct map* hashmap_put(struct map* map, MalType key, MalType value) {
+struct map* hashmap_put(struct map* map, MalType key, void* value) {
+  assert(value);
   if (map->size <= 2 * (map->used + 1)) {
     // Reallocate.
     size_t size = map->size * GROW_FACTOR;
@@ -130,7 +131,7 @@ struct map* hashmap_put(struct map* map, MalType key, MalType value) {
   return map;
 }
 
-inline MalType hashmap_get(hashmap map, MalType key) {
+inline void* hashmap_get(hashmap map, MalType key) {
   return map->buckets[search(map, key)].value; // may be null
 }
 
@@ -168,7 +169,7 @@ inline MalType map_key(hashmap map, map_cursor position) {
   return map->buckets[position].key;
 }
 
-inline MalType map_val(hashmap map, map_cursor position) {
+inline void* map_val(hashmap map, map_cursor position) {
   assert(position < map->size);
   assert(map->buckets[position].key);
   assert(map->buckets[position].value);

--- a/impls/c.2/hashmap.h
+++ b/impls/c.2/hashmap.h
@@ -12,10 +12,11 @@ struct map* map_empty();
 
 struct map* map_copy(hashmap);
 
-struct map* hashmap_put(struct map* map, MalType key, MalType value);
+struct map* hashmap_put(struct map* map, MalType key, void* value);
+// Value must not be NULL.
 // May reallocate.
 
-MalType hashmap_get(hashmap map, MalType key);
+void* hashmap_get(hashmap map, MalType key);
 // Returns NULL if the map does not contain the key.
 
 void map_dissoc_mutate(struct map* map, MalType key);
@@ -30,6 +31,6 @@ map_cursor map_iter(hashmap);
 bool map_cont(hashmap, map_cursor);
 map_cursor map_next(hashmap, map_cursor);
 MalType map_key(hashmap, map_cursor);
-MalType map_val(hashmap, map_cursor);
+void* map_val(hashmap, map_cursor);
 
 #endif

--- a/impls/c.2/linked_list.c
+++ b/impls/c.2/linked_list.c
@@ -11,9 +11,9 @@ list list_push(list lst, MalType data_ptr) {
   return new_head;
 }
 
-int list_count(list lst) {
+size_t list_count(list lst) {
 
-  int counter = 0;
+  size_t counter = 0;
 
   while(lst) {
 

--- a/impls/c.2/linked_list.h
+++ b/impls/c.2/linked_list.h
@@ -14,6 +14,6 @@ struct pair_s {
 
 /* interface */
 list list_push(list lst, MalType data_ptr);
-int list_count(list lst);
+size_t list_count(list lst);
 
 #endif

--- a/impls/c.2/printer.c
+++ b/impls/c.2/printer.c
@@ -140,7 +140,7 @@ int print_L(FILE* stream, const struct printf_info *i, const void *const *a) {
 int pr_str_vector(FILE* stream, const struct printf_info *i, vector_t v) {
   int written = 0;
   ADD(fprintf(stream, "["));
-  for (int j = 0; j < v->count; j++) {
+  for (size_t j = 0; j < v->count; j++) {
     ADD(fprintf(stream,
                 i->alt ? "%s%#M" : "%s%M",
                 j ? " " : "",
@@ -269,7 +269,7 @@ const char* mal_printf(const char* fmt, ...) {
   char* buffer = GC_MALLOC(n + 1);
 
   va_start(argptr, fmt);
-  int again = vsnprintf(buffer, n + 1, fmt, argptr);
+  int again = vsnprintf(buffer, n+1, fmt, argptr);
   assert(n == again);
 #ifdef NDEBUG
   (void)again;

--- a/impls/c.2/reader.c
+++ b/impls/c.2/reader.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <assert.h>
 
 #include <gc.h>
 
@@ -95,6 +96,7 @@ const char* read_symbol (Reader reader) {
   size_t len = *reader - start;
   char* result = GC_MALLOC(len + 1);
   strncpy(result, start, len);
+  assert(!result[len]);
   return result;
 }
 
@@ -177,7 +179,7 @@ MalType read_number(Reader reader) {
   // (followed by a digit).
   (*reader)++;
 
-  int has_decimal_point = 0;
+  bool has_decimal_point = false;
 
   while(true) {
     if(**reader == '.') {
@@ -255,8 +257,8 @@ MalType read_list(Reader reader) {
 
 MalType read_vector(Reader reader) {
   (*reader)++;
-  int capacity = 10;
-  struct vector* v = vector_new(10);
+  size_t capacity = 10;
+  struct vector* v = vector_new(capacity);
   while(true) {
     DEBUG("searching ']'");
     skip_spaces(reader);

--- a/impls/c.2/step2_eval.c
+++ b/impls/c.2/step2_eval.c
@@ -159,13 +159,14 @@ list evaluate_list(list lst, hashmap env) {
 }
 
 MalType evaluate_vector(vector_t lst, hashmap env) {
-  int capacity = lst->count;
+  size_t capacity = lst->count;
   struct vector* evlst = vector_new(capacity);
-  for(int i = 0; i <= lst->count - 1; i++) {
+  for (size_t i = 0; i < capacity; i++) {
     MalType new = EVAL(lst->nth[i], env);
     if (mal_error) return NULL;
     vector_append(&capacity, &evlst, new);
   }
+  assert(evlst->count == capacity);
   return make_vector(evlst);
 }
 

--- a/impls/c.2/step3_env.c
+++ b/impls/c.2/step3_env.c
@@ -221,13 +221,14 @@ list evaluate_list(list lst, Env* env) {
 }
 
 MalType evaluate_vector(vector_t lst, Env* env) {
-  int capacity = lst->count;
+  size_t capacity = lst->count;
   struct vector* evlst = vector_new(capacity);
-  for(int i = 0; i <= lst->count - 1; i++) {
+  for (size_t i = 0; i < capacity; i++) {
     MalType new = EVAL(lst->nth[i], env);
     if (mal_error) return NULL;
     vector_append(&capacity, &evlst, new);
   }
+  assert(evlst->count == capacity);
   return make_vector(evlst);
 }
 

--- a/impls/c.2/step4_if_fn_do.c
+++ b/impls/c.2/step4_if_fn_do.c
@@ -343,13 +343,14 @@ list evaluate_list(list lst, Env* env) {
 }
 
 MalType evaluate_vector(vector_t lst, Env* env) {
-  int capacity = lst->count;
+  size_t capacity = lst->count;
   struct vector* evlst = vector_new(capacity);
-  for(int i = 0; i <= lst->count - 1; i++) {
+  for (size_t i = 0; i < capacity; i++) {
     MalType new = EVAL(lst->nth[i], env);
     if (mal_error) return NULL;
     vector_append(&capacity, &evlst, new);
   }
+  assert(evlst->count == capacity);
   return make_vector(evlst);
 }
 

--- a/impls/c.2/step5_tco.c
+++ b/impls/c.2/step5_tco.c
@@ -362,13 +362,14 @@ list evaluate_list(list lst, Env* env) {
 }
 
 MalType evaluate_vector(vector_t lst, Env* env) {
-  int capacity = lst->count;
+  size_t capacity = lst->count;
   struct vector* evlst = vector_new(capacity);
-  for(int i = 0; i <= lst->count - 1; i++) {
+  for (size_t i = 0; i < capacity; i++) {
     MalType new = EVAL(lst->nth[i], env);
     if (mal_error) return NULL;
     vector_append(&capacity, &evlst, new);
   }
+  assert(evlst->count == capacity);
   return make_vector(evlst);
 }
 

--- a/impls/c.2/step5_tco.c
+++ b/impls/c.2/step5_tco.c
@@ -19,11 +19,14 @@ MalType apply(MalType, list); // For the apply phase and core apply/map/swap.
 list evaluate_list(list, Env*);
 MalType evaluate_vector(vector_t, Env*);
 MalType evaluate_hashmap(hashmap lst, Env* env);
-MalType eval_defbang(list, Env*);
-MalType eval_letstar(list, Env**); // TCO
-MalType eval_if(list, Env*); // TCO (even for nil)
-MalType eval_fnstar(list, const Env*);
-MalType eval_do(list, Env*); // TCO in the same env
+MalType eval_defbang(list, Env**);
+MalType eval_letstar(list, Env**);
+MalType eval_if(list, Env**);
+MalType eval_fnstar(list, Env**);
+MalType eval_do(list, Env**);
+
+typedef MalType (*special_t)(list, Env**);
+struct map* specials;
 
 MalType READ(const char* str) {
 
@@ -43,7 +46,7 @@ Env* env_apply(MalClosure closure, list args) {
   while (true) {
     if (!seq_cont(params, c)) {
       if (a) {
-        make_error("'apply': expected [%M], got [%N]", params, args);
+        make_error("'apply': expected %M, got [%N]", params, args);
       }
       break;
     }
@@ -55,7 +58,7 @@ Env* env_apply(MalClosure closure, list args) {
       break;
     }
     if (!a) {
-      make_error("'apply': expected [%M], got [%N]", params, args);
+      make_error("'apply': expected %M, got [%N]", params, args);
     }
     env_set(fn_env, parameter, a->data);
     c = seq_next(params, c);
@@ -105,38 +108,16 @@ MalType EVAL(MalType ast, Env* env) {
   lst = lst->next;
 
     /* handle special symbols first */
-    if (equal_forms(first, SYMBOL_DEF)) {
-      return eval_defbang(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_LET)) {
+  if (type(first) & MALTYPE_SYMBOL) {
+    special_t special = hashmap_get(specials, first);
+    if (special) {
+      ast = special(lst, &env);
+      if (mal_error) return NULL;
 
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_letstar(lst, &env);
-
-      if (mal_error) { return NULL; }
+      if(!env) { return ast; }
       goto TCE_entry_point;
     }
-    else if (equal_forms(first, SYMBOL_IF)) {
-
-      /* TCE - modify ast directly and jump back to eval */
-      ast = eval_if(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_FN)) {
-      return eval_fnstar(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_DO)) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
+  }
 
   /* first element is not a special symbol */
   MalType func = EVAL(first, env);
@@ -201,6 +182,13 @@ int main() {
   types_init();
   printer_init();
 
+  specials = map_empty();
+  specials = hashmap_put(specials, SYMBOL_DEF,        eval_defbang);
+  specials = hashmap_put(specials, SYMBOL_LET,        eval_letstar);
+  specials = hashmap_put(specials, SYMBOL_IF,         eval_if);
+  specials = hashmap_put(specials, SYMBOL_FN,         eval_fnstar);
+  specials = hashmap_put(specials, SYMBOL_DO,         eval_do);
+
   Env* repl_env = env_make(NULL);
 
   ns core;
@@ -229,16 +217,17 @@ int main() {
   return EXIT_SUCCESS;
 }
 
-MalType eval_defbang(list lst, Env* env) {
+MalType eval_defbang(list lst, Env** env) {
 
   explode2("def!", lst, defbang_symbol, defbang_value);
 
-  MalType result = EVAL(defbang_value, env);
+  MalType result = EVAL(defbang_value, *env);
   if (mal_error) {
     return NULL;
   }
   check_type("def!", MALTYPE_SYMBOL, defbang_symbol);
-  env_set(env, defbang_symbol, result);
+  env_set(*env, defbang_symbol, result);
+  *env = NULL; // no TCO
   return result;
 }
 
@@ -276,7 +265,7 @@ MalType eval_letstar(list lst, Env** env) {
   return forms;
 }
 
-MalType eval_if(list lst, Env* env) {
+MalType eval_if(list lst, Env** env) {
 
   if (!lst) {
     bad_arg_count("if", "two or three arguments", lst);
@@ -299,7 +288,7 @@ MalType eval_if(list lst, Env* env) {
     else_form = NULL;
   }
 
-  MalType condition = EVAL(raw_condition, env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (mal_error) {
     return NULL;
@@ -312,6 +301,7 @@ MalType eval_if(list lst, Env* env) {
       return else_form;
     }
     else {
+      *env = NULL; // no TCO
       return make_nil();
     }
 
@@ -320,7 +310,7 @@ MalType eval_if(list lst, Env* env) {
   }
 }
 
-MalType eval_do(list lst, Env* env) {
+MalType eval_do(list lst, Env** env) {
 
   /* handle empty 'do' */
   if (!lst) {
@@ -330,7 +320,7 @@ MalType eval_do(list lst, Env* env) {
   /* evaluate all but the last form */
   while (lst->next) {
 
-    EVAL(lst->data, env);
+    EVAL(lst->data, *env);
 
     /* return error early */
     if (mal_error) {
@@ -385,7 +375,7 @@ MalType evaluate_hashmap(hashmap lst, Env* env) {
   return make_hashmap(evlst);
 }
 
-MalType eval_fnstar(list lst, const Env* env) {
+MalType eval_fnstar(list lst, Env** env) {
 
   if (!lst || !lst->next || lst->next->next) {
     bad_arg_count("fn*", "two parameters", lst);
@@ -419,8 +409,9 @@ MalType eval_fnstar(list lst, const Env* env) {
       break;
     }
   }
-
-  return make_closure(env, lst);
+  Env* fn_env = *env;
+  *env = NULL; // no TCO
+  return make_closure(fn_env, lst);
 }
 
 /* used by core functions but not EVAL as doesn't do TCE */

--- a/impls/c.2/step6_file.c
+++ b/impls/c.2/step6_file.c
@@ -19,11 +19,14 @@ MalType apply(MalType, list); // For the apply phase and core apply/map/swap.
 list evaluate_list(list, Env*);
 MalType evaluate_vector(vector_t, Env*);
 MalType evaluate_hashmap(hashmap lst, Env* env);
-MalType eval_defbang(list, Env*);
-MalType eval_letstar(list, Env**); // TCO
-MalType eval_if(list, Env*); // TCO (even for nil)
-MalType eval_fnstar(list, const Env*);
-MalType eval_do(list, Env*); // TCO in the same env
+MalType eval_defbang(list, Env**);
+MalType eval_letstar(list, Env**);
+MalType eval_if(list, Env**);
+MalType eval_fnstar(list, Env**);
+MalType eval_do(list, Env**);
+
+typedef MalType (*special_t)(list, Env**);
+struct map* specials;
 
 MalType READ(const char* str) {
 
@@ -43,7 +46,7 @@ Env* env_apply(MalClosure closure, list args) {
   while (true) {
     if (!seq_cont(params, c)) {
       if (a) {
-        make_error("'apply': expected [%M], got [%N]", params, args);
+        make_error("'apply': expected %M, got [%N]", params, args);
       }
       break;
     }
@@ -55,7 +58,7 @@ Env* env_apply(MalClosure closure, list args) {
       break;
     }
     if (!a) {
-      make_error("'apply': expected [%M], got [%N]", params, args);
+      make_error("'apply': expected %M, got [%N]", params, args);
     }
     env_set(fn_env, parameter, a->data);
     c = seq_next(params, c);
@@ -105,38 +108,16 @@ MalType EVAL(MalType ast, Env* env) {
   lst = lst->next;
 
     /* handle special symbols first */
-    if (equal_forms(first, SYMBOL_DEF)) {
-      return eval_defbang(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_LET)) {
+  if (type(first) & MALTYPE_SYMBOL) {
+    special_t special = hashmap_get(specials, first);
+    if (special) {
+      ast = special(lst, &env);
+      if (mal_error) return NULL;
 
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_letstar(lst, &env);
-
-      if (mal_error) { return NULL; }
+      if(!env) { return ast; }
       goto TCE_entry_point;
     }
-    else if (equal_forms(first, SYMBOL_IF)) {
-
-      /* TCE - modify ast directly and jump back to eval */
-      ast = eval_if(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_FN)) {
-      return eval_fnstar(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_DO)) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
+  }
 
   /* first element is not a special symbol */
   MalType func = EVAL(first, env);
@@ -211,6 +192,13 @@ int main(int argc, char** argv) {
   types_init();
   printer_init();
 
+  specials = map_empty();
+  specials = hashmap_put(specials, SYMBOL_DEF,        eval_defbang);
+  specials = hashmap_put(specials, SYMBOL_LET,        eval_letstar);
+  specials = hashmap_put(specials, SYMBOL_IF,         eval_if);
+  specials = hashmap_put(specials, SYMBOL_FN,         eval_fnstar);
+  specials = hashmap_put(specials, SYMBOL_DO,         eval_do);
+
   repl_env = env_make(NULL);
 
   ns core;
@@ -259,16 +247,17 @@ int main(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
-MalType eval_defbang(list lst, Env* env) {
+MalType eval_defbang(list lst, Env** env) {
 
   explode2("def!", lst, defbang_symbol, defbang_value);
 
-  MalType result = EVAL(defbang_value, env);
+  MalType result = EVAL(defbang_value, *env);
   if (mal_error) {
     return NULL;
   }
   check_type("def!", MALTYPE_SYMBOL, defbang_symbol);
-  env_set(env, defbang_symbol, result);
+  env_set(*env, defbang_symbol, result);
+  *env = NULL; // no TCO
   return result;
 }
 
@@ -306,7 +295,7 @@ MalType eval_letstar(list lst, Env** env) {
   return forms;
 }
 
-MalType eval_if(list lst, Env* env) {
+MalType eval_if(list lst, Env** env) {
 
   if (!lst) {
     bad_arg_count("if", "two or three arguments", lst);
@@ -329,7 +318,7 @@ MalType eval_if(list lst, Env* env) {
     else_form = NULL;
   }
 
-  MalType condition = EVAL(raw_condition, env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (mal_error) {
     return NULL;
@@ -342,6 +331,7 @@ MalType eval_if(list lst, Env* env) {
       return else_form;
     }
     else {
+      *env = NULL; // no TCO
       return make_nil();
     }
 
@@ -350,7 +340,7 @@ MalType eval_if(list lst, Env* env) {
   }
 }
 
-MalType eval_do(list lst, Env* env) {
+MalType eval_do(list lst, Env** env) {
 
   /* handle empty 'do' */
   if (!lst) {
@@ -360,7 +350,7 @@ MalType eval_do(list lst, Env* env) {
   /* evaluate all but the last form */
   while (lst->next) {
 
-    EVAL(lst->data, env);
+    EVAL(lst->data, *env);
 
     /* return error early */
     if (mal_error) {
@@ -415,7 +405,7 @@ MalType evaluate_hashmap(hashmap lst, Env* env) {
   return make_hashmap(evlst);
 }
 
-MalType eval_fnstar(list lst, const Env* env) {
+MalType eval_fnstar(list lst, Env** env) {
 
   if (!lst || !lst->next || lst->next->next) {
     bad_arg_count("fn*", "two parameters", lst);
@@ -449,8 +439,9 @@ MalType eval_fnstar(list lst, const Env* env) {
       break;
     }
   }
-
-  return make_closure(env, lst);
+  Env* fn_env = *env;
+  *env = NULL; // no TCO
+  return make_closure(fn_env, lst);
 }
 
 /* used by core functions but not EVAL as doesn't do TCE */

--- a/impls/c.2/step6_file.c
+++ b/impls/c.2/step6_file.c
@@ -392,13 +392,14 @@ list evaluate_list(list lst, Env* env) {
 }
 
 MalType evaluate_vector(vector_t lst, Env* env) {
-  int capacity = lst->count;
+  size_t capacity = lst->count;
   struct vector* evlst = vector_new(capacity);
-  for(int i = 0; i <= lst->count - 1; i++) {
+  for (size_t i = 0; i < capacity; i++) {
     MalType new = EVAL(lst->nth[i], env);
     if (mal_error) return NULL;
     vector_append(&capacity, &evlst, new);
   }
+  assert(evlst->count == capacity);
   return make_vector(evlst);
 }
 

--- a/impls/c.2/step7_quote.c
+++ b/impls/c.2/step7_quote.c
@@ -445,7 +445,7 @@ MalType quasiquote(MalType ast) {
 MalType quasiquote_vector(vector_t vec) {
 
   MalType result = make_list(NULL);
-  for(int i = vec->count - 1; -1 < i; i--) {
+  for (size_t i = vec->count; i--; ) {
     result = quasiquote_folder(vec->nth[i], result);
     if (mal_error) return NULL;
   }
@@ -518,13 +518,14 @@ list evaluate_list(list lst, Env* env) {
 }
 
 MalType evaluate_vector(vector_t lst, Env* env) {
-  int capacity = lst->count;
+  size_t capacity = lst->count;
   struct vector* evlst = vector_new(capacity);
-  for(int i = 0; i <= lst->count - 1; i++) {
+  for (size_t i = 0; i < capacity; i++) {
     MalType new = EVAL(lst->nth[i], env);
     if (mal_error) return NULL;
     vector_append(&capacity, &evlst, new);
   }
+  assert(evlst->count == capacity);
   return make_vector(evlst);
 }
 

--- a/impls/c.2/step7_quote.c
+++ b/impls/c.2/step7_quote.c
@@ -19,17 +19,20 @@ MalType apply(MalType, list); // For the apply phase and core apply/map/swap.
 list evaluate_list(list, Env*);
 MalType evaluate_vector(vector_t, Env*);
 MalType evaluate_hashmap(hashmap lst, Env* env);
-MalType eval_defbang(list, Env*);
-MalType eval_letstar(list, Env**); // TCO
-MalType eval_if(list, Env*); // TCO (even for nil)
-MalType eval_fnstar(list, const Env*);
-MalType eval_do(list, Env*); // TCO in the same env
-MalType eval_quote(list);
-MalType eval_quasiquote(list);
+MalType eval_defbang(list, Env**);
+MalType eval_letstar(list, Env**);
+MalType eval_if(list, Env**);
+MalType eval_fnstar(list, Env**);
+MalType eval_do(list, Env**);
+MalType eval_quote(list, Env**);
+MalType eval_quasiquote(list, Env**);
 MalType quasiquote(MalType);
 MalType quasiquote_vector(vector_t);
 MalType quasiquote_list(list);
 MalType quasiquote_folder(MalType first, MalType qq_rest);
+
+typedef MalType (*special_t)(list, Env**);
+struct map* specials;
 
 MalType READ(const char* str) {
 
@@ -49,7 +52,7 @@ Env* env_apply(MalClosure closure, list args) {
   while (true) {
     if (!seq_cont(params, c)) {
       if (a) {
-        make_error("'apply': expected [%M], got [%N]", params, args);
+        make_error("'apply': expected %M, got [%N]", params, args);
       }
       break;
     }
@@ -61,7 +64,7 @@ Env* env_apply(MalClosure closure, list args) {
       break;
     }
     if (!a) {
-      make_error("'apply': expected [%M], got [%N]", params, args);
+      make_error("'apply': expected %M, got [%N]", params, args);
     }
     env_set(fn_env, parameter, a->data);
     c = seq_next(params, c);
@@ -111,49 +114,16 @@ MalType EVAL(MalType ast, Env* env) {
   lst = lst->next;
 
     /* handle special symbols first */
-    if (equal_forms(first, SYMBOL_DEF)) {
-      return eval_defbang(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_LET)) {
+  if (type(first) & MALTYPE_SYMBOL) {
+    special_t special = hashmap_get(specials, first);
+    if (special) {
+      ast = special(lst, &env);
+      if (mal_error) return NULL;
 
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_letstar(lst, &env);
-
-      if (mal_error) { return NULL; }
+      if(!env) { return ast; }
       goto TCE_entry_point;
     }
-    else if (equal_forms(first, SYMBOL_IF)) {
-
-      /* TCE - modify ast directly and jump back to eval */
-      ast = eval_if(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_FN)) {
-      return eval_fnstar(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_DO)) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_QUOTE)) {
-      return eval_quote(lst);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_QUASIQUOTE)) {
-
-      ast = eval_quasiquote(lst);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
+  }
 
   /* first element is not a special symbol */
   MalType func = EVAL(first, env);
@@ -228,6 +198,15 @@ int main(int argc, char** argv) {
   types_init();
   printer_init();
 
+  specials = map_empty();
+  specials = hashmap_put(specials, SYMBOL_DEF,        eval_defbang);
+  specials = hashmap_put(specials, SYMBOL_LET,        eval_letstar);
+  specials = hashmap_put(specials, SYMBOL_IF,         eval_if);
+  specials = hashmap_put(specials, SYMBOL_FN,         eval_fnstar);
+  specials = hashmap_put(specials, SYMBOL_DO,         eval_do);
+  specials = hashmap_put(specials, SYMBOL_QUOTE,      eval_quote);
+  specials = hashmap_put(specials, SYMBOL_QUASIQUOTE, eval_quasiquote);
+
   repl_env = env_make(NULL);
 
   ns core;
@@ -276,16 +255,17 @@ int main(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
-MalType eval_defbang(list lst, Env* env) {
+MalType eval_defbang(list lst, Env** env) {
 
   explode2("def!", lst, defbang_symbol, defbang_value);
 
-  MalType result = EVAL(defbang_value, env);
+  MalType result = EVAL(defbang_value, *env);
   if (mal_error) {
     return NULL;
   }
   check_type("def!", MALTYPE_SYMBOL, defbang_symbol);
-  env_set(env, defbang_symbol, result);
+  env_set(*env, defbang_symbol, result);
+  *env = NULL; // no TCO
   return result;
 }
 
@@ -323,7 +303,7 @@ MalType eval_letstar(list lst, Env** env) {
   return forms;
 }
 
-MalType eval_if(list lst, Env* env) {
+MalType eval_if(list lst, Env** env) {
 
   if (!lst) {
     bad_arg_count("if", "two or three arguments", lst);
@@ -346,7 +326,7 @@ MalType eval_if(list lst, Env* env) {
     else_form = NULL;
   }
 
-  MalType condition = EVAL(raw_condition, env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (mal_error) {
     return NULL;
@@ -359,6 +339,7 @@ MalType eval_if(list lst, Env* env) {
       return else_form;
     }
     else {
+      *env = NULL; // no TCO
       return make_nil();
     }
 
@@ -367,7 +348,7 @@ MalType eval_if(list lst, Env* env) {
   }
 }
 
-MalType eval_do(list lst, Env* env) {
+MalType eval_do(list lst, Env** env) {
 
   /* handle empty 'do' */
   if (!lst) {
@@ -377,7 +358,7 @@ MalType eval_do(list lst, Env* env) {
   /* evaluate all but the last form */
   while (lst->next) {
 
-    EVAL(lst->data, env);
+    EVAL(lst->data, *env);
 
     /* return error early */
     if (mal_error) {
@@ -389,13 +370,14 @@ MalType eval_do(list lst, Env* env) {
   return lst->data;
 }
 
-MalType eval_quote(list lst) {
+MalType eval_quote(list lst, Env** env) {
 
   explode1("quote", lst, form);
+  *env = NULL; // no TCO
   return form;
 }
 
-MalType eval_quasiquote(list lst) {
+MalType eval_quasiquote(list lst, Env**) {
   explode1("quasiquote", lst, form);
   return quasiquote(form);
   // Implicit error propagation.
@@ -541,7 +523,7 @@ MalType evaluate_hashmap(hashmap lst, Env* env) {
   return make_hashmap(evlst);
 }
 
-MalType eval_fnstar(list lst, const Env* env) {
+MalType eval_fnstar(list lst, Env** env) {
 
   if (!lst || !lst->next || lst->next->next) {
     bad_arg_count("fn*", "two parameters", lst);
@@ -575,8 +557,9 @@ MalType eval_fnstar(list lst, const Env* env) {
       break;
     }
   }
-
-  return make_closure(env, lst);
+  Env* fn_env = *env;
+  *env = NULL; // no TCO
+  return make_closure(fn_env, lst);
 }
 
 /* used by core functions but not EVAL as doesn't do TCE */

--- a/impls/c.2/step8_macros.c
+++ b/impls/c.2/step8_macros.c
@@ -456,7 +456,7 @@ MalType quasiquote(MalType ast) {
 MalType quasiquote_vector(vector_t vec) {
 
   MalType result = make_list(NULL);
-  for(int i = vec->count - 1; -1 < i; i--) {
+  for (size_t i = vec->count; i--; ) {
     result = quasiquote_folder(vec->nth[i], result);
     if (mal_error) return NULL;
   }
@@ -547,13 +547,14 @@ list evaluate_list(list lst, Env* env) {
 }
 
 MalType evaluate_vector(vector_t lst, Env* env) {
-  int capacity = lst->count;
+  size_t capacity = lst->count;
   struct vector* evlst = vector_new(capacity);
-  for(int i = 0; i <= lst->count - 1; i++) {
+  for (size_t i = 0; i < capacity; i++) {
     MalType new = EVAL(lst->nth[i], env);
     if (mal_error) return NULL;
     vector_append(&capacity, &evlst, new);
   }
+  assert(evlst->count == capacity);
   return make_vector(evlst);
 }
 

--- a/impls/c.2/step9_try.c
+++ b/impls/c.2/step9_try.c
@@ -19,19 +19,22 @@ MalType apply(MalType, list); // For the apply phase and core apply/map/swap.
 list evaluate_list(list, Env*);
 MalType evaluate_vector(vector_t, Env*);
 MalType evaluate_hashmap(hashmap lst, Env* env);
-MalType eval_defbang(list, Env*);
-MalType eval_letstar(list, Env**); // TCO
-MalType eval_if(list, Env*); // TCO (even for nil)
-MalType eval_fnstar(list, const Env*);
-MalType eval_do(list, Env*); // TCO in the same env
-MalType eval_quote(list);
-MalType eval_quasiquote(list);
+MalType eval_defbang(list, Env**);
+MalType eval_letstar(list, Env**);
+MalType eval_if(list, Env**);
+MalType eval_fnstar(list, Env**);
+MalType eval_do(list, Env**);
+MalType eval_quote(list, Env**);
+MalType eval_quasiquote(list, Env**);
 MalType quasiquote(MalType);
 MalType quasiquote_vector(vector_t);
 MalType quasiquote_list(list);
 MalType quasiquote_folder(MalType first, MalType qq_rest);
-MalType eval_defmacrobang(list, Env*);
-MalType eval_try(list, Env**); // TCO unless the environment is set to NULL.
+MalType eval_defmacrobang(list, Env**);
+MalType eval_try(list, Env**);
+
+typedef MalType (*special_t)(list, Env**);
+struct map* specials;
 
 MalType READ(const char* str) {
 
@@ -51,7 +54,7 @@ Env* env_apply(MalClosure closure, list args) {
   while (true) {
     if (!seq_cont(params, c)) {
       if (a) {
-        make_error("'apply': expected [%M], got [%N]", params, args);
+        make_error("'apply': expected %M, got [%N]", params, args);
       }
       break;
     }
@@ -63,7 +66,7 @@ Env* env_apply(MalClosure closure, list args) {
       break;
     }
     if (!a) {
-      make_error("'apply': expected [%M], got [%N]", params, args);
+      make_error("'apply': expected %M, got [%N]", params, args);
     }
     env_set(fn_env, parameter, a->data);
     c = seq_next(params, c);
@@ -113,62 +116,16 @@ MalType EVAL(MalType ast, Env* env) {
   lst = lst->next;
 
     /* handle special symbols first */
-    if (equal_forms(first, SYMBOL_DEF)) {
-      return eval_defbang(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_LET)) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_letstar(lst, &env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_IF)) {
-
-      /* TCE - modify ast directly and jump back to eval */
-      ast = eval_if(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_FN)) {
-      return eval_fnstar(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_DO)) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_QUOTE)) {
-      return eval_quote(lst);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_QUASIQUOTE)) {
-
-      ast = eval_quasiquote(lst);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_DEFMACRO)) {
-      return eval_defmacrobang(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_TRY)) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_try(lst, &env);
+  if (type(first) & MALTYPE_SYMBOL) {
+    special_t special = hashmap_get(specials, first);
+    if (special) {
+      ast = special(lst, &env);
       if (mal_error) return NULL;
 
       if(!env) { return ast; }
       goto TCE_entry_point;
     }
+  }
 
   /* first element is not a special symbol */
   MalType func = EVAL(first, env);
@@ -248,6 +205,17 @@ int main(int argc, char** argv) {
   types_init();
   printer_init();
 
+  specials = map_empty();
+  specials = hashmap_put(specials, SYMBOL_DEF,        eval_defbang);
+  specials = hashmap_put(specials, SYMBOL_LET,        eval_letstar);
+  specials = hashmap_put(specials, SYMBOL_IF,         eval_if);
+  specials = hashmap_put(specials, SYMBOL_FN,         eval_fnstar);
+  specials = hashmap_put(specials, SYMBOL_DO,         eval_do);
+  specials = hashmap_put(specials, SYMBOL_QUOTE,      eval_quote);
+  specials = hashmap_put(specials, SYMBOL_QUASIQUOTE, eval_quasiquote);
+  specials = hashmap_put(specials, SYMBOL_DEFMACRO,   eval_defmacrobang);
+  specials = hashmap_put(specials, SYMBOL_TRY,        eval_try);
+
   repl_env = env_make(NULL);
 
   ns core;
@@ -297,16 +265,17 @@ int main(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
-MalType eval_defbang(list lst, Env* env) {
+MalType eval_defbang(list lst, Env** env) {
 
   explode2("def!", lst, defbang_symbol, defbang_value);
 
-  MalType result = EVAL(defbang_value, env);
+  MalType result = EVAL(defbang_value, *env);
   if (mal_error) {
     return NULL;
   }
   check_type("def!", MALTYPE_SYMBOL, defbang_symbol);
-  env_set(env, defbang_symbol, result);
+  env_set(*env, defbang_symbol, result);
+  *env = NULL; // no TCO
   return result;
 }
 
@@ -344,7 +313,7 @@ MalType eval_letstar(list lst, Env** env) {
   return forms;
 }
 
-MalType eval_if(list lst, Env* env) {
+MalType eval_if(list lst, Env** env) {
 
   if (!lst) {
     bad_arg_count("if", "two or three arguments", lst);
@@ -367,7 +336,7 @@ MalType eval_if(list lst, Env* env) {
     else_form = NULL;
   }
 
-  MalType condition = EVAL(raw_condition, env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (mal_error) {
     return NULL;
@@ -380,6 +349,7 @@ MalType eval_if(list lst, Env* env) {
       return else_form;
     }
     else {
+      *env = NULL; // no TCO
       return make_nil();
     }
 
@@ -388,7 +358,7 @@ MalType eval_if(list lst, Env* env) {
   }
 }
 
-MalType eval_do(list lst, Env* env) {
+MalType eval_do(list lst, Env** env) {
 
   /* handle empty 'do' */
   if (!lst) {
@@ -398,7 +368,7 @@ MalType eval_do(list lst, Env* env) {
   /* evaluate all but the last form */
   while (lst->next) {
 
-    EVAL(lst->data, env);
+    EVAL(lst->data, *env);
 
     /* return error early */
     if (mal_error) {
@@ -410,13 +380,14 @@ MalType eval_do(list lst, Env* env) {
   return lst->data;
 }
 
-MalType eval_quote(list lst) {
+MalType eval_quote(list lst, Env** env) {
 
   explode1("quote", lst, form);
+  *env = NULL; // no TCO
   return form;
 }
 
-MalType eval_quasiquote(list lst) {
+MalType eval_quasiquote(list lst, Env**) {
   explode1("quasiquote", lst, form);
   return quasiquote(form);
   // Implicit error propagation.
@@ -519,11 +490,11 @@ MalType quasiquote_folder(MalType first, MalType qq_rest) {
                                SYMBOL_CONS));
 }
 
-MalType eval_defmacrobang(list lst, Env* env) {
+MalType eval_defmacrobang(list lst, Env** env) {
 
   explode2("defmacro!", lst, defbang_symbol, defbang_value);
 
-  MalType result = EVAL(defbang_value, env);
+  MalType result = EVAL(defbang_value, *env);
 
   if (mal_error) return NULL;
 
@@ -533,7 +504,8 @@ MalType eval_defmacrobang(list lst, Env* env) {
   }
   result = make_macro(closure->env, closure->fnstar_args);
   check_type("defmacro!", MALTYPE_SYMBOL, defbang_symbol);
-  env_set(env, defbang_symbol, result);
+  env_set(*env, defbang_symbol, result);
+  *env = NULL; // no TCO
   return result;
 }
 
@@ -628,7 +600,7 @@ MalType evaluate_hashmap(hashmap lst, Env* env) {
   return make_hashmap(evlst);
 }
 
-MalType eval_fnstar(list lst, const Env* env) {
+MalType eval_fnstar(list lst, Env** env) {
 
   if (!lst || !lst->next || lst->next->next) {
     bad_arg_count("fn*", "two parameters", lst);
@@ -662,8 +634,9 @@ MalType eval_fnstar(list lst, const Env* env) {
       break;
     }
   }
-
-  return make_closure(env, lst);
+  Env* fn_env = *env;
+  *env = NULL; // no TCO
+  return make_closure(fn_env, lst);
 }
 
 /* used by core functions but not EVAL as doesn't do TCE */

--- a/impls/c.2/step9_try.c
+++ b/impls/c.2/step9_try.c
@@ -466,7 +466,7 @@ MalType quasiquote(MalType ast) {
 MalType quasiquote_vector(vector_t vec) {
 
   MalType result = make_list(NULL);
-  for(int i = vec->count - 1; -1 < i; i--) {
+  for (size_t i = vec->count; i--; ) {
     result = quasiquote_folder(vec->nth[i], result);
     if (mal_error) return NULL;
   }
@@ -605,13 +605,14 @@ list evaluate_list(list lst, Env* env) {
 }
 
 MalType evaluate_vector(vector_t lst, Env* env) {
-  int capacity = lst->count;
+  size_t capacity = lst->count;
   struct vector* evlst = vector_new(capacity);
-  for(int i = 0; i <= lst->count - 1; i++) {
+  for (size_t i = 0; i < capacity; i++) {
     MalType new = EVAL(lst->nth[i], env);
     if (mal_error) return NULL;
     vector_append(&capacity, &evlst, new);
   }
+  assert(evlst->count == capacity);
   return make_vector(evlst);
 }
 

--- a/impls/c.2/stepA_mal.c
+++ b/impls/c.2/stepA_mal.c
@@ -470,7 +470,7 @@ MalType quasiquote(MalType ast) {
 MalType quasiquote_vector(vector_t vec) {
 
   MalType result = make_list(NULL);
-  for(int i = vec->count - 1; -1 < i; i--) {
+  for (size_t i = vec->count; i--; ) {
     result = quasiquote_folder(vec->nth[i], result);
     if (mal_error) return NULL;
   }
@@ -609,13 +609,14 @@ list evaluate_list(list lst, Env* env) {
 }
 
 MalType evaluate_vector(vector_t lst, Env* env) {
-  int capacity = lst->count;
+  size_t capacity = lst->count;
   struct vector* evlst = vector_new(capacity);
-  for(int i = 0; i <= lst->count - 1; i++) {
+  for (size_t i = 0; i < capacity; i++) {
     MalType new = EVAL(lst->nth[i], env);
     if (mal_error) return NULL;
     vector_append(&capacity, &evlst, new);
   }
+  assert(evlst->count == capacity);
   return make_vector(evlst);
 }
 

--- a/impls/c.2/stepA_mal.c
+++ b/impls/c.2/stepA_mal.c
@@ -19,19 +19,22 @@ MalType apply(MalType, list); // For the apply phase and core apply/map/swap.
 list evaluate_list(list, Env*);
 MalType evaluate_vector(vector_t, Env*);
 MalType evaluate_hashmap(hashmap lst, Env* env);
-MalType eval_defbang(list, Env*);
-MalType eval_letstar(list, Env**); // TCO
-MalType eval_if(list, Env*); // TCO (even for nil)
-MalType eval_fnstar(list, const Env*);
-MalType eval_do(list, Env*); // TCO in the same env
-MalType eval_quote(list);
-MalType eval_quasiquote(list);
+MalType eval_defbang(list, Env**);
+MalType eval_letstar(list, Env**);
+MalType eval_if(list, Env**);
+MalType eval_fnstar(list, Env**);
+MalType eval_do(list, Env**);
+MalType eval_quote(list, Env**);
+MalType eval_quasiquote(list, Env**);
 MalType quasiquote(MalType);
 MalType quasiquote_vector(vector_t);
 MalType quasiquote_list(list);
 MalType quasiquote_folder(MalType first, MalType qq_rest);
-MalType eval_defmacrobang(list, Env*);
-MalType eval_try(list, Env**); // TCO unless the environment is set to NULL.
+MalType eval_defmacrobang(list, Env**);
+MalType eval_try(list, Env**);
+
+typedef MalType (*special_t)(list, Env**);
+struct map* specials;
 
 MalType READ(const char* str) {
 
@@ -51,7 +54,7 @@ Env* env_apply(MalClosure closure, list args) {
   while (true) {
     if (!seq_cont(params, c)) {
       if (a) {
-        make_error("'apply': expected [%M], got [%N]", params, args);
+        make_error("'apply': expected %M, got [%N]", params, args);
       }
       break;
     }
@@ -63,7 +66,7 @@ Env* env_apply(MalClosure closure, list args) {
       break;
     }
     if (!a) {
-      make_error("'apply': expected [%M], got [%N]", params, args);
+      make_error("'apply': expected %M, got [%N]", params, args);
     }
     env_set(fn_env, parameter, a->data);
     c = seq_next(params, c);
@@ -113,62 +116,16 @@ MalType EVAL(MalType ast, Env* env) {
   lst = lst->next;
 
     /* handle special symbols first */
-    if (equal_forms(first, SYMBOL_DEF)) {
-      return eval_defbang(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_LET)) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_letstar(lst, &env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_IF)) {
-
-      /* TCE - modify ast directly and jump back to eval */
-      ast = eval_if(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_FN)) {
-      return eval_fnstar(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_DO)) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_do(lst, env);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_QUOTE)) {
-      return eval_quote(lst);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_QUASIQUOTE)) {
-
-      ast = eval_quasiquote(lst);
-
-      if (mal_error) { return NULL; }
-      goto TCE_entry_point;
-    }
-    else if (equal_forms(first, SYMBOL_DEFMACRO)) {
-      return eval_defmacrobang(lst, env);
-      // Implicit error propagation
-    }
-    else if (equal_forms(first, SYMBOL_TRY)) {
-
-      /* TCE - modify ast and env directly and jump back to eval */
-      ast = eval_try(lst, &env);
+  if (type(first) & MALTYPE_SYMBOL) {
+    special_t special = hashmap_get(specials, first);
+    if (special) {
+      ast = special(lst, &env);
       if (mal_error) return NULL;
 
       if(!env) { return ast; }
       goto TCE_entry_point;
     }
+  }
 
   /* first element is not a special symbol */
   MalType func = EVAL(first, env);
@@ -248,6 +205,17 @@ int main(int argc, char** argv) {
   types_init();
   printer_init();
 
+  specials = map_empty();
+  specials = hashmap_put(specials, SYMBOL_DEF,        eval_defbang);
+  specials = hashmap_put(specials, SYMBOL_LET,        eval_letstar);
+  specials = hashmap_put(specials, SYMBOL_IF,         eval_if);
+  specials = hashmap_put(specials, SYMBOL_FN,         eval_fnstar);
+  specials = hashmap_put(specials, SYMBOL_DO,         eval_do);
+  specials = hashmap_put(specials, SYMBOL_QUOTE,      eval_quote);
+  specials = hashmap_put(specials, SYMBOL_QUASIQUOTE, eval_quasiquote);
+  specials = hashmap_put(specials, SYMBOL_DEFMACRO,   eval_defmacrobang);
+  specials = hashmap_put(specials, SYMBOL_TRY,        eval_try);
+
   repl_env = env_make(NULL);
 
   ns core;
@@ -301,16 +269,17 @@ int main(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
-MalType eval_defbang(list lst, Env* env) {
+MalType eval_defbang(list lst, Env** env) {
 
   explode2("def!", lst, defbang_symbol, defbang_value);
 
-  MalType result = EVAL(defbang_value, env);
+  MalType result = EVAL(defbang_value, *env);
   if (mal_error) {
     return NULL;
   }
   check_type("def!", MALTYPE_SYMBOL, defbang_symbol);
-  env_set(env, defbang_symbol, result);
+  env_set(*env, defbang_symbol, result);
+  *env = NULL; // no TCO
   return result;
 }
 
@@ -348,7 +317,7 @@ MalType eval_letstar(list lst, Env** env) {
   return forms;
 }
 
-MalType eval_if(list lst, Env* env) {
+MalType eval_if(list lst, Env** env) {
 
   if (!lst) {
     bad_arg_count("if", "two or three arguments", lst);
@@ -371,7 +340,7 @@ MalType eval_if(list lst, Env* env) {
     else_form = NULL;
   }
 
-  MalType condition = EVAL(raw_condition, env);
+  MalType condition = EVAL(raw_condition, *env);
 
   if (mal_error) {
     return NULL;
@@ -384,6 +353,7 @@ MalType eval_if(list lst, Env* env) {
       return else_form;
     }
     else {
+      *env = NULL; // no TCO
       return make_nil();
     }
 
@@ -392,7 +362,7 @@ MalType eval_if(list lst, Env* env) {
   }
 }
 
-MalType eval_do(list lst, Env* env) {
+MalType eval_do(list lst, Env** env) {
 
   /* handle empty 'do' */
   if (!lst) {
@@ -402,7 +372,7 @@ MalType eval_do(list lst, Env* env) {
   /* evaluate all but the last form */
   while (lst->next) {
 
-    EVAL(lst->data, env);
+    EVAL(lst->data, *env);
 
     /* return error early */
     if (mal_error) {
@@ -414,13 +384,14 @@ MalType eval_do(list lst, Env* env) {
   return lst->data;
 }
 
-MalType eval_quote(list lst) {
+MalType eval_quote(list lst, Env** env) {
 
   explode1("quote", lst, form);
+  *env = NULL; // no TCO
   return form;
 }
 
-MalType eval_quasiquote(list lst) {
+MalType eval_quasiquote(list lst, Env**) {
   explode1("quasiquote", lst, form);
   return quasiquote(form);
   // Implicit error propagation.
@@ -523,11 +494,11 @@ MalType quasiquote_folder(MalType first, MalType qq_rest) {
                                SYMBOL_CONS));
 }
 
-MalType eval_defmacrobang(list lst, Env* env) {
+MalType eval_defmacrobang(list lst, Env** env) {
 
   explode2("defmacro!", lst, defbang_symbol, defbang_value);
 
-  MalType result = EVAL(defbang_value, env);
+  MalType result = EVAL(defbang_value, *env);
 
   if (mal_error) return NULL;
 
@@ -537,7 +508,8 @@ MalType eval_defmacrobang(list lst, Env* env) {
   }
   result = make_macro(closure->env, closure->fnstar_args);
   check_type("defmacro!", MALTYPE_SYMBOL, defbang_symbol);
-  env_set(env, defbang_symbol, result);
+  env_set(*env, defbang_symbol, result);
+  *env = NULL; // no TCO
   return result;
 }
 
@@ -632,7 +604,7 @@ MalType evaluate_hashmap(hashmap lst, Env* env) {
   return make_hashmap(evlst);
 }
 
-MalType eval_fnstar(list lst, const Env* env) {
+MalType eval_fnstar(list lst, Env** env) {
 
   if (!lst || !lst->next || lst->next->next) {
     bad_arg_count("fn*", "two parameters", lst);
@@ -666,8 +638,9 @@ MalType eval_fnstar(list lst, const Env* env) {
       break;
     }
   }
-
-  return make_closure(env, lst);
+  Env* fn_env = *env;
+  *env = NULL; // no TCO
+  return make_closure(fn_env, lst);
 }
 
 /* used by core functions but not EVAL as doesn't do TCE */

--- a/impls/c.2/types.c
+++ b/impls/c.2/types.c
@@ -30,7 +30,7 @@ struct MalType_s {
     } mal_list;
     struct {
       vector_t v;
-      MalType  meta;;
+      MalType  meta;
     } mal_vector;
     struct {
       hashmap m;
@@ -52,12 +52,12 @@ struct MalType_s THE_NIL = { MALTYPE_NIL, {0}};
 struct MalType_s THE_TRUE = { MALTYPE_TRUE, {0}};
 struct MalType_s THE_FALSE = { MALTYPE_FALSE, {0}};
 
-int is_nil(MalType val) { return val == &THE_NIL; }
-int is_false(MalType val) { return val == &THE_FALSE; }
-int is_true(MalType val) { return val == &THE_TRUE; }
+bool is_nil(MalType val) { return val == &THE_NIL; }
+bool is_false(MalType val) { return val == &THE_FALSE; }
+bool is_true(MalType val) { return val == &THE_TRUE; }
 
-inline int is_integer(MalType val, long* result) {
-  int ok = val->type & MALTYPE_INTEGER;
+inline bool is_integer(MalType val, long* result) {
+  bool ok = val->type & MALTYPE_INTEGER;
   if (ok) *result = val->value.mal_integer;
   return ok;
 }
@@ -67,8 +67,8 @@ MalType make_integer(long value) {
   return mal_val;
 }
 
-inline int is_float(MalType val, double* result) {
-  int ok = val->type & MALTYPE_FLOAT;
+inline bool is_float(MalType val, double* result) {
+  bool ok = val->type & MALTYPE_FLOAT;
   if (ok) *result = val->value.mal_float;
   return ok;
 }
@@ -101,7 +101,7 @@ size_t hash(const char* s) {
 inline const char* is_string(MalType val) {
   return val->type & MALTYPE_STRING ? val->value.mal_string.s : NULL;
 }
-MalType make_string(const char*  value) {
+MalType make_string(const char* value) {
   struct MalType_s* mal_val = GC_MALLOC(sizeof(*mal_val));
   *mal_val = (struct MalType_s){MALTYPE_STRING, {.mal_string={value, NO_HASH_YET}}};
   return mal_val;
@@ -110,7 +110,7 @@ MalType make_string(const char*  value) {
 inline const char* is_keyword(MalType val) {
   return val->type & MALTYPE_KEYWORD ? val->value.mal_string.s : NULL;
 }
-MalType make_keyword(const char*  value) {
+MalType make_keyword(const char* value) {
   struct MalType_s* mal_val = GC_MALLOC(sizeof(*mal_val));
   *mal_val = (struct MalType_s){MALTYPE_KEYWORD, {.mal_string={value, NO_HASH_YET}}};
   return mal_val;
@@ -119,14 +119,14 @@ MalType make_keyword(const char*  value) {
 inline const char* is_symbol(MalType val) {
   return val->type & MALTYPE_SYMBOL ? val->value.mal_string.s : NULL;
 }
-MalType make_symbol(const char*  value) {
+MalType make_symbol(const char* value) {
   struct MalType_s* mal_val = GC_MALLOC(sizeof(*mal_val));
   *mal_val = (struct MalType_s){MALTYPE_SYMBOL, {.mal_string={value, NO_HASH_YET}}};
   return mal_val;
 }
 
-inline int is_list(MalType val, list* result) {
-  int ok = val->type & MALTYPE_LIST;
+inline bool is_list(MalType val, list* result) {
+  bool ok = val->type & MALTYPE_LIST;
   if (ok) *result = val->value.mal_list.l;
   return ok;
 }

--- a/impls/c.2/types.h
+++ b/impls/c.2/types.h
@@ -22,7 +22,7 @@ enum mal_type_t {
   MALTYPE_MACRO    = 1 << 14,
 };
 
-typedef const struct MalType_s* MalType;
+typedef struct MalType_s* MalType;
 typedef const struct MalClosure_s* MalClosure;
 typedef struct pair_s* list; // mutable for appends
 typedef MalType(*function_t)(list);

--- a/impls/c.2/types.h
+++ b/impls/c.2/types.h
@@ -61,21 +61,21 @@ MalType make_closure(const Env* env, list fnstar_args);
 MalType make_macro(const Env* env, list fnstar_args);
 
 // A NULL result means that the type differs, except for lists.
-int is_list(MalType val, list*);
+bool is_list(MalType val, list*);
 vector_t is_vector(MalType val);
 hashmap is_hashmap(MalType val);
-int is_nil(MalType val);
+bool is_nil(MalType val);
 const char* is_string(MalType val);
-int is_false(MalType val);
+bool is_false(MalType val);
 const char* is_symbol(MalType val);
 const char* is_keyword(MalType val);
 function_t is_function(MalType val);
 MalClosure is_closure(MalType val);
 MalClosure is_macro(MalType val);
-int is_integer(MalType val, long*);
-int is_float(MalType val, double*);
+bool is_integer(MalType val, long*);
+bool is_float(MalType val, double*);
 MalType* is_atom(MalType val);
-int is_true(MalType val);
+bool is_true(MalType val);
 
 
 enum mal_type_t type(MalType);

--- a/impls/c.2/vector.c
+++ b/impls/c.2/vector.c
@@ -5,15 +5,16 @@
 #include "linked_list.h"
 #include "vector.h"
 
-struct vector* vector_new(int capacity) {
+struct vector* vector_new(size_t capacity) {
   struct vector* v = GC_MALLOC(sizeof(*v) + capacity*sizeof(MalType));
   v->count = 0;
   return v;
 }
 
-void vector_append(int* capacity, struct vector** v, MalType new_item) {
+void vector_append(size_t* capacity, struct vector** v, MalType new_item) {
   if ((*v)->count == *capacity) {
-    *capacity <<= 1;
+    // + 1 in case capacity is 0.
+    *capacity = (*capacity + 1) << 1;
     *v = GC_REALLOC(*v, sizeof(**v) + *capacity * sizeof(MalType));
   }
   (*v)->nth[(*v)->count++] = new_item;
@@ -25,7 +26,7 @@ seq_cursor seq_iter(MalType container) {
     return (seq_cursor){.l=l};
   }
   else {
-    assert(is_vector(container));
+    assert(type(container) == MALTYPE_VECTOR);
     return (seq_cursor){.i=0};
   }
 }
@@ -49,7 +50,6 @@ seq_cursor seq_next(MalType container, seq_cursor position) {
     return (seq_cursor){.i=position.i + 1};
   }
   else {
-    assert(position.l != NULL);
     return (seq_cursor){.l=position.l->next};
   }
 }
@@ -62,7 +62,6 @@ MalType seq_item(MalType container, seq_cursor position) {
     return v->nth[position.i];
   }
   else {
-    assert(position.l != NULL);
     return position.l->data;
   }
 }

--- a/impls/c.2/vector.h
+++ b/impls/c.2/vector.h
@@ -7,14 +7,14 @@
 // typedef const struct vector* vector_t;
 
 struct vector {
-  int count;
+  size_t count;
   MalType nth[];
 };
 
-struct vector* vector_new(int capacity);
+struct vector* vector_new(size_t capacity);
 //  The capacity first additions cause no reallocation.
 
-void vector_append(int* capacity, struct vector** v, MalType new_item);
+void vector_append(size_t* capacity, struct vector** v, MalType new_item);
 
 // Convenient way to iterate either on a list or a vector.
 // The same (unmodified) container must be be provided to each
@@ -22,7 +22,7 @@ void vector_append(int* capacity, struct vector** v, MalType new_item);
 // It must be a list or a vector.
 typedef union seq_cursor {
   list l;
-  int i;
+  size_t i;
 } seq_cursor;
 seq_cursor seq_iter(MalType);
 bool seq_cont(MalType, seq_cursor);


### PR DESCRIPTION
Compute hashes at most once.
Recognize forms with a hash instead of a sequence of string comparisons.