### PR TITLE
[hare] Update for hare 0.25.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ groovy ./stepX_YYY.groovy
 
 ### Hare
 
-The hare implementation was tested against Hare 0.24.2.
+The hare implementation was tested against Hare 0.25.2.
 
 ```
 cd impls/hare

--- a/impls/hare/Dockerfile
+++ b/impls/hare/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM debian:testing
 MAINTAINER Lou Woell <lou@reptitions.de>
 LABEL org.opencontainers.image.source=https://github.com/kanaka/mal
 LABEL org.opencontainers.image.description="mal test container: hare"

--- a/impls/hare/mal/core.ha
+++ b/impls/hare/mal/core.ha
@@ -765,7 +765,7 @@ fn apply(args: []MalType) (MalType | error) = {
 	case 0 =>
 		yield [];
 	case =>
-		yield alloc([nil...], length);
+		yield alloc([nil...], length)!;
 	};
 	defer free(ls);
 
@@ -896,7 +896,7 @@ fn malkeyword(args: []MalType) (MalType | error) = {
 
 	match(args[0]){
 	case let s: string =>
-		let name = strings::lpad(s.data, ':', len(s.data) + 1);
+		let name = strings::lpad(s.data, ':', len(s.data) + 1)!;
 		defer free(name);
 		return make_symbol(name);
 	case let k: symbol =>

--- a/impls/hare/mal/env.ha
+++ b/impls/hare/mal/env.ha
@@ -7,9 +7,9 @@ export fn env_init(outer: nullable * env = null) *env ={
 	const new = alloc(env {
 		outer = outer,
 		data = hm_init(),
-	});
+	})!;
 
-	append(gc.memory.envs, new);
+	append(gc.memory.envs, new)!;
 	return new;
 };
 

--- a/impls/hare/mal/gc.ha
+++ b/impls/hare/mal/gc.ha
@@ -70,7 +70,7 @@ fn finish_memory(memory: memory) void = {
 
 fn mark_hash(hm: hashmap) void = {
 
-	append(gc.marked.hashs, hm);
+	append(gc.marked.hashs, hm)!;
 	mark(hm.meta);
 
 	for(let v .. hm.data){
@@ -85,7 +85,7 @@ fn mark_env(envi: *env) void = {
 		if(e == envi) return void;
 	};
 
-	append(gc.marked.envs, envi);
+	append(gc.marked.envs, envi)!;
 	mark(envi.data);
 
 	match(envi.outer){
@@ -114,21 +114,21 @@ fn mark (val: MalType) void = {
 		for(let x .. gc.marked.vecs){
 			if(x == v) return void;
 		};
-		append(gc.marked.vecs, v);
+		append(gc.marked.vecs, v)!;
 		mark_col(v.data);
 		mark(v.meta);
 	case let l: list =>
 		for(let x .. gc.marked.lists){
 			if(x == l) return void;
 		};
-		append(gc.marked.lists, l);
+		append(gc.marked.lists, l)!;
 		mark_col(l.data);
 		mark(l.meta);
 	case  let f: function =>
 		for(let x .. gc.marked.funcs){
 			if(x == f) return void;
 		};
-		append(gc.marked.funcs, f);
+		append(gc.marked.funcs, f)!;
 		mark(f.meta);
 		mark(f.body);
 		mark_col(f.args);
@@ -137,14 +137,14 @@ fn mark (val: MalType) void = {
 		for(let x .. gc.marked.intrinsics){
 			if(x == i) return void;
 		};
-		append(gc.marked.intrinsics, i);
+		append(gc.marked.intrinsics, i)!;
 		mark(i.meta);
 	case let m: macro =>
 		let m = m:function;
 		for(let x .. gc.marked.funcs){
 			if(x == m) return void;
 		};
-		append(gc.marked.funcs, m);
+		append(gc.marked.funcs, m)!;
 		mark(m.meta);
 		mark(m.body);
 		mark_col(m.args);
@@ -164,13 +164,13 @@ fn mark (val: MalType) void = {
 		for(let x .. gc.marked.strings){
 			if(x == s) return void;
 		};
-		append(gc.marked.strings, s);
+		append(gc.marked.strings, s)!;
 		mark(s.meta);
 	case let a: atom =>
 		for(let x .. gc.marked.atoms){
 			if(x == a) return void;
 		};
-		append(gc.marked.atoms, a);
+		append(gc.marked.atoms, a)!;
 		mark(*a);
 	case => void;
 	};

--- a/impls/hare/mal/hashmap.ha
+++ b/impls/hare/mal/hashmap.ha
@@ -26,9 +26,9 @@ export fn hm_init(gcd: bool = true) hashmap = {
 	let new: hashmap = alloc(struct {
 		data: []hmap = [],
 		meta: MalType = nil,
-	});
+	})!;
 
-	if(gcd) append(gc.memory.hashs, new);
+	if(gcd) append(gc.memory.hashs, new)!;
 
 	return new;
 };
@@ -50,7 +50,7 @@ fn new(
 		child: [4](size | void) = [void...],
 	};
 
-	append(hm.data, new);
+	append(hm.data, new)!;
 
 	match(p.child) {
 	case void =>
@@ -180,7 +180,7 @@ fn hm_copy(hm: hashmap, filter: [](string | symbol) = []) hashmap = {
 
 	if(len(filter) == 0){
 		for(let e .. hm.data) {
-			append(new.data, e);
+			append(new.data, e)!;
 		};
 	} else {
 		for :map (let e .. hm.data) {

--- a/impls/hare/mal/printer.ha
+++ b/impls/hare/mal/printer.ha
@@ -43,7 +43,7 @@ fn print_string(
 	print_readable: bool
 ) void = {
 
-	let runes = strings::torunes(s.data);
+	let runes = strings::torunes(s.data)!;
 
 
 	if(!print_readable){

--- a/impls/hare/mal/reader.ha
+++ b/impls/hare/mal/reader.ha
@@ -153,7 +153,7 @@ fn read_collection(
 		case  hash_end =>
 			return unbalanced;
 		case let form: MalType =>
-			append(res, form);
+			append(res, form)!;
 			continue;
 		case io::EOF =>
 			return unexpected_eof;
@@ -180,7 +180,7 @@ fn read_string(s: str) (string | error) = {
 
 	let strbuf = memio::dynamic();
 	defer io::close(&strbuf)!;
-	let runes = strings::torunes(s);
+	let runes = strings::torunes(s)!;
 
 	for (let i: size = 0; i < len(runes); i += 1) {
 		let rn = switch (runes[i]) {

--- a/impls/hare/mal/types.ha
+++ b/impls/hare/mal/types.ha
@@ -51,9 +51,9 @@ export fn make_intrinsic(
 	const new = alloc(struct {
 		eval: *fn([]MalType) (MalType | error) = func,
 		meta: MalType = nil,
-	});
+	})!;
 
-	append(gc.memory.intrinsics, new);
+	append(gc.memory.intrinsics, new)!;
 	return new;
 };
 
@@ -66,7 +66,7 @@ export fn make_func(
 
 	let arg_list: []MalType = [];
 	if(len(args) > 0) {
-		arg_list = alloc([nil...], len(args));
+		arg_list = alloc([nil...], len(args))!;
 		arg_list[0..] = args;
 	};
 
@@ -75,9 +75,9 @@ export fn make_func(
 		envi: *env= envi,
 		args: []MalType = arg_list,
 		body: MalType = body,
-		meta: MalType = nil });
+		meta: MalType = nil })!;
 
-	append(gc.memory.funcs, new);
+	append(gc.memory.funcs, new)!;
 	return new;
 };
 
@@ -91,14 +91,14 @@ export fn make_list(s: size, init: []MalType = []) list = {
 	const new: list = alloc(struct {
 		data: []MalType = [],
 		meta: MalType = nil,
-	});
+	})!;
 
 	if (s == 0) return new;
 
-	new.data = alloc([nil...], s);
+	new.data = alloc([nil...], s)!;
 	new.data[0..len(init)] = init;
 
-	append(gc.memory.lists, new);
+	append(gc.memory.lists, new)!;
 	return new;
 };
 
@@ -112,14 +112,14 @@ export fn make_vec(s: size, init: []MalType = []) vector = {
 	const new: vector = alloc(struct {
 		data: []MalType = [],
 		meta: MalType = nil,
-	});
+	})!;
 
 	if (s == 0) return new;
 
-	new.data = alloc([nil...], s);
+	new.data = alloc([nil...], s)!;
 	new.data[0..len(init)] = init;
 
-	append(gc.memory.vecs, new);
+	append(gc.memory.vecs, new)!;
 	return new;
 };
 
@@ -144,7 +144,7 @@ export fn make_symbol(name: str) symbol = {
 		return s;
 	};
 
-	const new = strings::dup(name): symbol;
+	const new = strings::dup(name)!: symbol;
 	hm_add(gc.memory.symbols: hashmap, new, new);
 
 	return new;
@@ -152,14 +152,14 @@ export fn make_symbol(name: str) symbol = {
 
 export fn make_string(s: str) string = {
 
-	const new_str = strings::dup(s);
+	const new_str = strings::dup(s)!;
 
 	const new = alloc(struct {
 		data: str = new_str,
 		meta: MalType = nil,
-	});
+	})!;
 
-	append(gc.memory.strings, new);
+	append(gc.memory.strings, new)!;
 	return new;
 };
 
@@ -170,8 +170,8 @@ fn free_string(s: string) void = {
 
 export fn make_atom(ref: MalType) atom = {
 
-	const new = alloc(ref);
-	append(gc.memory.atoms, new);
+	const new = alloc(ref)!;
+	append(gc.memory.atoms, new)!;
 	return new;
 };
 

--- a/impls/hare/step4_if_fn_do.ha
+++ b/impls/hare/step4_if_fn_do.ha
@@ -112,14 +112,14 @@ fn eval_list(ls: mal::list, env: *mal::env) (mal::MalType | mal::error) = {
 		let args: []mal::MalType = [];
 		defer free(args);
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		return func.eval(args);
 	case let func: mal::function =>
 		let args: []mal::MalType = [];
 		defer free(args);
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		let local = mal::env_init(func.envi);
 		mal::env_bind(local, func.args, args);

--- a/impls/hare/step5_tco.ha
+++ b/impls/hare/step5_tco.ha
@@ -150,13 +150,13 @@ for(true){
 		let args: []mal::MalType = [];
 		defer free(args);
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		return func.eval(args);
 	case let func: mal::function =>
 		let args: []mal::MalType = [];
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		env = mal::env_init(func.envi);
 		mal::env_bind(env, func.args, args);

--- a/impls/hare/step6_file.ha
+++ b/impls/hare/step6_file.ha
@@ -149,13 +149,13 @@ for(true){
 	case let func: mal::intrinsic =>
 		let args: []mal::MalType = [];
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		return func.eval(args);
 	case let func: mal::function =>
 		let args: []mal::MalType = [];
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		env = mal::env_init(func.envi);
 		mal::env_bind(env, func.args, args);
@@ -245,7 +245,7 @@ export fn main() void = {
 
 	if(len(args) > 1){
 		let exec_str = strings::join("", "(load-file \"", args[1],
-			"\")");
+			"\")")!;
 		rep(strings::toutf8(exec_str), env, false);
 		free(exec_str);
 		os::exit(0);

--- a/impls/hare/step7_quote.ha
+++ b/impls/hare/step7_quote.ha
@@ -217,13 +217,13 @@ for(true){
 		let args: []mal::MalType = [];
 		defer free(args);
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		return func.eval(args);
 	case let func: mal::function =>
 		let args: []mal::MalType = [];
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		env = mal::env_init(func.envi);
 		mal::env_bind(env, func.args, args);
@@ -315,7 +315,7 @@ export fn main() void = {
 
 	if(len(args) > 1){
 		let exec_str = strings::join("", "(load-file \"", args[1],
-			"\")");
+			"\")")!;
 		rep(strings::toutf8(exec_str), env, false);
 		free(exec_str);
 		os::exit(0);

--- a/impls/hare/step8_macros.ha
+++ b/impls/hare/step8_macros.ha
@@ -258,7 +258,7 @@ for(true){
 		let args: []mal::MalType = [];
 		defer free(args);
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		return func.eval(args);
 	case let mac: mal::macro =>
@@ -267,7 +267,7 @@ for(true){
 	case let func: mal::function =>
 		let args: []mal::MalType = [];
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		env = mal::env_init(func.envi);
 		mal::env_bind(env, func.args, args);
@@ -381,7 +381,7 @@ export fn main() void = {
 
 	if(len(args) > 1){
 		let exec_str = strings::join("", "(load-file \"", args[1],
-					     "\")");
+					     "\")")!;
 		rep(strings::toutf8(exec_str), env, false);
 		free(exec_str);
 		os::exit(0);

--- a/impls/hare/step9_try.ha
+++ b/impls/hare/step9_try.ha
@@ -291,7 +291,7 @@ fn eval (ast: mal::MalType, env: *mal::env) (mal::MalType | mal::error) = {
 		let args: []mal::MalType = [];
 		defer free(args);
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		return func.eval(args);
 	case let mac: mal::macro =>
@@ -300,7 +300,7 @@ fn eval (ast: mal::MalType, env: *mal::env) (mal::MalType | mal::error) = {
 	case let func: mal::function =>
 		let args: []mal::MalType = [];
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		env = mal::env_init(func.envi);
 		mal::env_bind(env, func.args, args);
@@ -414,7 +414,7 @@ export fn main() void = {
 
 	if(len(args) > 1){
 		let exec_str = strings::join("", "(load-file \"", args[1],
-			"\")");
+			"\")")!;
 		rep(strings::toutf8(exec_str), env, false);
 		free(exec_str);
 		os::exit(0);

--- a/impls/hare/stepA_mal.ha
+++ b/impls/hare/stepA_mal.ha
@@ -291,7 +291,7 @@ fn eval (ast: mal::MalType, env: *mal::env) (mal::MalType | mal::error) = {
 		let args: []mal::MalType = [];
 		defer free(args);
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		return func.eval(args);
 	case let mac: mal::macro =>
@@ -300,7 +300,7 @@ fn eval (ast: mal::MalType, env: *mal::env) (mal::MalType | mal::error) = {
 	case let func: mal::function =>
 		let args: []mal::MalType = [];
 		for(let arg .. ls.data[1..]){
-			append(args, eval(arg, env)?);
+			append(args, eval(arg, env)?)!;
 		};
 		env = mal::env_init(func.envi);
 		mal::env_bind(env, func.args, args);
@@ -417,7 +417,7 @@ export fn main() void = {
 
 	if(len(args) > 1){
 		let exec_str = strings::join("", "(load-file \"", args[1],
-			"\")");
+			"\")")!;
 		rep(strings::toutf8(exec_str), env, false);
 		free(exec_str);
 		os::exit(0);


### PR DESCRIPTION
This PR updates the hare implementation to work with hare 0.25.2, by explicitly handling `!nomem`, for now we abort when out of memory, as was the default for previous versions of hare. Does not include any changes to the logic and should not alter behviour.

Switches the Docker image to Debian:testing, because Ubuntu hasn't updated it's hare repo.

Pull request requirements:

- [x] Commits are well written and well organized.
- [x] Commits for a specific implementation should be prefixed with
  the implementation name.
- [x] Github Actions CI passes all checks (including self-host)
