### PR TITLE
Add hints in the guide about garbage collection and environment mutation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all help:
 	@echo 'make "stats^IMPL"                 # run 'make stats' for IMPL'
 	@echo 'make "stats-lisp^IMPL"            # run 'make stats-lisp' for IMPL'
 	@echo
+	@echo 'make "valgrind^IMPL"              # run valgrind for (compiled) IMPL
 	@echo 'Options/Settings:'
 	@echo
 	@echo 'make MAL_IMPL=IMPL "test^mal..."  # use IMPL for self-host tests'
@@ -228,6 +229,11 @@ $(foreach i,$(DO_IMPLS),$(foreach s,$(STEPS),$(i)^$(s))): $$(call $$(word 1,$$(s
 
 $(foreach i,$(DO_IMPLS),$(foreach s,$(STEPS),build^$(i)^$(s))): $$(call $$(word 2,$$(subst ^, ,$$(@)))_STEP_TO_PROG,$$(word 3,$$(subst ^, ,$$(@))))
 
+# Example creating cycles with environment and atom mutability,
+# without trying to print an atom referencing itself.
+REFERENCE_CYCLES := (let* [f (fn* [] 0) a (atom 0) b (reset! a a)] 0)
+$(DO_IMPLS:%=valgrind^%): valgrind^%: build^%^stepA
+	printf '$(REFERENCE_CYCLES)' | valgrind $(call $*_STEP_TO_PROG,stepA)
 
 
 #

--- a/process/guide.md
+++ b/process/guide.md
@@ -712,6 +712,18 @@ Your mal implementation is still basically just a numeric calculator
 with save/restore capability. But you have set the foundation for step
 4 where it will begin to feel like a real programming language.
 
+Hints.
+
+To be honest, the `def!` special form only intends to mutate the
+special top REPL environment.  Feel free to forbid `def!` in all other
+environments if it makes your life easyer, but be warned that the test
+suite may then be less effective.
+
+Environments are mutable in nature.  Even if tests do not enforce this
+yet, every reference to an environment should be affected when it is
+modified, either by an obvious `def!` or by a later `let*` binding.
+Step 4 will allow closures to reference an environment, and should not
+only receive a copy of its state at the moment of capture.
 
 An aside on mutation and typing:
 
@@ -801,6 +813,11 @@ environment `env`. In this case, your native functions will need to be
 wrapped in the same way. You will probably also need a method/function
 that invokes your function object/structure for the default case of
 the apply section of `EVAL`.
+
+The function must take a reference to the environment they were
+created in, so that later changes in the environment affects next
+executions of the function.  This is not enforced by the test suite
+yet, but may be in the future.
 
 Try out the basic functionality you have implemented:
 

--- a/process/guide.md
+++ b/process/guide.md
@@ -308,6 +308,21 @@ expression support.
 
 * Copy `step0_repl.qx` to `step1_read_print.qx`.
 
+* Add a `types.qx` file defining the representation of MAL objects in
+  the implementation language.  Even if for now the translation of
+  numbers and strings may seem trivial, next steps will for example
+  introduce two other types implemented as strings.
+
+  If your implementation language provides garbage collection, memory
+  leaks are not a concern.  Else, do not let them distract you from
+  the MAL learning curve.  They will almost certainly not prevent you
+  from completing it.  Be warned that garbage collection was invented
+  exactly because of issues raised by the first Lisp, and involves
+  complex compromises with perfomance.  Should you find this challenge
+  interesting, at least wait for steps 4 to 6.  They introduce cycles
+  that generic reference counting or weak references cannot
+  handle. The end of this file contains a few hints.
+
 * Add a `reader.qx` file to hold functions related to the reader.
 
 * If the target language has object types (OOP), then the next step
@@ -1722,6 +1737,13 @@ implementation.
   repository. The [FAQ](../docs/FAQ.md#will-you-add-my-new-implementation)
   describes general requirements for getting an implementation merged
   into the main repository.
+* If the implementation language provides no garbage collection,
+  prevent memory leaks by MAL your interpreter.  Recall that function
+  closures reference the environment in which they were defined, and
+  that atoms introduce mutability, hence possible reference cycles.
+  `(let* [f (fn* [] 0)] 0)` and `(let* [a (atom 0) b (reset! a a)] 0)`
+  may lead you to interesting thoughts.  If the language is compiled,
+  `make valgrind^IMPL` may spare you some thinking and typing.
 * Take your interpreter implementation and have it emit source code in
   the target language rather than immediately evaluating it. In other
   words, create a compiler.

--- a/process/guide.md
+++ b/process/guide.md
@@ -257,8 +257,12 @@ make-a-lisp process.
   line editing support. Another option if your language supports it is
   to use an FFI (foreign function interface) to load and call directly
   into GNU readline, editline, or linenoise library. Add line
-  editing interface code to `readline.qx`
+  editing interface code to `readline.qx`.
 
+  If your interpreter uses an history file, `~/.mal-history` is
+  recommended for consistent debugging, with `~` expanded as usual,
+  but failures should not crash the interpreter because such a file is
+  unavailable during automated tests.
 
 <a name="step1"></a>
 


### PR DESCRIPTION
This is obviously inspired by #739, but does not adress the printing of `(reset! a a)`.